### PR TITLE
test/bats: Add has_tput helper to fix Alpine tests

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -11,6 +11,13 @@ filter_control_sequences() {
   "$@" | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g'
 }
 
+if ! command -v tput >/dev/null; then
+  tput() {
+    printf '1000\n'
+  }
+  export -f tput
+fi
+
 teardown() {
   [ -d "$TMP" ] && rm -f "$TMP"/*
 }


### PR DESCRIPTION
The test cases that use the `-p` or `--pretty` flag would fail if `tput` wasn't available (installed as part of the `ncurses` package). On Alpine, `ncurses` isn't installed by default. This change ensures the tests validate the expected behavior regardless of whether `tput` is available.

Alternatives might be to fail the whole test suite and insist the user install `ncurses` first, or to `skip` tests using `-p` or `--pretty` when `tput` is missing.

cc: @jasonkarns