### PR TITLE
enable fastfail for subshell in run help function

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -55,7 +55,7 @@ run() {
   set +e
   set +E
   set +T
-  output="$("$@" 2>&1)"
+  output="$(set -e; "$@" 2>&1)"
   status="$?"
   oldIFS=$IFS
   IFS=$'\n' lines=($output)


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: CONTRIBUTING.md
[coc]:         CODE_OF_CONDUCT.md
this change is related with :
https://github.com/bats-core/bats-core/issues/69
