### PR TITLE
Don't truncate skip message when ')' is included.

### DIFF
--- a/libexec/bats-format-tap-stream
+++ b/libexec/bats-format-tap-stream
@@ -152,7 +152,7 @@ while IFS= read -r line; do
     flush
     ;;
   "ok "* )
-    skip_expr="ok $index (.*) # skip ?(([^)]*))?"
+    skip_expr="ok $index (.*) # skip ?(([[:print:]]*))?"
     if [[ "$line" =~ $skip_expr ]]; then
       let skipped+=1
       buffer skip "${BASH_REMATCH[2]}"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -242,7 +242,7 @@ fixtures bats
 @test "skipped test with parens (pretty formatter)" {
   run bats --pretty "$FIXTURE_ROOT/skipped_with_parens.bats"
   [ $status -eq 0 ]
-  [[ "${lines[0]}" =~ "- a skipped test with parentheses in the reason (skipped: a reason (with parentheses))" ]]
+  [[ "${lines[@]}" =~ "- a skipped test with parentheses in the reason (skipped: "+"a reason (with parentheses))" ]]
 }
 
 @test "extended syntax" {

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -242,6 +242,10 @@ fixtures bats
 @test "skipped test with parens (pretty formatter)" {
   run bats --pretty "$FIXTURE_ROOT/skipped_with_parens.bats"
   [ $status -eq 0 ]
+
+  # Some systems (Alpine, for example) seem to emit an extra whitespace into
+  # entries in the 'lines' array when a carriage return is present from the
+  # pretty formatter.  This is why a '+' is used after the 'skipped' note.
   [[ "${lines[@]}" =~ "- a skipped test with parentheses in the reason (skipped: "+"a reason (with parentheses))" ]]
 }
 

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -239,6 +239,12 @@ fixtures bats
   [ "${lines[2]}" = "ok 2 a skipped test with a reason # skip a reason" ]
 }
 
+@test "skipped test with parens (pretty formatter)" {
+  run bats --pretty "$FIXTURE_ROOT/skipped_with_parens.bats"
+  [ $status -eq 0 ]
+  [[ "${lines[0]}" =~ "- a skipped test with parentheses in the reason (skipped: a reason (with parentheses))" ]]
+}
+
 @test "extended syntax" {
   run bats-exec-test -x "$FIXTURE_ROOT/failing_and_passing.bats"
   [ $status -eq 1 ]

--- a/test/fixtures/bats/skipped_with_parens.bats
+++ b/test/fixtures/bats/skipped_with_parens.bats
@@ -1,0 +1,3 @@
+@test "a skipped test with parentheses in the reason" {
+  skip "a reason (with parentheses)"
+}


### PR DESCRIPTION
Addresses sstephenson/bats#240.  When outputting a 'pretty' formatted
output stream, the 'skip' message was being processed with a character
class of [^)].  I couldn't find a reason for this to be the case, so
I've swapped it out to check instead for printable characters, spaces
included ([:print:]).  Please advise if there is a problem with this
approach.

Tested using Bash 4.3.11(1)-release.