### PR TITLE
Want method to compare output against expected checksum of given output

### DIFF
--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -71,6 +71,21 @@ skip() {
   exit 0
 }
 
+md5match() {
+  string="$1"
+  expsum="$2"
+  if which md5sum >/dev/null 2>&1; then
+    cmd=`which md5sum`
+    sum=`"$cmd" <<< "$string" | cut -d' ' -f1`
+  else
+    which openssl >/dev/null 2>&1 || return 1 
+    cmd=`which openssl`
+    sum=`echo "$string" | "$cmd" md5 | cut -d' ' -f2`
+  fi
+  [ -z "$sum" ] && return 1
+  if [ "$sum" = "$expsum" ] ; then return 0 ; else return 1 ; fi
+}
+
 bats_test_begin() {
   BATS_TEST_DESCRIPTION="$1"
   if [[ -n "$BATS_EXTENDED_SYNTAX" ]]; then


### PR DESCRIPTION
I am not sure if this is something others will find useful. I wanted to have a quick method to pass a checksum and results captured in `$output` and get a pass|fail. That's what this changeset accomplishes. If there's interest, but tests must be provided before it could be integrated, I am happy to create them.

Thanks!

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: CONTRIBUTING.md
[coc]:         CODE_OF_CONDUCT.md
