### PR TITLE
Support "unoffical Bash strict mode"

### DIFF
--- a/libexec/bats
+++ b/libexec/bats
@@ -100,34 +100,38 @@ for arg in "$@"; do
 done
 
 unset count_flag pretty
+count_flag=''
+pretty=''
 [ -t 0 ] && [ -t 1 ] && pretty="1"
-[ -n "$CI" ] && pretty=""
+[ -n "${CI:-}" ] && pretty=""
 
-for option in "${options[@]}"; do
-  case "$option" in
-  "h" | "help" )
-    help
-    exit 0
-    ;;
-  "v" | "version" )
-    version
-    exit 0
-    ;;
-  "c" | "count" )
-    count_flag="-c"
-    ;;
-  "t" | "tap" )
-    pretty=""
-    ;;
-  "p" | "pretty" )
-    pretty="1"
-    ;;
-  * )
-    usage >&2
-    exit 1
-    ;;
-  esac
-done
+if [[ "${#options[@]}" -ne '0' ]]; then
+  for option in "${options[@]}"; do
+    case "$option" in
+    "h" | "help" )
+      help
+      exit 0
+      ;;
+    "v" | "version" )
+      version
+      exit 0
+      ;;
+    "c" | "count" )
+      count_flag="-c"
+      ;;
+    "t" | "tap" )
+      pretty=""
+      ;;
+    "p" | "pretty" )
+      pretty="1"
+      ;;
+    * )
+      usage >&2
+      exit 1
+      ;;
+    esac
+  done
+fi
 
 if [ "${#arguments[@]}" -eq 0 ]; then
   usage >&2

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -73,6 +73,7 @@ teardown() {
   true
 }
 
+BATS_TEST_SKIPPED=''
 skip() {
   BATS_TEST_SKIPPED=${1:-1}
   BATS_TEST_COMPLETED=1
@@ -89,11 +90,16 @@ bats_test_begin() {
 
 bats_test_function() {
   local test_name="$1"
-  BATS_TEST_NAMES["${#BATS_TEST_NAMES[@]}"]="$test_name"
+  BATS_TEST_NAMES+=("$test_name")
 }
 
+BATS_CURRENT_STACK_TRACE=()
+BATS_PREVIOUS_STACK_TRACE=()
+
 bats_capture_stack_trace() {
-  BATS_PREVIOUS_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
+  if [[ "${#BATS_CURRENT_STACK_TRACE[@]}" -ne '0' ]]; then
+    BATS_PREVIOUS_STACK_TRACE=("${BATS_CURRENT_STACK_TRACE[@]}")
+  fi
   BATS_CURRENT_STACK_TRACE=()
 
   local test_pattern=" $BATS_TEST_NAME $BATS_TEST_SOURCE"
@@ -254,7 +260,7 @@ bats_teardown_trap() {
 
 bats_exit_trap() {
   local status
-  local skipped
+  local skipped=''
   trap - err exit
 
   if [ -n "$BATS_TEST_SKIPPED" ]; then

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -316,7 +316,7 @@ $(< "$FIXTURE_ROOT/unofficial_bash_strict_mode.bash")
 --------
 
 See:
-- https://github.com/sstephenson/bats/issues/171'
+- https://github.com/sstephenson/bats/issues/171
 - http://redsymbol.net/articles/unofficial-bash-strict-mode/
 
 If there is no error output from the test fixture, run the following to

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -85,8 +85,7 @@ fixtures bats
 @test "one failing test" {
   run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
-  printf 'lines:\n' >&2
-  printf '%s\n' "${lines[@]}" >&2
+  emit_debug_output
   [ "${lines[0]}" = '1..1' ]
   [ "${lines[1]}" = 'not ok 1 a failing test' ]
   [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/failing.bats, line 4)" ]
@@ -106,8 +105,7 @@ fixtures bats
 @test "failing test with significant status" {
   STATUS=2 run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
-  printf 'lines:\n' >&2
-  printf '%s\n' "${lines[@]}" >&2
+  emit_debug_output
   [ "${lines[3]}" = "#   \`eval \"( exit \${STATUS:-1} )\"' failed with status 2" ]
 }
 
@@ -175,8 +173,7 @@ fixtures bats
   cd "$TMP"
   run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
-  printf 'lines:\n' >&2
-  printf '%s\n' "${lines[@]}" >&2
+  emit_debug_output
   [ "${lines[2]}" = "# (in test file $FIXTURE_ROOT/failing.bats, line 4)" ]
 }
 
@@ -299,4 +296,45 @@ fixtures bats
   [ "${lines[1]}" = "ok 1 single-quoted name" ]
   [ "${lines[2]}" = "ok 2 double-quoted name" ]
   [ "${lines[3]}" = "ok 3 unquoted name" ]
+}
+
+@test 'ensure compatibility with unofficial Bash strict mode' {
+  local expected='ok 1 unofficial Bash strict mode conditions met'
+
+  # Run Bats under `set -u` to catch as many unset variable accesses as
+  # possible.
+  run bash -u "${BATS_TEST_DIRNAME%/*}/libexec/bats" \
+    "$FIXTURE_ROOT/unofficial_bash_strict_mode.bats"
+  if [[ "$status" -ne '0' || "${lines[1]}" != "$expected" ]]; then
+    cat <<END_OF_ERR_MSG
+
+This test failed because the Bats internals are violating one of the
+constraints imposed by:
+
+--------
+$(< "$FIXTURE_ROOT/unofficial_bash_strict_mode.bash")
+--------
+
+See:
+- https://github.com/sstephenson/bats/issues/171'
+- http://redsymbol.net/articles/unofficial-bash-strict-mode/
+
+If there is no error output from the test fixture, run the following to
+debug the problem:
+
+  $ bash -u bats $RELATIVE_FIXTURE_ROOT/unofficial_bash_strict_mode.bats
+
+If there's no error output even with this command, make sure you're using the
+latest version of Bash, as versions before 4.1-alpha may not produce any error
+output for unset variable accesses.
+
+If there's no output even when running the latest Bash, the problem may reside
+in the DEBUG trap handler. A particularly sneaky issue is that in Bash before
+4.1-alpha, an expansion of an empty array, e.g. "\${FOO[@]}", is considered
+an unset variable access. The solution is to add a size check before the
+expansion, e.g. [[ "\${#FOO[@]}" -ne '0' ]].
+
+END_OF_ERR_MSG
+    emit_debug_output && return 1
+  fi
 }

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -74,7 +74,7 @@ fixtures bats
 }
 
 @test "tap passing, failing and skipping tests" {
-  run filter_control_sequences bats --tap $FIXTURE_ROOT/passing_failing_and_skipping.bats
+  run filter_control_sequences bats --tap "$FIXTURE_ROOT/passing_failing_and_skipping.bats"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..3" ]
   [ "${lines[1]}" = "ok 1 a passing test" ]

--- a/test/fixtures/bats/unofficial_bash_strict_mode.bash
+++ b/test/fixtures/bats/unofficial_bash_strict_mode.bash
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'

--- a/test/fixtures/bats/unofficial_bash_strict_mode.bats
+++ b/test/fixtures/bats/unofficial_bash_strict_mode.bats
@@ -1,0 +1,4 @@
+load unofficial_bash_strict_mode
+@test "unofficial Bash strict mode conditions met" {
+  :
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -18,6 +18,10 @@ if ! command -v tput >/dev/null; then
   export -f tput
 fi
 
+emit_debug_output() {
+  printf '%s\n' 'output:' "$output" >&2
+}
+
 teardown() {
   [ -d "$TMP" ] && rm -f "$TMP"/*
 }


### PR DESCRIPTION
Part of #20. Addresses sstephenson/bats#171 filed by @felixSchl.

*Note: I'd originally called this "unofficial **Bats** strict mode" after frying my brain from debugging for a couple hours.*

Bats is now capable of executing test cases that conform to the "unoffical Bash strict mode" described by:

- http://redsymbol.net/articles/unofficial-bash-strict-mode/

While the test fixture is straightforward, it took trial and error to realize a few things. First, `set -u` changed in Bash 4.1-alpha. Chapter and verse from https://tiswww.case.edu/php/chet/bash/CHANGES:

```
  This document details the changes between this version,
  bash-4.1-alpha, and the previous version, bash-4.0-release.

  n.  Fixed the behavior of `set -u' to conform to the latest Posix
      interpretation: every expansion of an unset variable except $@ and
      $* will cause the shell to exit.
```

This almost certainly accounts for the fact that referencing `"${FOO[@]}"` when `FOO=()` is defined is OK under the latest Bash 4.4.12(1)-release, but breaks under the Bash 3.2.57(1)-release that ships with macOS. The fix was to do an array length check before each such operation.

It probably also accounts for the fact that under Bash 3.2.57, no error output is generated at all for certain unset variable accesses. The workaround there is to run the test using the latest version of Bash.

The biggest surprise was realizing that no error output is visible when the unset variable access happens inside a DEBUG trap handler. All versions of Bash seem susceptible to this.

As a result of these debugging subtleties, the test case contains a thorough error message to suggest how to proceed when the fixture fails.