### PR TITLE
Feature/add test for installer permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ COPY . /opt/bats/
 RUN apk --no-cache add bash \
     && ln -s /opt/bats/libexec/bats /usr/sbin/bats
 
+WORKDIR /opt/bats/
+
 ENTRYPOINT ["bats"]

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,42 @@ abs_dirname() {
   cd "$cwd"
 }
 
+# performs chmod a+x for all files in $target/$folder 
+# that exist in $src/$folder
+# 
+# Example:
+#     fix_folder_file_permissions $src $target $folder
+#
+fix_folder_file_permissions() {
+  src=$1
+  target=$2
+  folder=$3
+  # scan $src directory for the filenames to fix in $target
+  directory="${src}/${folder}"
+  for f in "${directory}"/*; do
+    # get basename of file (strip the path)
+    filename="${f##*/}"
+    # change the execution bit for the file in $target
+    chmod a+x "${target}/${folder}/$filename"
+  done
+}
+
+# executes fix_folder_file_permissions for the folders
+# bin and libexec.
+#
+# Example: 
+#     fix_installed_file_permissions "${BATS_ROOT}" "${PREFIX}"
+# 
+fix_installed_file_permissions() {
+  src=$1
+  target=$2
+  # we only need to adapt execution bits for bin and libexec
+  folders=(bin libexec)
+  for folder in ${folders[@]}; do
+    fix_folder_file_permissions "${src}" "${target}" "${folder}"
+  done
+}
+
 PREFIX="$1"
 if [ -z "$1" ]; then
   { echo "usage: $0 <prefix>"
@@ -41,8 +77,6 @@ if [ ! -L "$PREFIX"/bin/bats ]; then
     ln -s "$dir"/libexec/bats "$dir"/bin/bats
 fi
 
-# fix file permission
-chmod a+x "$PREFIX"/bin/*
-chmod a+x "$PREFIX"/libexec/*
+fix_installed_file_permissions "${BATS_ROOT}" "${PREFIX}"
 
 echo "Installed Bats to $PREFIX/bin/bats"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -355,31 +355,3 @@ END_OF_ERR_MSG
   [ "${lines[10]}" = 'ok 10 {' ]  # unquoted single brace is a valid description
   [ "${lines[11]}" = 'ok 11 ' ]   # empty name from single quote
 }
-
-@test "installer only fixes file permissions of installed files" {
-  # populate installation directory
-  mkdir -p "${BATS_TMPDIR}"/{bin,libexec,other}
-  # create some files that don't have the execution permission set
-  touch "${BATS_TMPDIR}/bin/existing-file-without-x-flag"
-  touch "${BATS_TMPDIR}/libexec/existing-file-without-x-flag"
-  touch "${BATS_TMPDIR}/other/existing-file-without-x-flag"
-  # install bats to populated directory
-  ./install.sh "${BATS_TMPDIR}"
-  # make sure the execution permissions have been set for the installed files
-  [ $(read_permissions "${BATS_TMPDIR}/bin/bats") = "lrwxrwxrwx" ]
-  [ $(read_permissions "${BATS_TMPDIR}/libexec/bats") = "-rwxrwxr-x" ]
-  # make sure the existing files have not been touched
-  [ $(read_permissions "${BATS_TMPDIR}/bin/existing-file-without-x-flag") = "-rw-rw-r--" ]
-  [ $(read_permissions "${BATS_TMPDIR}/libexec/existing-file-without-x-flag") = "-rw-rw-r--" ]
-  [ $(read_permissions "${BATS_TMPDIR}/other/existing-file-without-x-flag") = "-rw-rw-r--" ]
-}
-
-# returns human readable permissions for file $1
-# Example:
-#   read_permissions "/bin/bash"
-#   Returns:
-#     "-rwxr-xr-x"
-read_permissions() {
-  file=$1
-  stat -c '%A' "${file}"
-}


### PR DESCRIPTION
This PR is meant to be on top of #55. My first attempt to provide a test along with #55 failed, because of cross platform issues and implementation details of the test itself. This is now fixed. As the changes also include an adaption of the Dockerfile , I found it necessary to create a second PR for this.

# Add test for installer permissions
    
The test makes sure that install.sh doesn't change the permissions of files other than the installed ones.

After applying this commit, make sure to rebuild your docker image:

```
docker build --tag bats:latest .
```

The change to the docker file was necessary for the Travis CI test to succeed. Travis also performs a test using the docker image and it wasn't able to find install.sh in that case. However, because we're running tests in different environments, it was inevitable to refer to install.sh using a relative path.

Testing with the git bash in AppVeyor was another challenge. The execution flags of installed and previously existing files needed to be checked. For cross platform scenarios `find` is the easiest solution for checking the execution permissions.

However, the git bash –  on a Windows system, as performed by the AppVeyor test – would use Windows `find`, which expects a different parameter syntax compared to gnu find. This can be solved by using `/bin/find` in the git bash. See https://stackoverflow.com/questions/21438556/finding-files-in-a-git-bash-terminal#answer-40633578
