### PR TITLE
Ensure last line of output prints without newline

### DIFF
--- a/libexec/bats-exec-test
+++ b/libexec/bats-exec-test
@@ -292,6 +292,9 @@ bats_exit_trap() {
     while IFS= read -r line; do
       printf '# %s\n' "$line"
     done <"$BATS_OUT" >&3
+    if [[ -n "$line" ]]; then
+      printf '# %s\n' "$line"
+    fi
     status=1
   else
     echo "ok ${BATS_TEST_NUMBER} ${BATS_TEST_DESCRIPTION}${skipped}" >&3

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -434,3 +434,17 @@ END_OF_ERR_MSG
   [ "${lines[3]}" = "#   \`false' failed" ]
   [ "${lines[4]}" = "# a='exported_function'" ]
 }
+
+@test "output printed even when no final newline" {
+  run bats "$FIXTURE_ROOT/no-final-newline.bats"
+  printf 'num lines: %d\n' "${#lines[@]}" >&2
+  printf 'LINE: %s\n' "${lines[@]}" >&2
+  [ "$status" -eq 1 ]
+  [ "${#lines[@]}" -eq 7 ]
+  [ "${lines[1]}" = 'not ok 1 no final newline' ]
+  [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/no-final-newline.bats, line 2)" ]
+  [ "${lines[3]}" = "#   \`printf 'foo\nbar\nbaz' >&2 && return 1' failed" ]
+  [ "${lines[4]}" = '# foo' ]
+  [ "${lines[5]}" = '# bar' ]
+  [ "${lines[6]}" = '# baz' ]
+}

--- a/test/fixtures/bats/no-final-newline.bats
+++ b/test/fixtures/bats/no-final-newline.bats
@@ -1,0 +1,3 @@
+@test "no final newline" {
+  printf 'foo\nbar\nbaz' >&2 && return 1
+}


### PR DESCRIPTION
While running my mbland/go-script-bash tests with v1.0.0 (which I should've tried _before_ v1.0.0), I noticed some failed due to the last line of output missing. This happened because the `while` loop used to replace `sed` in #88 would break the loop when the last line didn't end with a newline.

As it turns out, the fix was pretty easy, thanks to the hints from:

- https://stackoverflow.com/a/14547230
- https://unix.stackexchange.com/a/418067

However, there was a slight performance hit for the existing tests when the `[[ -n "$line" ]]` conditional appeared as part of the `while` expression. Instead, this change emits the last line in an `if` statement after the `while` loop.

I got my mbland/go-script-bash tests to pass by updating the code to always emit a newline, which was the right thing to do regardless. However, it seemed still worth handling this condition in Bats itself, to maintain behavioral parity with v0.4.0.

Once this gets merged, I'll cut v1.0.1.

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
