### PR TITLE
Refactors cli argument handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,12 +19,24 @@ abs_dirname() {
   cd "$cwd"
 }
 
-PREFIX="$1"
-if [ -z "$1" ]; then
-  { echo "usage: $0 <prefix>"
-    echo "  e.g. $0 /usr/local"
-  } >&2
+help() {
+  echo "usage: $0 <installation_dir>"
+  echo "  e.g. $0 /usr/local"
+}
+
+if [[ "$#" -ne 1 ]]; then
+  echo "one argument expected, got $#" >&2
+  help >&2
   exit 1
+elif [[ "$1" == '-h' || "$1" == '--help' ]]; then
+  help
+  exit
+elif [[ "$1" =~ ^- ]]; then
+  echo "bad option: $1" >&2
+  help >&2
+  exit 1
+else
+  PREFIX="$1"
 fi
 
 BATS_ROOT="$(abs_dirname "$0")"

--- a/libexec/bats
+++ b/libexec/bats
@@ -79,61 +79,50 @@ export BATS_PREFIX
 export BATS_CWD
 export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
 export PATH="$BATS_LIBEXEC:$PATH"
+export BATS_COUNT_ONLY=false
+export BATS_PRETTY_FORMAT=false
 
-options=()
-arguments=()
-for arg in "$@"; do
-  if [ "${arg:0:1}" = "-" ]; then
-    if [ "${arg:1:1}" = "-" ]; then
-      options[${#options[*]}]="${arg:2}"
-    else
-      index=1
-      while option="${arg:$index:1}"; do
-        [ -n "$option" ] || break
-        options[${#options[*]}]="$option"
-        let index+=1
-      done
-    fi
-  else
-    arguments[${#arguments[*]}]="$arg"
-  fi
-done
+if [[ -t 0 && -t 1 ]]; then
+  BATS_PRETTY_FORMAT=true
+fi
+if [[ -n "${CI:-}" ]]; then
+  BATS_PRETTY_FORMAT=false
+fi
 
-unset count_flag pretty
-count_flag=''
-pretty=''
-[ -t 0 ] && [ -t 1 ] && pretty="1"
-[ -n "${CI:-}" ] && pretty=""
+declare -a arguments=()
 
-if [[ "${#options[@]}" -ne '0' ]]; then
-  for option in "${options[@]}"; do
-    case "$option" in
-    "h" | "help" )
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -h | --help )
       help
       exit 0
       ;;
-    "v" | "version" )
+    -v | --version )
       version
       exit 0
       ;;
-    "c" | "count" )
-      count_flag="-c"
+    -c | --count )
+      BATS_COUNT_ONLY=true
       ;;
-    "t" | "tap" )
-      pretty=""
+    -t | --tap )
+      BATS_PRETTY_FORMAT=false
       ;;
-    "p" | "pretty" )
-      pretty="1"
+    -p | --pretty )
+      BATS_PRETTY_FORMAT=true
       ;;
-    * )
+    -* )
+      echo "bad argument: $option" >&2
       usage >&2
       exit 1
       ;;
-    esac
-  done
-fi
+    *)
+      arguments+=( "$1" )
+  esac
+  shift
+done
 
 if [ "${#arguments[@]}" -eq 0 ]; then
+  echo 'no tests specified' >&2
   usage >&2
   exit 1
 fi
@@ -152,6 +141,7 @@ for filename in "${arguments[@]}"; do
     filenames["${#filenames[@]}"]="$filename"
   fi
 done
+unset arguments
 
 if [ "${#filenames[@]}" -eq 1 ]; then
   command="bats-exec-test"
@@ -160,10 +150,9 @@ else
 fi
 
 set -o pipefail execfail
-if [ -z "$pretty" ]; then
-  exec "$command" $count_flag "${filenames[@]}"
+if [[ "$BATS_PRETTY_FORMAT" == false ]]; then
+  exec "$command" "${filenames[@]}"
 else
-  extended_syntax_flag="-x"
   formatter="bats-format-tap-stream"
-  exec "$command" $count_flag $extended_syntax_flag "${filenames[@]}" | "$formatter"
+  exec "$command" "${filenames[@]}" | "$formatter"
 fi

--- a/libexec/bats-exec-suite
+++ b/libexec/bats-exec-suite
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-count_only_flag=""
-if [ "$1" = "-c" ]; then
-  count_only_flag=1
-  shift
-fi
-
-extended_syntax_flag=""
-if [ "$1" = "-x" ]; then
-  extended_syntax_flag="-x"
-  shift
-fi
-
 trap "kill 0; exit 1" int
 
 count=0
@@ -24,7 +12,7 @@ for filename in "$@"; do
   done <"$filename"
 done
 
-if [ -n "$count_only_flag" ]; then
+if [[ "$BATS_COUNT_ONLY" == 'true' ]]; then
   echo "$count"
   exit
 fi
@@ -43,7 +31,7 @@ for filename in "$@"; do
         echo "${line/ $index / $(($offset + $index)) }"
         ;;
       "ok "* | "not ok "* )
-        [ -n "$extended_syntax_flag" ] || let index+=1
+        [[ "$BATS_PRETTY_FORMAT" == 'true' ]] || let index+=1
         echo "${line/ $index / $(($offset + $index)) }"
         [ "${line:0:6}" != "not ok" ] || status=1
         ;;
@@ -52,7 +40,7 @@ for filename in "$@"; do
         ;;
       esac
     done
-  } < <( bats-exec-test $extended_syntax_flag "$filename" )
+  } < <( bats-exec-test "$filename" )
   offset=$(($offset + $index))
 done
 

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -3,18 +3,6 @@ set -e
 set -E
 set -T
 
-BATS_COUNT_ONLY=""
-if [ "$1" = "-c" ]; then
-  BATS_COUNT_ONLY=1
-  shift
-fi
-
-BATS_EXTENDED_SYNTAX=""
-if [ "$1" = "-x" ]; then
-  BATS_EXTENDED_SYNTAX="$1"
-  shift
-fi
-
 BATS_TEST_FILENAME="$1"
 if [ -z "$BATS_TEST_FILENAME" ]; then
   echo "usage: bats-exec <filename>" >&2
@@ -82,7 +70,7 @@ skip() {
 
 bats_test_begin() {
   BATS_TEST_DESCRIPTION="$1"
-  if [ -n "$BATS_EXTENDED_SYNTAX" ]; then
+  if [[ "$BATS_PRETTY_FORMAT" == 'true' ]]; then
     echo "begin $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
   fi
   setup
@@ -290,7 +278,7 @@ bats_perform_tests() {
   test_number=1
   status=0
   for test_name in "$@"; do
-    "$0" $BATS_EXTENDED_SYNTAX "$BATS_TEST_FILENAME" "$test_name" "$test_number" || status=1
+    "$0" "$BATS_TEST_FILENAME" "$test_name" "$test_number" || status=1
     let test_number+=1
   done
   exit "$status"
@@ -353,7 +341,7 @@ if [ "$#" -eq 0 ]; then
   bats_preprocess_source
   bats_evaluate_preprocessed_source
 
-  if [ -n "$BATS_COUNT_ONLY" ]; then
+  if [[ "$BATS_COUNT_ONLY" == 'true' ]]; then
     echo "${#BATS_TEST_NAMES[@]}"
   else
     bats_perform_tests "${BATS_TEST_NAMES[@]}"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -6,7 +6,8 @@ fixtures bats
 @test "no arguments prints usage instructions" {
   run bats
   [ $status -eq 1 ]
-  [ $(expr "${lines[1]}" : "Usage:") -ne 0 ]
+  [ $(expr "${lines[0]}" : "no tests specified") -ne 0 ]
+  [ $(expr "${lines[2]}" : "Usage:") -ne 0 ]
 }
 
 @test "-v and --version print version number" {
@@ -237,15 +238,6 @@ fixtures bats
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 a skipped test # skip" ]
   [ "${lines[2]}" = "ok 2 a skipped test with a reason # skip a reason" ]
-}
-
-@test "extended syntax" {
-  run bats-exec-test -x "$FIXTURE_ROOT/failing_and_passing.bats"
-  [ $status -eq 1 ]
-  [ "${lines[1]}" = 'begin 1 a failing test' ]
-  [ "${lines[2]}" = 'not ok 1 a failing test' ]
-  [ "${lines[5]}" = 'begin 2 a passing test' ]
-  [ "${lines[6]}" = 'ok 2 a passing test' ]
 }
 
 @test "pretty and tap formats" {

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -51,14 +51,3 @@ fixtures suite
   echo "$output" | grep "^ok . quasi-truth"
 }
 
-@test "extended syntax in suite" {
-  FLUNK=1 run bats-exec-suite -x "$FIXTURE_ROOT/multiple/"*.bats
-  [ $status -eq 1 ]
-  [ "${lines[0]}" = "1..3" ]
-  [ "${lines[1]}" = "begin 1 truth" ]
-  [ "${lines[2]}" = "ok 1 truth" ]
-  [ "${lines[3]}" = "begin 2 more truth" ]
-  [ "${lines[4]}" = "ok 2 more truth" ]
-  [ "${lines[5]}" = "begin 3 quasi-truth" ]
-  [ "${lines[6]}" = "not ok 3 quasi-truth" ]
-}


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: CONTRIBUTING.md
[coc]:         CODE_OF_CONDUCT.md

I never understood why cli arguments are treated in such a chaotic way in Bats. The loop to read them is unnecessarily complicated and once read they are passed anew to the lib scripts where they are read again. It seems to me over-engineered.

In this PR, I read them in `while` loop, I set environment variables accordingly and remove argument handling from the lib scripts. Also, I print error messages on no or bad arguments/options. Closes #45.

I also added argument handling to `install.sh`. Supersedes #46.

This should also be considered in combination with #59 .

Execution flow is much more understandable now, at least to me. In total, I removed 2 unnecessary tests and ~30 lines of codes.