### PR TITLE
Separate stdout and stderr from the run output

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -67,6 +67,11 @@ members of the project's leadership.
 
 ## Project Maintainers
 
+### bats-core organization:
+* Bianca Tamayo <<hi@biancatamayo.me>>
+
+
+## Project Original Author(s)
 * Sam Stephenson <<sstephenson@gmail.com>>
 
 ## Attribution

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,24 @@
+Copyright (c) 2017 Bianca Tamayo and bats-core organization
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 Copyright (c) 2014 Sam Stephenson
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ command with the location to the prefix in which you want to install
 Bats. For example, to install Bats into `/usr/local`,
 
     $ git clone https://github.com/bats-core/bats-core.git
-    $ cd bats
+    $ cd bats-core
     $ ./install.sh /usr/local
 
 Note that you may need to run `install.sh` with `sudo` if you do not

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## BATS-core: Bash Automated Testing System (2017)
 
+[![Build Status](https://travis-ci.org/bats-core/bats-core.svg?branch=master)](https://travis-ci.org/bats-core/bats-core)
+
 ### Background:
 ### What is this repo?
 **Tuesday, September 19, 2017:** This is a mirrored fork of [bats](https://github.com/sstephenson/bats), at [0360811](https://github.com/sstephenson/bats/commit/03608115df2071fff4eaaff1605768c275e5f81f). It was created via `git clone --bare` and `git push --mirror`.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ then iterates over the test cases and executes each one in its own
 process.
 
 For more details about how Bats evaluates test files, see 
-[Bats Evaluation Process](https://github.com/sstephenson/bats/wiki/Bats-Evaluation-Process)
+[Bats Evaluation Process](https://github.com/bats-core/bats-core/wiki/Bats-Evaluation-Process)
 on the wiki.
 
 ### `run`: Test other commands
@@ -239,7 +239,7 @@ Check out a copy of the Bats repository. Then, either add the Bats
 command with the location to the prefix in which you want to install
 Bats. For example, to install Bats into `/usr/local`,
 
-    $ git clone https://github.com/sstephenson/bats.git
+    $ git clone https://github.com/bats-core/bats-core.git
     $ cd bats
     $ ./install.sh /usr/local
 
@@ -250,15 +250,15 @@ have permission to write to the installation prefix.
 ## Support
 
 The Bats source code repository is [hosted on
-GitHub](https://github.com/sstephenson/bats). There you can file bugs
+GitHub](https://github.com/bats-core/bats-core). There you can file bugs
 on the issue tracker or submit tested pull requests for review.
 
 For real-world examples from open-source projects using Bats, see
-[Projects Using Bats](https://github.com/sstephenson/bats/wiki/Projects-Using-Bats)
+[Projects Using Bats](https://github.com/bats-core/bats-core/wiki/Projects-Using-Bats)
 on the wiki.
 
 To learn how to set up your editor for Bats syntax highlighting, see
-[Syntax Highlighting](https://github.com/sstephenson/bats/wiki/Syntax-Highlighting)
+[Syntax Highlighting](https://github.com/bats-core/bats-core/wiki/Syntax-Highlighting)
 on the wiki.
 
 
@@ -318,5 +318,9 @@ on the wiki.
 
 ---
 
-© 2014 Sam Stephenson. Bats is released under an MIT-style license;
+© 2017 Bianca Tamayo (bats-core organization)
+
+© 2014 Sam Stephenson
+
+Bats is released under an MIT-style license;
 see `LICENSE` for details.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Doing it this way accomplishes two things:
 3. Allows the possibility of merging back to original, or merging from original if or when the need arises
 4. Prevents lock-out by giving administrative access to more than one person, increases transferability
 
+## Misc
+- We are `#bats` on freenode
 
 ---
 # Bats: Bash Automated Testing System

--- a/libexec/bats
+++ b/libexec/bats
@@ -22,7 +22,7 @@ help() {
   echo "  -t, --tap      Show results in TAP format"
   echo "  -v, --version  Display the version number"
   echo
-  echo "  For more information, see https://github.com/sstephenson/bats"
+  echo "  For more information, see https://github.com/bats-core/bats-core"
   echo
 }
 

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -48,17 +48,25 @@ load() {
 }
 
 run() {
-  local e E T oldIFS
+  local e E T oldIFS 
   [[ ! "$-" =~ e ]] || e=1
   [[ ! "$-" =~ E ]] || E=1
   [[ ! "$-" =~ T ]] || T=1
   set +e
   set +E
   set +T
-  output="$("$@" 2>&1)"
-  status="$?"
+
+  eval "$({ t_sdterr=$({ t_stdout=$("$@"); t_ret=$?; } 2>&1; declare -p t_stdout  >&2; declare -pi t_ret >&2); declare -p t_sdterr; } 2>&1)"
+  
+  status=$t_ret
+  output="${t_stdout}${t_sdterr}"
+  stdout=$t_stdout
+  stderr=$t_sdterr
+
   oldIFS=$IFS
   IFS=$'\n' lines=($output)
+  IFS=$'\n' stdlines=($t_stdout)
+  IFS=$'\n' errlines=($t_sdterr)
   [ -z "$e" ] || set -e
   [ -z "$E" ] || set -E
   [ -z "$T" ] || set -T

--- a/man/bats.1
+++ b/man/bats.1
@@ -89,12 +89,14 @@ ok 2 addition using dc
 The \fBbats\fR interpreter exits with a value of \fB0\fR if all test cases pass, or \fB1\fR if one or more test cases fail\.
 .
 .SH "SEE ALSO"
-Bats wiki: \fIhttps://github\.com/sstephenson/bats/wiki/\fR
+Bats wiki: \fIhttps://github\.com/bats\-core/bats\-core/wiki/\fR
 .
 .P
 \fBbash\fR(1), \fBbats\fR(7)
 .
 .SH "COPYRIGHT"
+
+(c) 2017 Bianca Tamayo (bats-core organization)
 (c) 2014 Sam Stephenson
 .
 .P

--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -93,7 +93,7 @@ or `1` if one or more test cases fail.
 SEE ALSO
 --------
 
-Bats wiki: _https://github.com/sstephenson/bats/wiki/_
+Bats wiki: _https://github.com/bats\-core/bats\-core/wiki/_
 
 `bash`(1), `bats`(7)
 
@@ -101,6 +101,7 @@ Bats wiki: _https://github.com/sstephenson/bats/wiki/_
 COPYRIGHT
 ---------
 
+(c) 2017 Bianca Tamayo (bats-core organization)
 (c) 2014 Sam Stephenson
 
 Bats is released under the terms of an MIT-style license.

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -262,3 +262,8 @@ fixtures bats
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 loop_func" ]
 }
+
+@test "testing stdout and stderr are separated" {
+  run bats "$FIXTURE_ROOT/stdout_stderr_separate.bats"
+  [ $status -eq 0 ]
+}

--- a/test/fixtures/bats/stdout_stderr_separate.bats
+++ b/test/fixtures/bats/stdout_stderr_separate.bats
@@ -1,0 +1,14 @@
+# see issue #89
+echo_std_err() {
+  echo "std output"
+  (>&2 echo "err output")
+  return 0
+}
+
+@test "std err" {
+  run echo_std_err
+  [ $status -eq 0 ]
+  [ "${stdout}" = "std output" ]
+  [ "${stderr}" = "err output" ]
+  [ "${output}" = "std outputerr output" ]
+}


### PR DESCRIPTION
Put all tested method output in the same variable is an alteration of the real method result. 
For exemple :

``` shell
testedMethod() {
  echo "the result"
  (>&2 echo "some log informations")
  return 0
}
value=$(testedMethod)
```
value contain only "the result" and when I use it in a script I'm only interested in "the result".
But it's not possible to assert only the stdout. It should be possible to assert separatly stdout and stderr.

That's why I propose this update.
In order to keep compatibility I juste add variables :

* **stdout**: Only the stdout output
* **stderr**: Only the stderr output
* **stdlines**: stdout by line
* **errlines**: stderr by line
* **output**: Contain stdout+stderr concatenated