### PR TITLE
Emit ` || return 1` suffix for double-bracket tests

### DIFF
--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -45,7 +45,7 @@ while IFS= read -r line; do
     tests["${#tests[@]}"]="$encoded_name"
     echo "${encoded_name}() { bats_test_begin \"${name}\" ${index}; ${body}"
   elif [[ "$line" =~ \]\][[:space:]]*$ ]]; then
-    printf "%s || false\n" "$line"
+    printf "%s || return 1\n" "$line"
   else
     printf "%s\n" "$line"
   fi

--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -44,6 +44,8 @@ while IFS= read -r line; do
     encode_name "$name" 'encoded_name'
     tests["${#tests[@]}"]="$encoded_name"
     echo "${encoded_name}() { bats_test_begin \"${name}\" ${index}; ${body}"
+  elif [[ "$line" =~ \]\][[:space:]]*$ ]]; then
+    printf "%s || false\n" "$line"
   else
     printf "%s\n" "$line"
   fi

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -338,3 +338,11 @@ END_OF_ERR_MSG
     emit_debug_output && return 1
   fi
 }
+
+@test "ensure double bracket expressions fail as necessary" {
+  run bats "$FIXTURE_ROOT/double_brackets.bats"
+  [ "$status" -eq '1' ]
+  [ "${lines[1]}" == 'not ok 1 double bracket returns false' ]
+  [ "${lines[2]}" == "# (in test file $RELATIVE_FIXTURE_ROOT/double_brackets.bats, line 4)" ]
+  [ "${lines[3]}" == "#   \`[[ \"\$value\" == 'false' ]]' failed" ]
+}

--- a/test/fixtures/bats/double_brackets.bats
+++ b/test/fixtures/bats/double_brackets.bats
@@ -1,0 +1,5 @@
+@test "double bracket returns false" {
+  local value='true'
+  [[ "$value" == 'true' ]]
+  [[ "$value" == 'false' ]]
+}


### PR DESCRIPTION
Closes #18. Note: I had originally used ` || false`, but then realized ` || return 1` was even better.

Corresponds to sstephenson/bats#49. For a negligible performance cost, assertions using `[[ ... ]]` will now behave as expected even on Bash versions prior to 4.1-alpha. Most notably, they will work with Bash 3.2.57(1)-release that ships with macOS.

The nice thing is, the way `bats_print_failed_command` already works, the `|| return 1` suffix doesn't appear in the failure output. Also, since the cost is negligible, there's no need to make the suffix insertion dependent on a version check.

Tested using both 3.2.57(1)-release and Bash 4.4.12(1)-release.