### PR TITLE
Fix BATS_ROOT resolution when /bin => /usr/bin

### DIFF
--- a/bin/bats
+++ b/bin/bats
@@ -38,8 +38,7 @@ bats_resolve_absolute_root_dir() {
       path="$(bats_resolve_link "$target_name")"
     else
       printf -v "$result" -- '%s' "${PWD%/*}"
-      set +P
-      set "-$original_shell_options"
+      set +P "-$original_shell_options"
       cd "$cwd"
       return
     fi

--- a/bin/bats
+++ b/bin/bats
@@ -9,8 +9,6 @@ elif command -v 'readlink' >/dev/null; then
   BATS_READLINK='readlink'
 fi
 
-BATS_MAX_SYMLINKS="${BATS_MAX_SYMLINKS:-16}"
-
 bats_resolve_link() {
   if ! "$BATS_READLINK" "$1"; then
     return 0
@@ -23,9 +21,8 @@ bats_resolve_absolute_root_dir() {
   local result="$2"
   local target_dir
   local target_name
-  local limit="$BATS_MAX_SYMLINKS"
 
-  while [[ "$limit" -ne -1 ]]; do
+  while true; do
     target_dir="${path%/*}"
     target_name="${path##*/}"
 
@@ -34,7 +31,7 @@ bats_resolve_absolute_root_dir() {
     fi
 
     # Resolve the parent directory, e.g. /bin => /usr/bin on CentOS (#113).
-    while [[ -L "$PWD" && "$((--limit))" -ne -1 ]]; do
+    while [[ -L "$PWD" ]]; do
       target_dir="$(bats_resolve_link "$PWD")"
       if [[ "${target_dir:0:1}" != '/' ]]; then
         target_dir="$PWD/../$target_dir"
@@ -42,20 +39,14 @@ bats_resolve_absolute_root_dir() {
       cd "$target_dir"
     done
 
-    if [[ "$limit" -eq -1 ]]; then
-      break
-    elif [[ ! -L "$target_name" ]]; then
+    if [[ -L "$target_name" ]]; then
+      path="$(bats_resolve_link "$target_name")"
+    else
       printf -v "$result" -- '%s' "${PWD%/*}"
       cd "$cwd"
       return
-    elif [[ "$((--limit))" -ne -1 ]]; then
-      path="$(bats_resolve_link "$target_name")"
     fi
   done
-
-  printf '%s failed to resolve after following %d symlink(s)\n' \
-    "$0" "$BATS_MAX_SYMLINKS" >&2
-  return 1
 }
 
 export BATS_ROOT

--- a/bin/bats
+++ b/bin/bats
@@ -21,8 +21,8 @@ bats_resolve_absolute_root_dir() {
   local cwd="$PWD"
   local path="$1"
   local result="$2"
-  local target_dir="${path%/*}"
-  local target_name="${path##*/}"
+  local target_dir
+  local target_name
   local limit="$BATS_MAX_SYMLINKS"
 
   while [[ "$limit" -ne -1 ]]; do
@@ -42,7 +42,9 @@ bats_resolve_absolute_root_dir() {
       cd "$target_dir"
     done
 
-    if [[ ! -L "$target_name" ]]; then
+    if [[ "$limit" -eq -1 ]]; then
+      break
+    elif [[ ! -L "$target_name" ]]; then
       printf -v "$result" -- '%s' "${PWD%/*}"
       cd "$cwd"
       return

--- a/bin/bats
+++ b/bin/bats
@@ -9,27 +9,53 @@ elif command -v 'readlink' >/dev/null; then
   BATS_READLINK='readlink'
 fi
 
+BATS_MAX_SYMLINKS="${BATS_MAX_SYMLINKS:-16}"
+
 bats_resolve_link() {
   if ! "$BATS_READLINK" "$1"; then
     return 0
   fi
 }
 
-bats_absolute_path() {
+bats_resolve_absolute_root_dir() {
   local cwd="$PWD"
   local path="$1"
   local result="$2"
+  local target_dir="${path%/*}"
+  local target_name="${path##*/}"
+  local limit="$BATS_MAX_SYMLINKS"
 
-  while [[ -n "$path" ]]; do
-    cd "${path%/*}"
-    path="$(bats_resolve_link "${path##*/}")"
+  while [[ "$limit" -ne -1 ]]; do
+    target_dir="${path%/*}"
+    target_name="${path##*/}"
+
+    if [[ "$target_dir" != "$path" ]]; then
+      cd "$target_dir"
+    fi
+
+    # Resolve the parent directory, e.g. /bin => /usr/bin on CentOS (#113).
+    while [[ -L "$PWD" && "$((--limit))" -ne -1 ]]; do
+      target_dir="$(bats_resolve_link "$PWD")"
+      if [[ "${target_dir:0:1}" != '/' ]]; then
+        target_dir="$PWD/../$target_dir"
+      fi
+      cd "$target_dir"
+    done
+
+    if [[ ! -L "$target_name" ]]; then
+      printf -v "$result" -- '%s' "${PWD%/*}"
+      cd "$cwd"
+      return
+    elif [[ "$((--limit))" -ne -1 ]]; then
+      path="$(bats_resolve_link "$target_name")"
+    fi
   done
 
-  printf -v "$result" -- '%s' "$PWD"
-  cd "$cwd"
+  printf '%s failed to resolve after following %d symlink(s)\n' \
+    "$0" "$BATS_MAX_SYMLINKS" >&2
+  return 1
 }
 
 export BATS_ROOT
-bats_absolute_path "$0" 'BATS_ROOT'
-BATS_ROOT="${BATS_ROOT%/*}"
+bats_resolve_absolute_root_dir "$0" 'BATS_ROOT'
 exec "$BATS_ROOT/libexec/bats-core/bats" "$@"

--- a/bin/bats
+++ b/bin/bats
@@ -23,6 +23,7 @@ bats_resolve_absolute_root_dir() {
   local target_name
   local original_shell_options="$-"
 
+  # Resolve the parent directory, e.g. /bin => /usr/bin on CentOS (#113).
   set -P
 
   while true; do

--- a/bin/bats
+++ b/bin/bats
@@ -21,6 +21,9 @@ bats_resolve_absolute_root_dir() {
   local result="$2"
   local target_dir
   local target_name
+  local original_shell_options="$-"
+
+  set -P
 
   while true; do
     target_dir="${path%/*}"
@@ -30,19 +33,12 @@ bats_resolve_absolute_root_dir() {
       cd "$target_dir"
     fi
 
-    # Resolve the parent directory, e.g. /bin => /usr/bin on CentOS (#113).
-    while [[ -L "$PWD" ]]; do
-      target_dir="$(bats_resolve_link "$PWD")"
-      if [[ "${target_dir:0:1}" != '/' ]]; then
-        target_dir="$PWD/../$target_dir"
-      fi
-      cd "$target_dir"
-    done
-
     if [[ -L "$target_name" ]]; then
       path="$(bats_resolve_link "$target_name")"
     else
       printf -v "$result" -- '%s' "${PWD%/*}"
+      set +P
+      set "-$original_shell_options"
       cd "$cwd"
       return
     fi

--- a/test/install.bats
+++ b/test/install.bats
@@ -54,8 +54,8 @@ setup() {
   # Simulate a symlink to bin/bats (without using a symlink, for Windows sake)
   # by creating a wrapper script that executes bin/bats via a relative path.
   #
-  # The real test is in the .travis.yml script using the Dockerfile, which uses
-  # a real symbolic link.
+  # root.bats contains tests that use real symlinks on platforms that support
+  # them, as does the .travis.yml script that exercises the Dockerfile.
   local bats_symlink="$INSTALL_DIR/bin/bats-link"
   printf '%s\n' '#! /usr/bin/env bash' \
     "cd '$INSTALL_DIR/bin'" \

--- a/test/root.bats
+++ b/test/root.bats
@@ -63,7 +63,6 @@ setup() {
     "$BATS_TEST_SUITE_TMPDIR/usr/bin"
 
   BATS_MAX_SYMLINKS=1 run "$BATS_TEST_SUITE_TMPDIR/bin/bats" -v
-  emit_debug_output
   [ "$status" -eq 1 ]
 
   local expected="$BATS_TEST_SUITE_TMPDIR/bin/bats failed to resolve "

--- a/test/root.bats
+++ b/test/root.bats
@@ -38,38 +38,6 @@ setup() {
   [ "${output%% *}" == 'Bats' ]
 }
 
-@test "short-circuit symlink resolution via BATS_MAX_SYMLINKS" {
-  BATS_MAX_SYMLINKS=1 run "$BATS_TEST_SUITE_TMPDIR/bin/bats" -v
-  [ "$status" -eq 1 ]
-
-  local expected="$BATS_TEST_SUITE_TMPDIR/bin/bats failed to resolve "
-  expected+="after following 1 symlink(s)"
-  [ "$output" == "$expected" ]
-}
-
-@test "find BATS_ROOT without symlinks" {
-  BATS_MAX_SYMLINKS=0 run "$BATS_TEST_SUITE_TMPDIR/opt/bats-core/bin/bats" -v
-  [ "$status" -eq 0 ]
-  [ "${output%% *}" == 'Bats' ]
-}
-
-# The resolution scheme here is:
-#
-# - /bin => /usr/bin
-# - /usr/bin => /opt/bats-core/bin
-@test "parent directories exhaust BATS_MAX_SYMLINKS" {
-  rm -rf "$BATS_TEST_SUITE_TMPDIR/usr/bin"
-  ln -s "$BATS_TEST_SUITE_TMPDIR/opt/bats-core/bin" \
-    "$BATS_TEST_SUITE_TMPDIR/usr/bin"
-
-  BATS_MAX_SYMLINKS=1 run "$BATS_TEST_SUITE_TMPDIR/bin/bats" -v
-  [ "$status" -eq 1 ]
-
-  local expected="$BATS_TEST_SUITE_TMPDIR/bin/bats failed to resolve "
-  expected+="after following 1 symlink(s)"
-  [ "$output" == "$expected" ]
-}
-
 # The resolution scheme here is:
 #
 # - /bin => /usr/bin (relative directory)
@@ -93,7 +61,7 @@ setup() {
   ln -s bats opt/bats-core/bin/baz
 
   cd - >/dev/null
-  BATS_MAX_SYMLINKS=8 run "$BATS_TEST_SUITE_TMPDIR/bin/foo" -v
+  run "$BATS_TEST_SUITE_TMPDIR/bin/foo" -v
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
 }

--- a/test/root.bats
+++ b/test/root.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+#
+# This suite is dedicated to calculating BATS_ROOT when going through various
+# permutations of symlinks. It was inspired by the report in issue #113 that the
+# calculation was broken on CentOS, where /bin is symlinked to /usr/bin.
+#
+# The basic test environment is (all paths relative to BATS_TEST_SUITE_TMPDIR):
+#
+# - /bin is a relative symlink to /usr/bin, exercising the symlink resolution of
+#   the `bats` parent directory (i.e. "${0%/*}")
+# - /usr/bin/bats is an absolute symlink to /opt/bats-core/bin/bats, exercising
+#   the symlink resolution of the `bats` executable itself (i.e. "${0##*/}")
+
+load test_helper
+
+# This would make a good candidate for a one-time setup/teardown per #39.
+setup() {
+  make_bats_test_suite_tmpdir
+  cd "$BATS_TEST_SUITE_TMPDIR"
+  mkdir -p {usr/bin,opt/bats-core}
+  "$BATS_ROOT/install.sh" "opt/bats-core"
+
+  ln -s "usr/bin" "bin"
+
+  if [[ ! -L "bin" ]]; then
+    cd - >/dev/null
+    skip "symbolic links aren't functional on OSTYPE=$OSTYPE"
+  fi
+
+  ln -s "$BATS_TEST_SUITE_TMPDIR/opt/bats-core/bin/bats" \
+    "$BATS_TEST_SUITE_TMPDIR/usr/bin/bats"
+  cd - >/dev/null
+}
+
+@test "#113: set BATS_ROOT when /bin is a symlink to /usr/bin" {
+  run "$BATS_TEST_SUITE_TMPDIR/bin/bats" -v
+  [ "$status" -eq 0 ]
+  [ "${output%% *}" == 'Bats' ]
+}
+
+@test "short-circuit symlink resolution via BATS_MAX_SYMLINKS" {
+  BATS_MAX_SYMLINKS=1 run "$BATS_TEST_SUITE_TMPDIR/bin/bats" -v
+  [ "$status" -eq 1 ]
+
+  local expected="$BATS_TEST_SUITE_TMPDIR/bin/bats failed to resolve "
+  expected+="after following 1 symlink(s)"
+  [ "$output" == "$expected" ]
+}
+
+# The resolution scheme here is:
+#
+# - /bin => /usr/bin (relative directory)
+# - /usr/bin/foo => /usr/bin/bar (relative executable)
+# - /usr/bin/bar => /opt/bats/bin0/bar (absolute executable)
+# - /opt/bats/bin0 => /opt/bats/bin1 (relative directory)
+# - /opt/bats/bin1 => /opt/bats/bin2 (absolute directory)
+# - /opt/bats/bin2/bar => /opt/bats-core/bin/bar (absolute executable)
+# - /opt/bats-core/bin/bar => /opt/bats-core/bin/baz (relative executable)
+# - /opt/bats-core/bin/baz => /opt/bats-core/bin/bats (relative executable)
+@test "set BATS_ROOT with extreme symlink resolution" {
+  cd "$BATS_TEST_SUITE_TMPDIR"
+  mkdir -p "opt/bats/bin2"
+
+  ln -s bar usr/bin/foo
+  ln -s "$BATS_TEST_SUITE_TMPDIR/opt/bats/bin0/bar" usr/bin/bar
+  ln -s bin1 opt/bats/bin0
+  ln -s "$BATS_TEST_SUITE_TMPDIR/opt/bats/bin2" opt/bats/bin1
+  ln -s "$BATS_TEST_SUITE_TMPDIR/opt/bats-core/bin/bar" opt/bats/bin2/bar
+  ln -s baz opt/bats-core/bin/bar
+  ln -s bats opt/bats-core/bin/baz
+
+  cd - >/dev/null
+  run "$BATS_TEST_SUITE_TMPDIR/bin/foo" -v
+  [ "$status" -eq 0 ]
+  [ "${output%% *}" == 'Bats' ]
+}

--- a/test/root.bats
+++ b/test/root.bats
@@ -47,6 +47,30 @@ setup() {
   [ "$output" == "$expected" ]
 }
 
+@test "find BATS_ROOT without symlinks" {
+  BATS_MAX_SYMLINKS=0 run "$BATS_TEST_SUITE_TMPDIR/opt/bats-core/bin/bats" -v
+  [ "$status" -eq 0 ]
+  [ "${output%% *}" == 'Bats' ]
+}
+
+# The resolution scheme here is:
+#
+# - /bin => /usr/bin
+# - /usr/bin => /opt/bats-core/bin
+@test "parent directories exhaust BATS_MAX_SYMLINKS" {
+  rm -rf "$BATS_TEST_SUITE_TMPDIR/usr/bin"
+  ln -s "$BATS_TEST_SUITE_TMPDIR/opt/bats-core/bin" \
+    "$BATS_TEST_SUITE_TMPDIR/usr/bin"
+
+  BATS_MAX_SYMLINKS=1 run "$BATS_TEST_SUITE_TMPDIR/bin/bats" -v
+  emit_debug_output
+  [ "$status" -eq 1 ]
+
+  local expected="$BATS_TEST_SUITE_TMPDIR/bin/bats failed to resolve "
+  expected+="after following 1 symlink(s)"
+  [ "$output" == "$expected" ]
+}
+
 # The resolution scheme here is:
 #
 # - /bin => /usr/bin (relative directory)
@@ -70,7 +94,7 @@ setup() {
   ln -s bats opt/bats-core/bin/baz
 
   cd - >/dev/null
-  run "$BATS_TEST_SUITE_TMPDIR/bin/foo" -v
+  BATS_MAX_SYMLINKS=8 run "$BATS_TEST_SUITE_TMPDIR/bin/foo" -v
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -4,7 +4,7 @@ fixtures() {
 }
 
 make_bats_test_suite_tmpdir() {
-  export BATS_TEST_SUITE_TMPDIR="$BATS_TMPDIR/tmp"
+  export BATS_TEST_SUITE_TMPDIR="$BATS_TMPDIR/bats-test-tmp"
   mkdir -p "$BATS_TEST_SUITE_TMPDIR"
 }
 


### PR DESCRIPTION
Closes #113. This should be robust enough to handle the /bin => /usr/bin symlink on CentOS7 as originally reported, as well as any manner of symlink chains leading to the `bin/bats` executable in the installation directory. Maintains portability between `readlink` implementations by not relying on the GNU-specific `-e` option.

There's no perceptible performance impact.

This renames the original `bats_absolute_path` function to the more obvious `bats_resolve_absolute_root_dir`, and introduces the `BATS_MAX_SYMLINKS` variable to ensure symlink resolution short-circuits in case cycles appear. While this can be user-controlled, I've not documented it in the README, hoping that no one will need to change the setting in a real-world situation.

Also tweaks the value of `BATS_TEST_SUITE_TMPDIR` from `tmp` to `bats-test-tmp` to avoid potential collisions with other `BATS_TMPDIR` directories.

cc: @rgm3

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
