### PR TITLE
Fix BATS_CWD bug introduced in #91

### DIFF
--- a/libexec/bats
+++ b/libexec/bats
@@ -41,7 +41,7 @@ expand_path() {
   printf -v "$result" '%s/%s' "$dirname" "${path##*/}"
 }
 
-export BATS_CWD="${PWD%/*}"
+export BATS_CWD="$PWD"
 export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
 export PATH="$BATS_ROOT/libexec:$PATH"
 

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -82,6 +82,13 @@ fixtures bats
   [ "${lines[3]}" = "not ok 3 a failing test" ]
 }
 
+@test "BATS_CWD is correct as validated by bats_trim_filename output" {
+  local trimmed
+  bats_trim_filename "$BATS_TEST_DIRNAME/foo" 'trimmed'
+  printf 'ACTUAL: %s\n' "$trimmed" >&2
+  [ "$trimmed" = 'test/foo' ]
+}
+
 @test "one failing test" {
   run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -82,11 +82,11 @@ fixtures bats
   [ "${lines[3]}" = "not ok 3 a failing test" ]
 }
 
-@test "BATS_CWD is correct as validated by bats_trim_filename output" {
+@test "BATS_CWD is correctly set to PWD as validated by bats_trim_filename" {
   local trimmed
-  bats_trim_filename "$BATS_TEST_DIRNAME/foo" 'trimmed'
+  bats_trim_filename "$PWD/foo/bar" 'trimmed'
   printf 'ACTUAL: %s\n' "$trimmed" >&2
-  [ "$trimmed" = 'test/foo' ]
+  [ "$trimmed" = 'foo/bar' ]
 }
 
 @test "one failing test" {


### PR DESCRIPTION
I didn't catch this until trying to update mbland/go-script-bash to use Bats v1.0.0, because we didn't have any bats-core tests validating it.

I know we just pushed v1.0.0 yesterday, but I'm already ready for v1.0.1 once this goes in!

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
