### PR TITLE
Show errors when Bash EXIT trap fires without ERR

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -244,10 +244,10 @@ bats_debug_trap() {
 bats_error_trap() {
   local status="$?"
   if [[ -z "$BATS_TEST_COMPLETED" ]]; then
-    if [[ "$status" -eq 0 ]]; then
-      status=1
+    BATS_ERROR_STATUS="$status"
+    if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
+      BATS_ERROR_STATUS=1
     fi
-    BATS_ERROR_STATUS="${status:-1}"
     BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
     trap - debug
   fi

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -95,6 +95,7 @@ bats_test_function() {
 
 BATS_CURRENT_STACK_TRACE=()
 BATS_PREVIOUS_STACK_TRACE=()
+BATS_ERROR_STACK_TRACE=()
 
 bats_capture_stack_trace() {
   if [[ "${#BATS_CURRENT_STACK_TRACE[@]}" -ne '0' ]]; then
@@ -271,6 +272,11 @@ bats_exit_trap() {
   fi
 
   if [ -z "$BATS_TEST_COMPLETED" ] || [ -z "$BATS_TEARDOWN_COMPLETED" ]; then
+    if [[ "${#BATS_ERROR_STACK_TRACE[@]}" -eq 0 ]]; then
+      # Some Bash command failures trigger the EXIT trap, but not ERR.
+      BATS_ERROR_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
+      BATS_ERROR_STATUS=1
+    fi
     echo "not ok $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
     bats_print_stack_trace "${BATS_ERROR_STACK_TRACE[@]}" >&3
     bats_print_failed_command "${BATS_ERROR_STACK_TRACE[${#BATS_ERROR_STACK_TRACE[@]}-1]}" "$BATS_ERROR_STATUS" >&3

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -230,17 +230,24 @@ bats_debug_trap() {
 }
 
 # For some versions of Bash, the `ERR` trap may not always fire for every
-# command failure, but the `EXIT` trap will. For this reason we call it at the
-# very beginning of `bats_teardown_trap` (the `DEBUG` trap for the call will
-# move `BATS_CURRENT_STACK_TRACE` to `BATS_PREVIOUS_STACK_TRACE`) and check the
-# value of `$?` before taking other actions.
+# command failure, but the `EXIT` trap will. Also, some command failures may not
+# set `$?` properly. See #72 and #81 for details.
+#
+# For this reason, we call `bats_error_trap` at the very beginning of
+# `bats_teardown_trap` (the `DEBUG` trap for the call will move
+# `BATS_CURRENT_STACK_TRACE` to `BATS_PREVIOUS_STACK_TRACE`) and check the value
+# of `$BATS_TEST_COMPLETED` before taking other actions. We also adjust the exit
+# status value if needed.
 #
 # See `bats_exit_trap` for an additional EXIT error handling case when `$?`
-# isn't set properly.
+# isn't set properly during `teardown()` errors.
 bats_error_trap() {
   local status="$?"
-  if [[ "$status" -ne '0' ]]; then
-    BATS_ERROR_STATUS="$status"
+  if [[ -z "$BATS_TEST_COMPLETED" ]]; then
+    if [[ "$status" -eq 0 ]]; then
+      status=1
+    fi
+    BATS_ERROR_STATUS="${status:-1}"
     BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
     trap - debug
   fi
@@ -277,8 +284,13 @@ bats_exit_trap() {
     if [[ "${#BATS_ERROR_STACK_TRACE[@]}" -eq 0 ]]; then
       # For some versions of bash, `$?` may not be set properly for some error
       # conditions before triggering the EXIT trap directly (see #72 and #81).
-      # Thanks to the `BATS_TEST_COMPLETED` and `BATS_TEARDOWN_COMPLETED`
-      # signals, this will pinpoint such errors.
+      # Thanks to the `BATS_TEARDOWN_COMPLETED` signal, this will pinpoint such
+      # errors if they happen during `teardown()` when `bats_perform_test` calls
+      # `bats_teardown_trap` directly after the test itself passes.
+      #
+      # If instead the test fails, and the `teardown()` error happens while
+      # `bats_teardown_trap` runs as the EXIT trap, the test will fail with no
+      # output, since there's no way to reach the `bats_exit_trap` call.
       BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
       BATS_ERROR_STATUS=1
     fi

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -229,11 +229,14 @@ bats_debug_trap() {
   fi
 }
 
-# When running under Bash 3.2.57(1)-release on macOS, the `ERR` trap may not
-# always fire, but the `EXIT` trap will. For this reason we call it at the very
-# beginning of `bats_teardown_trap` (the `DEBUG` trap for the call will move
-# `BATS_CURRENT_STACK_TRACE` to `BATS_PREVIOUS_STACK_TRACE`) and check the value
-# of `$?` before taking other actions.
+# For some versions of Bash, the `ERR` trap may not always fire for every
+# command failure, but the `EXIT` trap will. For this reason we call it at the
+# very beginning of `bats_teardown_trap` (the `DEBUG` trap for the call will
+# move `BATS_CURRENT_STACK_TRACE` to `BATS_PREVIOUS_STACK_TRACE`) and check the
+# value of `$?` before taking other actions.
+#
+# See `bats_exit_trap` for an additional EXIT error handling case when `$?`
+# isn't set properly.
 bats_error_trap() {
   local status="$?"
   if [[ "$status" -ne '0' ]]; then
@@ -245,7 +248,6 @@ bats_error_trap() {
 
 bats_teardown_trap() {
   bats_error_trap
-  trap "bats_exit_trap" exit
   local status=0
   teardown >>"$BATS_OUT" 2>&1 || status="$?"
 
@@ -273,8 +275,11 @@ bats_exit_trap() {
 
   if [ -z "$BATS_TEST_COMPLETED" ] || [ -z "$BATS_TEARDOWN_COMPLETED" ]; then
     if [[ "${#BATS_ERROR_STACK_TRACE[@]}" -eq 0 ]]; then
-      # Some Bash command failures trigger the EXIT trap, but not ERR.
-      BATS_ERROR_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
+      # For some versions of bash, `$?` may not be set properly for some error
+      # conditions before triggering the EXIT trap directly (see #72 and #81).
+      # Thanks to the `BATS_TEST_COMPLETED` and `BATS_TEARDOWN_COMPLETED`
+      # signals, this will pinpoint such errors.
+      BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
       BATS_ERROR_STATUS=1
     fi
     echo "not ok $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
@@ -318,6 +323,8 @@ bats_perform_test() {
     trap "bats_teardown_trap" exit
     "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
     BATS_TEST_COMPLETED=1
+    trap "bats_exit_trap" exit
+    bats_teardown_trap
 
   else
     echo "bats: unknown test name \`$BATS_TEST_NAME'" >&2

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -355,3 +355,19 @@ END_OF_ERR_MSG
   [ "${lines[10]}" = 'ok 10 {' ]  # unquoted single brace is a valid description
   [ "${lines[11]}" = 'ok 11 ' ]   # empty name from single quote
 }
+
+@test "sourcing a nonexistent file in setup produces error output" {
+  run bats "$FIXTURE_ROOT/source_nonexistent_file.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" = 'not ok 1 sourcing nonexistent file fails in setup' ]
+  [ "${lines[2]}" = "# (from function \`setup' in test file $RELATIVE_FIXTURE_ROOT/source_nonexistent_file.bats, line 2)" ]
+  [ "${lines[3]}" = "#   \`source \"nonexistent file\"' failed" ]
+}
+
+@test "referencing unset parameter in setup produces error output" {
+  run bats "$FIXTURE_ROOT/reference_unset_parameter.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" = 'not ok 1 referencing unset parameter fails in setup' ]
+  [ "${lines[2]}" = "# (from function \`setup' in test file $RELATIVE_FIXTURE_ROOT/reference_unset_parameter.bats, line 3)" ]
+  [ "${lines[3]}" = "#   \`echo \"\$unset_parameter\"' failed" ]
+}

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -85,7 +85,6 @@ fixtures bats
 @test "one failing test" {
   run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
-  emit_debug_output
   [ "${lines[0]}" = '1..1' ]
   [ "${lines[1]}" = 'not ok 1 a failing test' ]
   [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/failing.bats, line 4)" ]
@@ -105,7 +104,6 @@ fixtures bats
 @test "failing test with significant status" {
   STATUS=2 run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
-  emit_debug_output
   [ "${lines[3]}" = "#   \`eval \"( exit \${STATUS:-1} )\"' failed with status 2" ]
 }
 
@@ -173,7 +171,6 @@ fixtures bats
   cd "$TMP"
   run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
-  emit_debug_output
   [ "${lines[2]}" = "# (in test file $FIXTURE_ROOT/failing.bats, line 4)" ]
 }
 
@@ -341,7 +338,6 @@ END_OF_ERR_MSG
 
 @test "parse @test lines with various whitespace combinations" {
   run bats "$FIXTURE_ROOT/whitespace.bats"
-  emit_debug_output
   [ $status -eq 0 ]
   [ "${lines[1]}" = 'ok 1 no extra whitespace' ]
   [ "${lines[2]}" = 'ok 2 tab at beginning of line' ]
@@ -357,17 +353,49 @@ END_OF_ERR_MSG
 }
 
 @test "sourcing a nonexistent file in setup produces error output" {
-  run bats "$FIXTURE_ROOT/source_nonexistent_file.bats"
+  run bats "$FIXTURE_ROOT/source_nonexistent_file_in_setup.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'not ok 1 sourcing nonexistent file fails in setup' ]
-  [ "${lines[2]}" = "# (from function \`setup' in test file $RELATIVE_FIXTURE_ROOT/source_nonexistent_file.bats, line 2)" ]
+  [ "${lines[2]}" = "# (from function \`setup' in test file $RELATIVE_FIXTURE_ROOT/source_nonexistent_file_in_setup.bats, line 2)" ]
   [ "${lines[3]}" = "#   \`source \"nonexistent file\"' failed" ]
 }
 
 @test "referencing unset parameter in setup produces error output" {
-  run bats "$FIXTURE_ROOT/reference_unset_parameter.bats"
+  run bats "$FIXTURE_ROOT/reference_unset_parameter_in_setup.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'not ok 1 referencing unset parameter fails in setup' ]
-  [ "${lines[2]}" = "# (from function \`setup' in test file $RELATIVE_FIXTURE_ROOT/reference_unset_parameter.bats, line 3)" ]
+  [ "${lines[2]}" = "# (from function \`setup' in test file $RELATIVE_FIXTURE_ROOT/reference_unset_parameter_in_setup.bats, line 3)" ]
+  [ "${lines[3]}" = "#   \`echo \"\$unset_parameter\"' failed" ]
+}
+
+@test "sourcing a nonexistent file in test produces error output" {
+  run bats "$FIXTURE_ROOT/source_nonexistent_file.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" = 'not ok 1 sourcing nonexistent file fails' ]
+  [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/source_nonexistent_file.bats, line 2)" ]
+  [ "${lines[3]}" = "#   \`source \"nonexistent file\"' failed" ]
+}
+
+@test "referencing unset parameter in test produces error output" {
+  run bats "$FIXTURE_ROOT/reference_unset_parameter.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" = 'not ok 1 referencing unset parameter fails' ]
+  [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/reference_unset_parameter.bats, line 3)" ]
+  [ "${lines[3]}" = "#   \`echo \"\$unset_parameter\"' failed" ]
+}
+
+@test "sourcing a nonexistent file in teardown produces error output" {
+  run bats "$FIXTURE_ROOT/source_nonexistent_file_in_teardown.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" = 'not ok 1 sourcing nonexistent file fails in teardown' ]
+  [ "${lines[2]}" = "# (from function \`teardown' in test file $RELATIVE_FIXTURE_ROOT/source_nonexistent_file_in_teardown.bats, line 2)" ]
+  [ "${lines[3]}" = "#   \`source \"nonexistent file\"' failed" ]
+}
+
+@test "referencing unset parameter in teardown produces error output" {
+  run bats "$FIXTURE_ROOT/reference_unset_parameter_in_teardown.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" = 'not ok 1 referencing unset parameter fails in teardown' ]
+  [ "${lines[2]}" = "# (from function \`teardown' in test file $RELATIVE_FIXTURE_ROOT/reference_unset_parameter_in_teardown.bats, line 3)" ]
   [ "${lines[3]}" = "#   \`echo \"\$unset_parameter\"' failed" ]
 }

--- a/test/fixtures/bats/reference_unset_parameter.bats
+++ b/test/fixtures/bats/reference_unset_parameter.bats
@@ -1,8 +1,4 @@
-setup() {
+@test "referencing unset parameter fails" {
   set -u
   echo "$unset_parameter"
-}
-
-@test "referencing unset parameter fails in setup" {
-  :
 }

--- a/test/fixtures/bats/reference_unset_parameter.bats
+++ b/test/fixtures/bats/reference_unset_parameter.bats
@@ -1,0 +1,8 @@
+setup() {
+  set -u
+  echo "$unset_parameter"
+}
+
+@test "referencing unset parameter fails in setup" {
+  :
+}

--- a/test/fixtures/bats/reference_unset_parameter_in_setup.bats
+++ b/test/fixtures/bats/reference_unset_parameter_in_setup.bats
@@ -3,6 +3,11 @@ setup() {
   echo "$unset_parameter"
 }
 
+teardown() {
+  echo "should not capture the next line"
+  [ 1 -eq 2 ]
+}
+
 @test "referencing unset parameter fails in setup" {
   :
 }

--- a/test/fixtures/bats/reference_unset_parameter_in_setup.bats
+++ b/test/fixtures/bats/reference_unset_parameter_in_setup.bats
@@ -1,0 +1,8 @@
+setup() {
+  set -u
+  echo "$unset_parameter"
+}
+
+@test "referencing unset parameter fails in setup" {
+  :
+}

--- a/test/fixtures/bats/reference_unset_parameter_in_teardown.bats
+++ b/test/fixtures/bats/reference_unset_parameter_in_teardown.bats
@@ -1,0 +1,8 @@
+teardown() {
+  set -u
+  echo "$unset_parameter"
+}
+
+@test "referencing unset parameter fails in teardown" {
+  :
+}

--- a/test/fixtures/bats/source_nonexistent_file.bats
+++ b/test/fixtures/bats/source_nonexistent_file.bats
@@ -1,0 +1,7 @@
+setup() {
+  source "nonexistent file"
+}
+
+@test "sourcing nonexistent file fails in setup" {
+  :
+}

--- a/test/fixtures/bats/source_nonexistent_file.bats
+++ b/test/fixtures/bats/source_nonexistent_file.bats
@@ -1,7 +1,3 @@
-setup() {
+@test "sourcing nonexistent file fails" {
   source "nonexistent file"
-}
-
-@test "sourcing nonexistent file fails in setup" {
-  :
 }

--- a/test/fixtures/bats/source_nonexistent_file_in_setup.bats
+++ b/test/fixtures/bats/source_nonexistent_file_in_setup.bats
@@ -1,0 +1,7 @@
+setup() {
+  source "nonexistent file"
+}
+
+@test "sourcing nonexistent file fails in setup" {
+  :
+}

--- a/test/fixtures/bats/source_nonexistent_file_in_setup.bats
+++ b/test/fixtures/bats/source_nonexistent_file_in_setup.bats
@@ -2,6 +2,11 @@ setup() {
   source "nonexistent file"
 }
 
+teardown() {
+  echo "should not capture the next line"
+  [ 1 -eq 2 ]
+}
+
 @test "sourcing nonexistent file fails in setup" {
   :
 }

--- a/test/fixtures/bats/source_nonexistent_file_in_teardown.bats
+++ b/test/fixtures/bats/source_nonexistent_file_in_teardown.bats
@@ -1,0 +1,7 @@
+teardown() {
+  source "nonexistent file"
+}
+
+@test "sourcing nonexistent file fails in teardown" {
+  :
+}


### PR DESCRIPTION
Closes #72 and #81. Both of those issues deal with the `bats_error_trap` executing with an incorrect value for `$?`. Bats exited with an error, but provided no stack trace information to pinpoint its source.

* #72 deals with the inconsistent failure-mode behavior of the `source` builtin between Bash versions. I believe it's feasible to update `load` with robust error checking around `source` and strongly recommend its use in Bats test files instead of using `source` directly. I've already opened #80 to track this.

* #81 deals with inconsistent failure-mode behavior of `set -u`, particularly when code within a Bats test file itself references an unbound variable.

With credit to sstephenson, Bats was smart enough to know and to report that an error occurred, even when it couldn't tell exactly where the error came from.

Building on that existing mechanism, this change produces output for these failure cases even when `bats_error_trap` isn't called with the correct value for `$?`. It passes all the existing tests under Bash 3.2.57(1)-release and 4.4.19(1)-release. I also timed the original suites with and without the change to ensure the runtime cost was negligible.

A couple more notes:

* This change obsoletes the suggestion in #81 that a test case to validate testing code running under `set -u` is necessary. `run()` disables `set -e` for the code under test to begin with, sidestepping the problem with `set -eu` interactions in Bash versions prior to 4.1.0.

* I've noticed that this mechanism does _not_ work when the problematic behavior is in `teardown()`. The change preserves existing behavior, the remedy for that issue requires further thinking (and a new issue).

cc: @cpmills1975 @tterranigma @eedwards-sk

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: CONTRIBUTING.md
[coc]:         CODE_OF_CONDUCT.md
