### PR TITLE
Publish to npm

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,4 @@
+Andrew Martin (https://control-plane.io/)
+Bianca Tamayo <hi@biancatamayo.me> (https://biancatamayo.me/)
+Jason Karns <jason.karns@gmail.com> (http://jasonkarns.com/)
+Mike Bland <mbland@acm.org> (https://mike-bland.com/)

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ with the `-h` or `--help` options. These are the options that Bats currently
 supports:
 
 ```
-Bats 1.0.1
+Bats x.y.z
 Usage: bats [-c] [-p | -t] <test> [<test> ...]
 
   <test> is the path to a Bats test file, or the path to a directory

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Bats-core: Bash Automated Testing System (2018)
 
 [![Latest release](https://img.shields.io/github/release/bats-core/bats-core.svg)](https://github.com/bats-core/bats-core/releases/latest)
+[![npm package](https://img.shields.io/npm/v/bats.svg)](https://www.npmjs.com/package/bats)
 [![License](https://img.shields.io/github/license/bats-core/bats-core.svg)](https://github.com/bats-core/bats-core/blob/master/LICENSE.md)
 [![Continuous integration status for Linux and macOS](https://img.shields.io/travis/bats-core/bats-core/master.svg)](https://travis-ci.org/bats-core/bats-core)
 [![Continuous integration status for Windows](https://img.shields.io/appveyor/ci/bats-core/bats-core/master.svg)](https://ci.appveyor.com/project/bats-core/bats-core)

--- a/package.json
+++ b/package.json
@@ -5,12 +5,6 @@
   "homepage": "https://github.com/bats-core/bats-core#readme",
   "license": "MIT",
   "author": "Sam Stephenson <sstephenson@gmail.com> (http://sstephenson.us/)",
-  "contributors": [
-    "Andrew Martin (https://control-plane.io/)",
-    "Bianca Tamayo <hi@biancatamayo.me> (https://biancatamayo.me/)",
-    "Jason Karns <jason.karns@gmail.com> (http://jasonkarns.com/)",
-    "Mike Bland <mbland@acm.org> (https://mike-bland.com/)"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bats-core/bats-core.git"
@@ -19,7 +13,9 @@
     "url": "https://github.com/bats-core/bats-core/issues"
   },
   "files": [
-    "bin", "libexec", "man"
+    "bin",
+    "libexec",
+    "man"
   ],
   "directories": {
     "bin": "bin",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,40 @@
 {
   "name": "bats",
-  "version": "v1.0.1",
+  "version": "0.4.0",
   "description": "Bash Automated Testing System",
   "homepage": "https://github.com/bats-core/bats-core#readme",
-  "repository": "github:bats-core/bats-core",
-  "bin": "./bin/bats"
+  "license": "MIT",
+  "author": "Sam Stephenson <sstephenson@gmail.com> (http://sstephenson.us/)",
+  "contributors": [
+    "Andrew Martin (https://control-plane.io/)",
+    "Bianca Tamayo <hi@biancatamayo.me> (https://biancatamayo.me/)",
+    "Jason Karns <jason.karns@gmail.com> (http://jasonkarns.com/)",
+    "Mike Bland <mbland@acm.org> (https://mike-bland.com/)"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bats-core/bats-core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/bats-core/bats-core/issues"
+  },
+  "files": [
+    "bin", "libexec", "man"
+  ],
+  "directories": {
+    "bin": "bin",
+    "doc": "docs",
+    "man": "man",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "bin/bats test"
+  },
+  "keywords": [
+    "bats",
+    "bash",
+    "shell",
+    "test",
+    "unit"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bats",
-  "version": "0.4.0",
+  "version": "1.0.1",
   "description": "Bash Automated Testing System",
   "homepage": "https://github.com/bats-core/bats-core#readme",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,13 +5,8 @@
   "homepage": "https://github.com/bats-core/bats-core#readme",
   "license": "MIT",
   "author": "Sam Stephenson <sstephenson@gmail.com> (http://sstephenson.us/)",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/bats-core/bats-core.git"
-  },
-  "bugs": {
-    "url": "https://github.com/bats-core/bats-core/issues"
-  },
+  "repository": "github:bats-core/bats-core",
+  "bugs": "https://github.com/bats-core/bats-core/issues",
   "files": [
     "bin",
     "libexec",


### PR DESCRIPTION
Updates to package.json for publishing to npm.

- [ ] author/contributor details good?
- [ ] compatibility with bpkg https://github.com/bpkg/bpkg/issues/17
- [ ] keywords?

The referenced issue from bpkg indicates that they intend to move off of package.json, or otherwise find a way to make bpkg's use compatible with npm. Per that issue, I don't know if that has happened or not. But as this PR stands at present, I _believe_ it will break compatibility with bpkg due to the conflicting semantics of `scripts`.

For now, my intention is to first get the metadata correct (authorship info, keywords, etc) and publish the currently tagged versions to the npm registry. This can occur without having the package.json merged to master, so we don't necessarily have to resolve the bpkg compatibility issue _immediately_.

- [ ] I have reviewed the [Contributor Guidelines][contributor].
- [ ] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
