### PR TITLE
Fix posix incorrectness

### DIFF
--- a/libexec/bats-preprocess
+++ b/libexec/bats-preprocess
@@ -7,8 +7,8 @@ encode_name() {
   local hex_code
 
   if [[ ! "$name" =~ [^[:alnum:]\ _-] ]]; then
-    name="${name//_/-5f}"
-    name="${name//-/-2d}"
+    name="${name//_/5f}"
+    name="${name//-/2d}"
     name="${name// /_}"
     result+="$name"
   else
@@ -22,7 +22,7 @@ encode_name() {
       elif [[ "$char" =~ [[:alnum:]] ]]; then
         result+="$char"
       else
-        printf -v 'hex_code' -- "-%02x" \'"$char"
+        printf -v 'hex_code' -- "%02x" \'"$char"
         result+="$hex_code"
       fi
     done

--- a/test/fixtures/bats/single_line.bats
+++ b/test/fixtures/bats/single_line.bats
@@ -2,7 +2,7 @@
 
 @test "passing" { true; }
 
-@test "input redirection" { diff - <( echo hello ); } <<EOS
+@test "input redirection" { [ "$(</dev/stdin)" = hello ]; } <<EOS
 hello
 EOS
 


### PR DESCRIPTION
Two things break Bats on my machine: Bash identifiers that include a dash, and process substitution. These two features are Bash POSIX extensions.

The two commits in this pull-request remove these dependencies. The first commit removes the dashes from generated test names, and the second commit uses command-substitution and input-redirection for the process-substitution effect.