### PR TITLE
WIP: Add CppUnit XML as an output option

### DIFF
--- a/libexec/bats
+++ b/libexec/bats
@@ -20,6 +20,7 @@ help() {
   echo "  -h, --help     Display this help message"
   echo "  -p, --pretty   Show results in pretty format (default for terminals)"
   echo "  -t, --tap      Show results in TAP format"
+  echo "  -u, --cppunit  Show results in CppUnit XML format"
   echo "  -v, --version  Display the version number"
   echo
   echo "  For more information, see https://github.com/bats-core/bats-core"
@@ -102,6 +103,7 @@ done
 unset count_flag pretty
 count_flag=''
 pretty=''
+cppunit=''
 [ -t 0 ] && [ -t 1 ] && pretty="1"
 [ -n "${CI:-}" ] && pretty=""
 
@@ -124,6 +126,9 @@ if [[ "${#options[@]}" -ne '0' ]]; then
       ;;
     "p" | "pretty" )
       pretty="1"
+      ;;
+    "u" | "cppunit" )
+      cppunit="1"
       ;;
     * )
       usage >&2
@@ -160,10 +165,14 @@ else
 fi
 
 set -o pipefail execfail
-if [ -z "$pretty" ]; then
+if [ -z "$pretty" ] && [ -z "$cppunit" ]; then
   exec "$command" $count_flag "${filenames[@]}"
 else
+  if [ -z "$cppunit" ]; then
+    formatter="bats-format-tap-stream"
+  else
+    formatter="bats-format-cppunit"
+  fi
   extended_syntax_flag="-x"
-  formatter="bats-format-tap-stream"
   exec "$command" $count_flag $extended_syntax_flag "${filenames[@]}" | "$formatter"
 fi

--- a/libexec/bats-format-cppunit
+++ b/libexec/bats-format-cppunit
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -e
+
+_count=0
+_skipped=0
+_failures=0
+_name=""
+_in_msg=0
+
+begin() {
+  printf "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+  printf "<TestRun>\n"
+}
+
+_fail_buffer=""
+
+fail_entry() {
+  printf "    <FailedTest id=\"%d\">\n" "$_count"
+}
+
+fail_exit() {
+  printf "    </FailedTest>\n"
+}
+
+fail_loc_mes_beg() {
+  printf "\n"
+  printf "      <Message>"
+}
+
+fail_loc_mes_end() {
+  printf "</Message>\n"
+}
+
+fail() {
+  if [[ $_in_msg == 1 ]]; then
+    fail_loc_mes_end
+    fail_exit
+  fi
+  fail_entry
+  printf "      <Name>%s</Name>\n" "$_name"
+  printf "      <FailureType>Assertion</FailureType>\n"
+}
+
+fail_loc() {
+  printf "\n"
+  printf "      <Location>\n"
+  printf "        <File>%s</File>\n" "${BASH_REMATCH[1]}"
+  printf "        <Line>%d</Line>\n" "${BASH_REMATCH[2]}"
+  printf "      </Location>\n"
+}
+
+fail_mes() {
+  if [[ $_in_msg == 0 ]]; then
+    fail_loc_mes_beg
+  fi
+  printf "\n%s\n" "$1"
+}
+
+fail_buffer() {
+  _fail_buffer="${_fail_buffer}$("$@")"
+}
+
+flush_fail_buffer() {
+  printf "  <FailedTests>\n"
+  printf "%s\n" "${_fail_buffer}"
+  if [[ $_in_msg == 1 ]]; then
+    fail_loc_mes_end
+    fail_exit
+  fi
+  printf "  </FailedTests>\n"
+  _fail_buffer=""
+}
+
+_pass_buffer=""
+
+pass_entry() {
+  printf "\n"
+  printf "    <Test id=\"%d\">\n" "$_count"
+}
+
+pass_exit() {
+  printf "    </Test>\n"
+}
+
+pass() {
+  pass_entry
+  printf "      <Name>%s</Name>\n" "$_name"
+  pass_exit
+}
+
+pass_buffer() {
+  _pass_buffer="${_pass_buffer}$("$@")"
+}
+
+flush_pass_buffer() {
+  printf "  <SuccessfulTests>"
+  printf "%s\n" "${_pass_buffer}"
+  printf "  </SuccessfulTests>\n"
+  _pass_buffer=""
+}
+
+summary() {
+  printf "  <Statistics>\n"
+  printf "    <Tests>%d</Tests>\n" "$_count"
+  printf "    <FailuresTotal>%d</FailuresTotal>\n" "$_failures"
+  printf "    <Errors>0</Errors>\n"
+  printf "    <Failures>%d</Failures>\n" "$_failures"
+  if [ "$_skipped" -gt 0 ]; then
+    printf "    <Skipped>%d</Skipped>\n" "$_skipped"
+  fi
+  printf "  </Statistics>\n"
+}
+
+end() {
+  printf "</TestRun>\n"
+}
+
+finish() {
+  begin
+  flush_fail_buffer
+  flush_pass_buffer
+  summary
+  end
+}
+
+trap finish EXIT
+
+while IFS= read -r line; do
+  case "$line" in
+  "ok "* )
+    let _count+=1
+    skip_expr="ok $_count [[:alnum:][:punct:][:space:]]* # skip.*?"
+    if [[ "$line" =~ $skip_expr ]]; then
+      let _skipped+=1
+    else
+      _name="${line#* $_count }"
+      pass_buffer pass
+    fi
+    ;;
+  "not ok "* )
+    let _count+=1
+    let _failures+=1
+    _name="${line#* $_count }"
+    fail_buffer fail
+    _in_msg=0
+    ;;
+  "# "* )
+    pos_expr="in test file ([^,]*), line ([[:digit:]]+)"
+    if [[ "$1" =~ $pos_expr ]]; then
+      fail_buffer fail_loc "${line:2}"
+    else
+      fail_buffer fail_mes "${line:2}"
+      _in_msg=1
+    fi
+    ;;
+  esac
+done


### PR DESCRIPTION
CppUnit is a widely used framework which outputs its own XML format. In case you're using it for nearly all of your test, you don't like to add another plugin to your CI server just to analyze one project outputting TAP. Thus, give Bats the possibility to output CppUnit XML.

I've tested this as good as I could, with some real-world input and some faked Bats files and compared the output with real-world CppUnit XML. All seems good, there may be edge cases, though.