### PR TITLE
travis: Enable build with default Linux image Bash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
 - linux
 
 env:
+  - BASHVER=
   - BASHVER=3.2
   - BASHVER=4.0
   - BASHVER=4.1
@@ -20,7 +21,7 @@ services:
 
 script:
 - |
-  if [[ "$TRAVIS_OS_NAME" == 'linux' ]]; then
+  if [[ "$TRAVIS_OS_NAME" == 'linux' && -n "$BASHVER" ]]; then
     docker build --build-arg bashver=${BASHVER} --tag bats/bats:bash-${BASHVER} .
     docker run -it bash:${BASHVER} --version
     time docker run -it bats/bats:bash-${BASHVER} --tap /opt/bats/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
     docker run -it bash:${BASHVER} --version
     time docker run -it bats/bats:bash-${BASHVER} --tap /opt/bats/test
   else
-    bash -c 'time bin/bats --tap test'
+    time bin/bats --tap test
   fi
 
 notifications:


### PR DESCRIPTION
Since I'm paranoid that we might need to resolve an issue specific to 4.3.11(1)-release (or whatever the Bash version is in the stock Travis Linux image). Also, I didn't want to hold up #116 any longer with more tiny requests.

cc: @cdevinesr

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
