### PR TITLE
More support for strict mode

### DIFF
--- a/bin/bats
+++ b/bin/bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 BATS_READLINK='true'
 if command -v 'greadlink' >/dev/null; then

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 export BATS_VERSION='1.1.0'
 

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 count_only_flag=''
 extended_syntax_flag=''

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eET
+set -eETuo pipefail
 
 BATS_COUNT_ONLY=''
 BATS_TEST_FILTER=''
@@ -330,10 +330,6 @@ bats_perform_test() {
   BATS_TEST_NAME="$1"
   if declare -F "$BATS_TEST_NAME" >/dev/null; then
     BATS_TEST_NUMBER="$2"
-    if [[ -z "$BATS_TEST_NUMBER" ]]; then
-      printf '1..1\n'
-      BATS_TEST_NUMBER=1
-    fi
 
     # Some versions of Bash will reset BASH_LINENO to the first line of the
     # function when the ERR trap fires. All versions of Bash appear to reset it
@@ -364,7 +360,7 @@ bats_perform_test() {
   fi
 }
 
-if [[ -z "$TMPDIR" ]]; then
+if [[ "${TMPDIR:-}" == '' ]]; then
   BATS_TMPDIR='/tmp'
 else
   BATS_TMPDIR="${TMPDIR%/}"
@@ -413,7 +409,7 @@ bats_detect_duplicate_test_case_names() {
 }
 
 bats_evaluate_preprocessed_source() {
-  if [[ -z "$BATS_TEST_SOURCE" ]]; then
+  if [[ "${BATS_TEST_SOURCE:-}" == '' ]]; then
     BATS_TEST_SOURCE="${BATS_PARENT_TMPNAME}.src"
   fi
   source "$BATS_TEST_SOURCE"

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 header_pattern='[0-9]+\.\.[0-9]+'
 IFS= read -r header
@@ -58,7 +58,7 @@ fail() {
 }
 
 log() {
-  set_color 1
+  set_color 1 normal
   buffer '   %s\n' "$1"
   clear_color
 }
@@ -114,7 +114,7 @@ set_color() {
   local color="$1"
   local weight=22
 
-  if [[ "$2" == 'bold' ]]; then
+  if [[ "${2:-normal}" == 'bold' ]]; then
     weight=1
   fi
   buffer '\x1B[%d;%dm' "$(( 30 + $color ))" "$weight"

--- a/libexec/bats-core/bats-preprocess
+++ b/libexec/bats-core/bats-preprocess
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 bats_encode_test_name() {
   local name="$1"

--- a/test/fixtures/bats/environment.bats
+++ b/test/fixtures/bats/environment.bats
@@ -4,5 +4,5 @@
 }
 
 @test "variables do not persist across tests" {
-  [ -z "$variable" ]
+  [ "${variable:-}" == '' ]
 }

--- a/test/fixtures/bats/load.bats
+++ b/test/fixtures/bats/load.bats
@@ -1,4 +1,4 @@
-[ -n "$HELPER_NAME" ] || HELPER_NAME="test_helper"
+[ "${HELPER_NAME:-}" != '' ] || HELPER_NAME="test_helper"
 load "$HELPER_NAME"
 
 @test "calling a loaded helper" {

--- a/test/fixtures/suite/multiple/b.bats
+++ b/test/fixtures/suite/multiple/b.bats
@@ -3,5 +3,5 @@
 }
 
 @test "quasi-truth" {
-  [ -z "$FLUNK" ]
+  [ "${FLUNK:-}" == '' ]
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -9,7 +9,7 @@ make_bats_test_suite_tmpdir() {
 }
 
 filter_control_sequences() {
-  "$@" | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g'
+  sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g' <<< "$("$@" || :)"
 }
 
 if ! command -v tput >/dev/null; then
@@ -24,7 +24,7 @@ emit_debug_output() {
 }
 
 teardown() {
-  if [[ -n "$BATS_TEST_SUITE_TMPDIR" ]]; then
+  if [[ "${BATS_TEST_SUITE_TMPDIR:-}" != '' ]]; then
     rm -rf "$BATS_TEST_SUITE_TMPDIR"
   fi
 }


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: CONTRIBUTING.md
[coc]:         CODE_OF_CONDUCT.md

I do not know why I got some more unbound variables compared to #26 . My approach was to 'set -euo pipefail' in all `libexec/` files and see what needs fixing. Commit 157ec232d95 is there just to show where the `set -euo pipefail` line was added and is not meant to be left as is. 

I am not sure how to properly solve the failing test, especially as #59 is pending.