### PR TITLE
Cover more Bash versions with Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,12 @@ services:
   - docker
 
 script:
-- bash -c 'time bin/bats --tap test'
 - |
   if [[ "$TRAVIS_OS_NAME" == 'linux' ]]; then
     docker build --build-arg bashver=${BASHVER} --tag bats/bats:bash-${BASHVER} .
-    docker run -it bats/bats:bash-${BASHVER} --tap /opt/bats/test
+    time docker run -it bats/bats:bash-${BASHVER} --tap /opt/bats/test
+  else
+    bash -c 'time bin/bats --tap test'
   fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ script:
 - bash -c 'time bin/bats --tap test'
 - |
   if [[ "$TRAVIS_OS_NAME" == 'linux' ]]; then
-    docker build --tag bats:latest .
-    docker run -it bats:latest --tap /opt/bats/test
+    for bashver in 3.2 4.0 4.1 4.2 4.3 4.4
+    do
+      docker build --build-arg bashver=${bashver} --tag bats:bash${bashver} .
+      docker run -it bats:bash${bashver} --tap /opt/bats/test
+    done
   fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ script:
   if [[ "$TRAVIS_OS_NAME" == 'linux' ]]; then
     for bashver in 3.2 4.0 4.1 4.2 4.3 4.4
     do
-      docker build --build-arg bashver=${bashver} --tag bats:bash${bashver} .
-      docker run -it bats:bash${bashver} --tap /opt/bats/test
+      docker build --build-arg bashver=${bashver} --tag bats/bats:bash-${bashver} .
+      docker run -it bats/bats:bash-${bashver} --tap /opt/bats/test
     done
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,14 @@ script:
 - bash -c 'time bin/bats --tap test'
 - |
   if [[ "$TRAVIS_OS_NAME" == 'linux' ]]; then
+    RC=0
     for bashver in 3.2 4.0 4.1 4.2 4.3 4.4
     do
       docker build --build-arg bashver=${bashver} --tag bats/bats:bash-${bashver} .
-      docker run -it bats/bats:bash-${bashver} --tap /opt/bats/test
+      docker run -it bats/bats:bash-${bashver} --tap /opt/bats/test || RC=1
     done
   fi
+  [ ${RC} -eq 0 ]
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ script:
       docker build --build-arg bashver=${bashver} --tag bats/bats:bash-${bashver} .
       docker run -it bats/bats:bash-${bashver} --tap /opt/bats/test || RC=1
     done
+    [ ${RC} -eq 0 ]
   fi
-  [ ${RC} -eq 0 ]
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
 - |
   if [[ "$TRAVIS_OS_NAME" == 'linux' ]]; then
     docker build --build-arg bashver=${BASHVER} --tag bats/bats:bash-${BASHVER} .
+    docker run -it bash:${BASHVER} --version
     time docker run -it bats/bats:bash-${BASHVER} --tap /opt/bats/test
   else
     bash -c 'time bin/bats --tap test'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ ARG bashver=latest
 
 FROM bash:${bashver}
 
-RUN bash --version
 RUN ln -s /opt/bats/bin/bats /usr/sbin/bats
 
 COPY . /opt/bats/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG bashver
+ARG bashver=latest
 
-FROM bash:$bashver
+FROM bash:${bashver}
 
 RUN ln -s /opt/bats/bin/bats /usr/sbin/bats
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG bashver=latest
 
 FROM bash:${bashver}
 
+RUN bash --version
 RUN ln -s /opt/bats/bin/bats /usr/sbin/bats
 
 COPY . /opt/bats/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM alpine:3.6
+ARG bashver
 
-RUN apk --no-cache add bash \
-    && ln -s /opt/bats/bin/bats /usr/sbin/bats
+FROM bash:$bashver
+
+RUN ln -s /opt/bats/bin/bats /usr/sbin/bats
 
 COPY . /opt/bats/
 
-ENTRYPOINT ["bats"]
+ENTRYPOINT ["bash", "/usr/sbin/bats"]


### PR DESCRIPTION
Revised the Dockerfile to use the official Bash images for improved
version-specific test coverage.  These images are based on Alpine.  Given that
we're only trying to support 3.2.57 and up (because OSX), coverage has been
set to only go that far back (though there are older versions available in
Docker image form if we would like to use them).

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
