### PR TITLE
Fix multiple error trap firing weirdness (Bash 4.2)

### DIFF
--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -245,7 +245,9 @@ bats_error_trap() {
 }
 
 bats_teardown_trap() {
-  bats_error_trap
+  if [ "${BATS_ERROR_STATUS:-?}" = "?" ]; then
+    bats_error_trap
+  fi
   local status=0
   teardown >>"$BATS_OUT" 2>&1 || status="$?"
 

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -245,9 +245,7 @@ bats_error_trap() {
 }
 
 bats_teardown_trap() {
-  if [ "${BATS_ERROR_STATUS:-?}" = "?" ]; then
-    bats_error_trap
-  fi
+  bats_error_trap
   local status=0
   teardown >>"$BATS_OUT" 2>&1 || status="$?"
 

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -235,7 +235,7 @@ bats_debug_trap() {
 bats_error_trap() {
   local status="$?"
   if [[ -z "$BATS_TEST_COMPLETED" ]]; then
-    BATS_ERROR_STATUS="$status"
+    BATS_ERROR_STATUS="${BATS_ERROR_STATUS:-$status}"
     if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
       BATS_ERROR_STATUS=1
     fi
@@ -330,6 +330,7 @@ bats_perform_test() {
 
     BATS_TEST_COMPLETED=""
     BATS_TEARDOWN_COMPLETED=""
+    BATS_ERROR_STATUS=""
     trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
     trap "bats_error_trap" err
     trap "bats_teardown_trap" exit

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -111,7 +111,6 @@ fixtures bats
 @test "failing test with significant status" {
   STATUS=2 run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
-  echo "$output"
   [ "${lines[3]}" = "#   \`eval \"( exit \${STATUS:-1} )\"' failed with status 2" ]
 }
 

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -111,6 +111,7 @@ fixtures bats
 @test "failing test with significant status" {
   STATUS=2 run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
+  echo "$output"
   [ "${lines[3]}" = "#   \`eval \"( exit \${STATUS:-1} )\"' failed with status 2" ]
 }
 


### PR DESCRIPTION
On Bash 4.2, when bats_error_trap fires multiple times, a non-zero
return code gets "lost", causing the "failure with significant status"
test to fail.  This correction allows that test to pass by only having
the error trap run inside the teardown trap if BATS_ERROR_STATUS is not
set.

Tested on Bash 4.2.46(2)-release and 4.3.33(1)-release.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
