### PR TITLE
Add Appveyor configuration, update Travis CI configuration, fix macOS bug

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,15 @@
+version: 'v0.4.0.{build}'
+
+build: off
+
+# This presumes that Git bash is installed at `C:\Program Files\Git` and the
+# bash we're using is `C:\Program Files\Git\bin\bash.exe`.
+#
+# If instead it finds the Windows Subsystem for Linux bash at
+# `C:\Windows\System32\bash.exe`, it will fail with an error like:
+#   /mnt/c/.../bats-core/test/test_helper.bash: line 1:
+#     syntax error near unexpected token `$'{\r''
+test_script:
+  - where bash
+  - bash --version
+  - bash libexec/bats test

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,4 +12,4 @@ build: off
 test_script:
   - where bash
   - bash --version
-  - bash libexec/bats test
+  - bash -c 'time libexec/bats test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
-language: c
-script: bash -c 'time bin/bats --tap test'
+language: bash
+os:
+- linux
+- osx
+
+script:
+- bash -c 'time bin/bats --tap test'
+
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-script: bin/bats --tap test
+script: bash -c 'time bin/bats --tap test'
 notifications:
   email:
     on_success: never

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -218,13 +218,22 @@ bats_debug_trap() {
   fi
 }
 
+# When running under Bash 3.2.57(1)-release on macOS, the `ERR` trap may not
+# always fire, but the `EXIT` trap will. For this reason we call it at the very
+# beginning of `bats_teardown_trap` (the `DEBUG` trap for the call will move
+# `BATS_CURRENT_STACK_TRACE` to `BATS_PREVIOUS_STACK_TRACE`) and check the value
+# of `$?` before taking other actions.
 bats_error_trap() {
-  BATS_ERROR_STATUS="$?"
-  BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
-  trap - debug
+  local status="$?"
+  if [[ "$status" -ne '0' ]]; then
+    BATS_ERROR_STATUS="$status"
+    BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
+    trap - debug
+  fi
 }
 
 bats_teardown_trap() {
+  bats_error_trap
   trap "bats_exit_trap" exit
   local status=0
   teardown >>"$BATS_OUT" 2>&1 || status="$?"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -67,6 +67,8 @@ fixtures bats
 @test "one failing test" {
   run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
+  printf 'lines:\n' >&2
+  printf '%s\n' "${lines[@]}" >&2
   [ "${lines[0]}" = '1..1' ]
   [ "${lines[1]}" = 'not ok 1 a failing test' ]
   [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/failing.bats, line 4)" ]
@@ -86,6 +88,8 @@ fixtures bats
 @test "failing test with significant status" {
   STATUS=2 run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
+  printf 'lines:\n' >&2
+  printf '%s\n' "${lines[@]}" >&2
   [ "${lines[3]}" = "#   \`eval \"( exit \${STATUS:-1} )\"' failed with status 2" ]
 }
 
@@ -153,6 +157,8 @@ fixtures bats
   cd "$TMP"
   run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
+  printf 'lines:\n' >&2
+  printf '%s\n' "${lines[@]}" >&2
   [ "${lines[2]}" = "# (in test file $FIXTURE_ROOT/failing.bats, line 4)" ]
 }
 


### PR DESCRIPTION
Spawned from #8. Both CI systems will also report test suite run times, and Travis will run macOS builds.

In order to get the macOS build to pass, this also includes a commit to work around the Bash 3.2.57 ERR trap bug. See the commit message for 0f6dde5 for details.

Also worth noting are the build times for this PR:

```
Linux:
real	0m4.248s
user	0m3.488s
sys	0m1.018s

macOS:
real	0m8.898s
user	0m3.798s
sys	0m4.161s

Windows:
real	0m28.079s
user	0m6.764s
sys	0m14.828s
```

vs. those from #8:
```
Linux:
real	0m1.947s
user	0m1.564s
sys	0m0.419s

macOS:
real	0m4.910s
user	0m2.725s
sys	0m1.507s

Windows:
real	0m11.291s
user	0m3.027s
sys	0m5.625s
```