### PR TITLE
 Add support for global helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ supports:
 
 ```
 Bats x.y.z
-Usage: bats [-c] [-r] [-p | -t] <test> [<test> ...]
+Usage: bats [-c] [-r] [-p | -t] [--global-helper=script_name] <test> [<test> ...]
 
   <test> is the path to a Bats test file, or the path to a directory
   containing Bats test files.
@@ -191,6 +191,8 @@ Usage: bats [-c] [-r] [-p | -t] <test> [<test> ...]
   -r, --recursive  Include tests in subdirectories
   -t, --tap        Show results in TAP format
   -v, --version    Display the version number
+  --global-helper  Load a global test helper script before each test file
+                   is processed
 ```
 
 To run your tests, invoke the `bats` interpreter with one or more paths to test
@@ -283,6 +285,18 @@ load test_helper
 
 will source the script `test/test_helper.bash` in your test file. This can be
 useful for sharing functions to set up your environment or load fixtures.
+
+If you have a lot of test files that will share the same test helper script,
+you can tell bats to load the helper script prior to each supplied test by
+using the `--global-helper` command line argument.
+
+You can also make use of this functionality by exporting
+`BATS_GLOBAL_HELPER_SCRIPT` with the desired value.
+
+Note: --global-helper takes arguments the same way `load` would, so if you
+run `bats test/suite/subtests`, and your global helper is
+`test/suite/subtests/test\_helper.bash`, you'd use
+`--global-helper=test_helper`.  You can also use absolute paths, if desired.
 
 ### `skip`: Easily skip tests
 
@@ -407,6 +421,8 @@ some detailed guidelines to refer to:
 
 There are several global variables you can use to introspect on Bats tests:
 
+* `$BATS_GLOBAL_HELPER_SCRIPT` is the test helper script that will get loaded
+  prior to processing each test file.
 * `$BATS_TEST_FILENAME` is the fully expanded path to the Bats test file.
 * `$BATS_TEST_DIRNAME` is the directory in which the Bats test file is located.
 * `$BATS_TEST_NAMES` is an array of function names for each test case.

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -7,7 +7,7 @@ version() {
 
 usage() {
   version
-  printf "Usage: bats [-c] [-r] [-p | -t] <test> [<test> ...]\n"
+  printf "Usage: bats [-c] [-r] [-p | -t] [--global-helper=script_name] <test> [<test> ...]\n"
 }
 
 abort() {
@@ -28,6 +28,8 @@ help() {
   echo "  -r, --recursive  Include tests in subdirectories"
   echo "  -t, --tap        Show results in TAP format"
   echo "  -v, --version    Display the version number"
+  echo "  --global-helper  Load a global test helper script before each test file"
+  echo "                   is processed"
   echo
   echo "  For more information, see https://github.com/bats-core/bats-core"
   echo
@@ -57,7 +59,17 @@ arguments=()
 for arg in "$@"; do
   if [[ "${arg:0:1}" = "-" ]]; then
     if [[ "${arg:1:1}" = "-" ]]; then
-      options[${#options[*]}]="${arg:2}"
+      if [ "$(expr "${arg:2}" : "global-helper=.*$")" -ne 0 ]; then
+        BATS_GLOBAL_HELPER_SCRIPT="${arg##*=}"
+
+        if [ -z "${BATS_GLOBAL_HELPER_SCRIPT}" ]; then
+          abort "You must supply a script with --global-helper"
+        else
+          export BATS_GLOBAL_HELPER_SCRIPT
+        fi
+      else
+        options[${#options[*]}]="${arg:2}"
+      fi
     else
       index=1
       while option="${arg:$index:1}"; do

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -52,6 +52,7 @@ expand_path() {
 
 export BATS_CWD="$PWD"
 export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
+export BATS_GLOBAL_HELPER_SCRIPT=""
 export PATH="$BATS_ROOT/libexec/bats-core:$PATH"
 
 options=()
@@ -59,13 +60,11 @@ arguments=()
 for arg in "$@"; do
   if [[ "${arg:0:1}" = "-" ]]; then
     if [[ "${arg:1:1}" = "-" ]]; then
-      if [ "$(expr "${arg:2}" : "global-helper=.*$")" -ne 0 ]; then
+      if [[ "${arg:2}" =~ ^global-helper=.*$ ]]; then
         BATS_GLOBAL_HELPER_SCRIPT="${arg##*=}"
 
-        if [ -z "${BATS_GLOBAL_HELPER_SCRIPT}" ]; then
+        if [[ -z "${BATS_GLOBAL_HELPER_SCRIPT}" ]]; then
           abort "You must supply a script with --global-helper"
-        else
-          export BATS_GLOBAL_HELPER_SCRIPT
         fi
       else
         options[${#options[*]}]="${arg:2}"

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -400,6 +400,12 @@ bats_evaluate_preprocessed_source() {
   source "$BATS_TEST_SOURCE"
 }
 
+bats_load_global_helper() {
+  if [[ -n "${BATS_GLOBAL_HELPER_SCRIPT:-}" ]]; then
+    load "${BATS_GLOBAL_HELPER_SCRIPT}"
+  fi
+}
+
 exec 3<&1
 
 if [[ "$#" -eq 0 ]]; then
@@ -413,5 +419,6 @@ if [[ "$#" -eq 0 ]]; then
   fi
 else
   bats_evaluate_preprocessed_source
+  bats_load_global_helper
   bats_perform_test "$@"
 fi

--- a/man/bats.1
+++ b/man/bats.1
@@ -56,6 +56,10 @@ Show results in TAP format
 \fB\-v\fR, \fB\-\-version\fR
 Display the version number
 .
+.TP
+\fB\--global-helper\fR
+Load a global test helper script before each test file is processed
+.
 .SH "OUTPUT"
 When you run Bats from a terminal, you\'ll see output as each test is performed, with a check\-mark next to the test\'s name if it passes or an "X" if it fails\.
 .

--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -58,6 +58,8 @@ OPTIONS
     Show results in TAP format
   * `-v`, `--version`:
     Display the version number
+  * `--global-helper`:
+    Load a global test helper script before each test file is processed
 
 
 OUTPUT

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -36,6 +36,12 @@ fixtures bats
   [ $(expr "$output" : ".*does not exist") -ne 0 ]
 }
 
+@test "missing script for --global-helper prints error and usage instructions" {
+  run bats --global-helper=
+  [ $status -eq 1 ]
+  [ $(expr "$output" : ".*You must supply a script with --global-helper.*") -ne 0 ]
+}
+
 @test "empty test file runs zero tests" {
   run bats "$FIXTURE_ROOT/empty.bats"
   [ $status -eq 0 ]

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -39,7 +39,9 @@ fixtures bats
 @test "missing script for --global-helper prints error and usage instructions" {
   run bats --global-helper=
   [ $status -eq 1 ]
-  [ $(expr "$output" : ".*You must supply a script with --global-helper.*") -ne 0 ]
+  emit_debug_output
+  [ "${lines[0]}" = "Error: You must supply a script with --global-helper" ]
+  [ "${lines[2]%% *}" == 'Usage:' ]
 }
 
 @test "empty test file runs zero tests" {

--- a/test/fixtures/suite/global-helper/01_test_one.bats
+++ b/test/fixtures/suite/global-helper/01_test_one.bats
@@ -1,3 +1,3 @@
 @test "test one" {
-  [ "$(tail -1 /tmp/ghtestfile)" == "GH Test: test one" ]
+  [ "$(< ${BATS_TEST_SUITE_TMPDIR}/ghtestfile)" == "GH Test: test one" ]
 }

--- a/test/fixtures/suite/global-helper/01_test_one.bats
+++ b/test/fixtures/suite/global-helper/01_test_one.bats
@@ -1,0 +1,3 @@
+@test "test one" {
+  [ "$(tail -1 /tmp/ghtestfile)" == "GH Test: test one" ]
+}

--- a/test/fixtures/suite/global-helper/02_test_two.bats
+++ b/test/fixtures/suite/global-helper/02_test_two.bats
@@ -1,3 +1,3 @@
 @test "test two" {
-  [ "$(tail -1 /tmp/ghtestfile)" == "GH Test: test two" ]
+  [ "$(< ${BATS_TEST_SUITE_TMPDIR}/ghtestfile)" == "GH Test: test two" ]
 }

--- a/test/fixtures/suite/global-helper/02_test_two.bats
+++ b/test/fixtures/suite/global-helper/02_test_two.bats
@@ -1,0 +1,3 @@
+@test "test two" {
+  [ "$(tail -1 /tmp/ghtestfile)" == "GH Test: test two" ]
+}

--- a/test/fixtures/suite/global-helper/03_test_three.bats
+++ b/test/fixtures/suite/global-helper/03_test_three.bats
@@ -1,3 +1,3 @@
 @test "test three" {
-  [ "$(tail -1 /tmp/ghtestfile)" == "GH Test: test three" ]
+  [ "$(< ${BATS_TEST_SUITE_TMPDIR}/ghtestfile)" == "GH Test: test three" ]
 }

--- a/test/fixtures/suite/global-helper/03_test_three.bats
+++ b/test/fixtures/suite/global-helper/03_test_three.bats
@@ -1,0 +1,3 @@
+@test "test three" {
+  [ "$(tail -1 /tmp/ghtestfile)" == "GH Test: test three" ]
+}

--- a/test/fixtures/suite/global-helper/gh_test_helper.bash
+++ b/test/fixtures/suite/global-helper/gh_test_helper.bash
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 setup() {
-  echo "GH Test: ${BATS_TEST_DESCRIPTION}" > /tmp/ghtestfile
+  echo "GH Test: ${BATS_TEST_DESCRIPTION}" > ${BATS_TEST_SUITE_TMPDIR}/ghtestfile
 }
 
 teardown() {
-  rm -f /tmp/ghtestfile
+  rm -f ${BATS_TEST_SUITE_TMPDIR}/ghtestfile
 }

--- a/test/fixtures/suite/global-helper/gh_test_helper.bash
+++ b/test/fixtures/suite/global-helper/gh_test_helper.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+setup() {
+  echo "GH Test: ${BATS_TEST_DESCRIPTION}" > /tmp/ghtestfile
+}
+
+teardown() {
+  rm -f /tmp/ghtestfile
+}

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -78,3 +78,12 @@ fixtures suite
   [ "${lines[1]}" = "ok 1 another passing test" ]
   [ "${lines[2]}" = "ok 2 a passing test" ]
 }
+
+@test "global helper script" {
+  run bats --global-helper=gh_test_helper "${FIXTURE_ROOT}/global-helper"
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..3" ]
+  [ "${lines[1]}" = "ok 1 test one" ]
+  [ "${lines[2]}" = "ok 2 test two" ]
+  [ "${lines[3]}" = "ok 3 test three" ]
+}

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -80,6 +80,7 @@ fixtures suite
 }
 
 @test "global helper script" {
+  make_bats_test_suite_tmpdir
   run bats --global-helper=gh_test_helper "${FIXTURE_ROOT}/global-helper"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..3" ]


### PR DESCRIPTION
Addresses sstephenson/bats#255

This feature takes the same type of arguments 'load' would.  It
can be used at the command line with `--global-helper=helper_script`,
or via environment variable by exporting `BATS_GLOBAL_HELPER_SCRIPT`.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
