### PR TITLE
Emit correct trace after calling exported function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ services:
   - docker
 
 script:
+- bash -c 'time bin/bats --tap test'
 - |
-  bash -c 'time bin/bats --tap test'
   if [[ "$TRAVIS_OS_NAME" == 'linux' ]]; then
     docker build --tag bats:latest .
     docker run -it bats:latest --tap /opt/bats/test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.6
 
-COPY . /opt/bats/
-
 RUN apk --no-cache add bash \
     && ln -s /opt/bats/libexec/bats /usr/sbin/bats
+
+COPY . /opt/bats/
 
 ENTRYPOINT ["bats"]

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -107,11 +107,13 @@ bats_capture_stack_trace() {
   local setup_pattern=" setup $BATS_TEST_SOURCE"
   local teardown_pattern=" teardown $BATS_TEST_SOURCE"
 
+  local source_file
   local frame
   local i
 
   for ((i=2; i != ${#FUNCNAME[@]}; ++i)); do
-    frame="${BASH_LINENO[$((i-1))]} ${FUNCNAME[$i]} ${BASH_SOURCE[$i]}"
+    source_file="${BASH_SOURCE[$i]:-$BATS_TEST_SOURCE}"
+    frame="${BASH_LINENO[$((i-1))]} ${FUNCNAME[$i]} $source_file"
     BATS_CURRENT_STACK_TRACE["${#BATS_CURRENT_STACK_TRACE[@]}"]="$frame"
     if [[ "$frame" = *"$test_pattern"     || \
           "$frame" = *"$setup_pattern"    || \

--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -112,6 +112,8 @@ bats_capture_stack_trace() {
   local i
 
   for ((i=2; i != ${#FUNCNAME[@]}; ++i)); do
+    # Use BATS_TEST_SOURCE if necessary to work around Bash < 4.4 bug whereby
+    # calling an exported function erases the test file's BASH_SOURCE entry.
     source_file="${BASH_SOURCE[$i]:-$BATS_TEST_SOURCE}"
     frame="${BASH_LINENO[$((i-1))]} ${FUNCNAME[$i]} $source_file"
     BATS_CURRENT_STACK_TRACE["${#BATS_CURRENT_STACK_TRACE[@]}"]="$frame"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -399,3 +399,15 @@ END_OF_ERR_MSG
   [ "${lines[2]}" = "# (from function \`teardown' in test file $RELATIVE_FIXTURE_ROOT/reference_unset_parameter_in_teardown.bats, line 3)" ]
   [ "${lines[3]}" = "#   \`echo \"\$unset_parameter\"' failed" ]
 }
+
+@test "execute exported function without breaking failing test output" {
+  exported_function() { return 0; }
+  export -f exported_function
+  run bats "$FIXTURE_ROOT/exported_function.bats"
+  [ $status -eq 1 ]
+  [ "${lines[0]}" = "1..1" ]
+  [ "${lines[1]}" = "not ok 1 failing test" ]
+  [ "${lines[2]}" = "# (in test file test/fixtures/bats/exported_function.bats, line 7)" ]
+  [ "${lines[3]}" = "#   \`false' failed" ]
+  [ "${lines[4]}" = "# a='exported_function'" ]
+}

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -407,12 +407,7 @@ END_OF_ERR_MSG
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..1" ]
   [ "${lines[1]}" = "not ok 1 failing test" ]
-  local expected='# \(in test file .*test/fixtures/bats/exported_function\.bats, line 7\)'
-  if [[ ! "${lines[2]}" =~ $expected ]]; then
-    printf 'Expected stack trace to match /%s/\n' "$expected" >&2
-    emit_debug_output
-    false
-  fi
+  [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/exported_function.bats, line 7)" ]
   [ "${lines[3]}" = "#   \`false' failed" ]
   [ "${lines[4]}" = "# a='exported_function'" ]
 }

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -407,7 +407,12 @@ END_OF_ERR_MSG
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..1" ]
   [ "${lines[1]}" = "not ok 1 failing test" ]
-  [ "${lines[2]}" = "# (in test file test/fixtures/bats/exported_function.bats, line 7)" ]
+  local expected='# \(in test file .*test/fixtures/bats/exported_function\.bats, line 7\)'
+  if [[ ! "${lines[2]}" =~ $expected ]]; then
+    printf 'Expected stack trace to match /%s/\n' "$expected" >&2
+    emit_debug_output
+    false
+  fi
   [ "${lines[3]}" = "#   \`false' failed" ]
   [ "${lines[4]}" = "# a='exported_function'" ]
 }

--- a/test/fixtures/bats/exported_function.bats
+++ b/test/fixtures/bats/exported_function.bats
@@ -1,0 +1,8 @@
+if exported_function; then
+  a='exported_function'
+fi
+
+@test "failing test" {
+  echo "a='$a'"
+  false
+}


### PR DESCRIPTION
Closes #34. Incorporates the test code from that PR.

This fixes a problem whereby invoking an exported function within a test script would result in an incorrect stack trace. It does this by using `BATS_TEST_SOURCE` to capture a function's frame when its corresponding `BASH_SOURCE` entry is empty.

Note: I believe the earlier problem described in sstephenson/bats#225 whereby no output was generated at all was fixed by commit 0f6dde530ee41c36dcb32341ca41af49fb00ad7d.

My investigation revealed that in Bash versions all the way up through 4.3.48, before this code change, the test failed as @Pawamoy reported, with the underlying test fixture producing the following output:

```
   not ok 1 failing test
     (in file , line 7,
      from function `bats_perform_test' in file libexec/bats-exec-test, line 339,
      from function `main' in test file , line 391)
```

Starting with Bash 4.4, the test passed.

The apparent reason for the failure is that the `BASH_SOURCE` entry corresponding to the test file was getting wiped out when the exported function was called. (Once I converged on this as a potential culprit, I verified it by printing the contents of `BASH_SOURCE` before and after the exported function call.) Since `bats_capture_stack_trace` depends on matching a `BASH_SOURCE` value against `BATS_TEST_SOURCE`, when the `BASH_SOURCE` corresponding to the test function was empty, it would keep collecting stack frames, resulting in the output above.

As best I can currently tell,  the change accounting for the fix in Bash 4.4 is (from the Bash 4.4 ChangeLog):

```
  1/2/2014
  --------
  ...snip...

  2/26
  ----
  [bash-4.3 released]
  ...snip...

  11/28
  -----
  execute_cmd.c
    - struct func_array_state: new state to save state of BASH_LINENO,
      BASH_SOURCE, and FUNCNAME during function execution so it can be
      restored on a jump to top level
    - restore_funcarray_state: new function to restore func_array_state
    - execute_function: fill in func_array_state variable, add unwind-
      protect to restore it on jump to top level, call explicitly at
      end of function if subshell != 0 (may not be necessary, but safe
      for now).  Fixes bug with local assignments to FUNCNAME reported
      by Arfrever Frehtes Taifersar Arahesis <arfrever.fta@gmail.com>

  1/1/2015
  --------
  ...snip...

  7/7
  ---
  ...snip...
  [bash-4.4-alpha frozen]
```

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: CONTRIBUTING.md
[coc]:         CODE_OF_CONDUCT.md
