### PR TITLE
bats: Replace echo with printf

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,6 +50,7 @@ CONTRIBUTING.md file][atom].
       * [Command substitution](#command-substitution)
       * [Process substitution](#process-substitution)
       * [Conditionals and loops](#conditionals-and-loops)
+      * [Generating output](#generating-output)
       * [Gotchas](#gotchas)
   * [Open Source License](#open-source-license)
   * [Credits](#credits)
@@ -259,22 +260,10 @@ The following are intended to prevent too-compact code:
 
 ### Variable and parameter declarations
 
-- Declare all constants near the top of the file using `declare -r`.
-  - Exception: `declare` is not available in test files run using `bats`.
-  - Exception: In module code (i.e. code imported via `. "$_GO_USE_MODULES"`),
-    use `readonly` instead. Otherwise if a module is imported into a function,
-    variables declared with `declare` will go out of scope after the first
-    function call, and will not be redefined for subsequent calls, causing
-    errors.
-- Avoid globals; but if you must, declare all globals near the top of the file,
-  outside of any function, using `declare`.
-  - Exception: `declare` is not available in test files run using `bats`.
-  - _Gotcha:_ Never initialize an array on the same line as an `export` or
-    `declare -g` statement. See [the Gotchas section](#gotchas) below for more
-    details.
+- _Gotcha:_ Never initialize an array on the same line as an `export` or
+  `declare -g` statement. See [the Gotchas section](#gotchas) below for more
+  details.
 - Declare all variables inside functions using `local`.
-  - Exception: If a function needs to set a one-time initialization flag, it
-    may declare that value using `readonly`.
 - Declare temporary file-level variables using `declare`. Use `unset` to remove
   them when finished.
 - Don't use `local -r`, as a readonly local variable in one scope can cause a
@@ -300,14 +289,30 @@ The following are intended to prevent too-compact code:
 
 ### Command substitution
 
-- Use `$()` instead of backticks.
+- If possible, don't. While this capability is one of Bash's core strengths,
+  every new process created by Bats makes the framework slower, and speed is
+  critical to encouraging the practice of automated testing. (This is especially
+  true on Windows, [where process creation is one or two orders of magnitude
+  slower][win-slow]. See [bats-core/bats-core#8][pr-8] for an illustration of
+  the difference avoiding subshells makes.) Bash is quite powerful; see if you
+  can do what you need in pure Bash first.
+- If you need to capture the output from a function, store the output using
+  `printf -v` instead if possible. `-v` specfies the name of the variable into
+  which to write the result; the caller can supply this name as a parameter.
+- If you must use command substituion, use `$()` instead of backticks, as it's
+  more robust, more searchable, and can be nested.
+
+[win-slow]: https://rufflewind.com/2014-08-23/windows-bash-slow
+[pr-8]: https://github.com/bats-core/bats-core/pull/8
 
 ### Process substitution
 
-- Use wherever possible, such as when piping input into a `while` loop (which
-  avoids having the loop body execute in a subshell) or running a command taking
-  multiple filename arguments based on output from a function or pipeline (e.g.
-  `diff`).
+- If possible, don't use it. See the advice on avoiding subprocesses and using
+  `printf -v` in the **Command substitution** section above.
+- Use wherever necessary and possible, such as when piping input into a `while`
+  loop (which avoids having the loop body execute in a subshell) or running a
+  command taking multiple filename arguments based on output from a function or
+  pipeline (e.g.  `diff`).
 - *Warning*: It is impossible to directly determine the exit status of a process
   substitution; emitting an exit status as the last line of output is a possible
   workaround.
@@ -318,6 +323,18 @@ The following are intended to prevent too-compact code:
   **Formatting**, quote variables and strings within the brackets, but not
   regular expressions (or variables containing regular expressions) appearing
   on the right side of the `=~` operator.
+
+### Generating output
+
+- Use `printf` instead of `echo`. Both are Bash builtins, and there's no
+  perceptible performance difference when running Bats under the `time` builtin.
+  However, `printf` provides a more consistent experience in general, as `echo`
+  has limitations to the arguments it accepts, and even the same version of Bash
+  may produce different results for `echo` based on how the binary was compiled.
+  See [Stack Overflow: Why is printf better than echo?][printf-vs-echo] for
+  excruciating details.
+
+[printf-vs-echo]: https://unix.stackexchange.com/a/65819
 
 ### Gotchas
 

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -2,12 +2,12 @@
 set -e
 
 version() {
-  echo "Bats 1.0.2"
+  printf 'Bats 1.0.2\n'
 }
 
 usage() {
   version
-  printf "Usage: bats [-c] [-r] [-p | -t] <test> [<test> ...]\n"
+  printf 'Usage: bats [-c] [-r] [-p | -t] <test> [<test> ...]\n'
 }
 
 abort() {
@@ -17,20 +17,25 @@ abort() {
 }
 
 help() {
+  local line
   usage
-  echo
-  echo "  <test> is the path to a Bats test file, or the path to a directory"
-  echo "  containing Bats test files."
-  echo
-  echo "  -c, --count      Count the number of test cases without running any tests"
-  echo "  -h, --help       Display this help message"
-  echo "  -p, --pretty     Show results in pretty format (default for terminals)"
-  echo "  -r, --recursive  Include tests in subdirectories"
-  echo "  -t, --tap        Show results in TAP format"
-  echo "  -v, --version    Display the version number"
-  echo
-  echo "  For more information, see https://github.com/bats-core/bats-core"
-  echo
+  while read -r line; do
+    printf '%s\n' "$line"
+  done <<END_OF_HELP_TEXT
+
+  <test> is the path to a Bats test file, or the path to a directory
+  containing Bats test files.
+
+  -c, --count      Count the number of test cases without running any tests
+  -h, --help       Display this help message
+  -p, --pretty     Show results in pretty format (default for terminals)
+  -r, --recursive  Include tests in subdirectories
+  -t, --tap        Show results in TAP format
+  -v, --version    Display the version number
+
+  For more information, see https://github.com/bats-core/bats-core
+
+END_OF_HELP_TEXT
 }
 
 expand_path() {

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -25,11 +25,11 @@ for filename in "$@"; do
 done
 
 if [[ -n "$count_only_flag" ]]; then
-  echo "$count"
+  printf '%d\n' "$count"
   exit
 fi
 
-echo "1..$count"
+printf '1..%d\n' "$count"
 status=0
 offset=0
 for filename in "$@"; do
@@ -40,19 +40,19 @@ for filename in "$@"; do
       case "$line" in
       "begin "* )
         let index+=1
-        echo "${line/ $index / $(($offset + $index)) }"
+        printf '%s\n' "${line/ $index / $(($offset + $index)) }"
         ;;
       "ok "* | "not ok "* )
         if [[ -z "$extended_syntax_flag" ]]; then
           let index+=1
         fi
-        echo "${line/ $index / $(($offset + $index)) }"
+        printf '%s\n' "${line/ $index / $(($offset + $index)) }"
         if [[ "${line:0:6}" == "not ok" ]]; then
           status=1
         fi
         ;;
       * )
-        echo "$line"
+        printf '%s\n' "$line"
         ;;
       esac
     done

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -15,10 +15,10 @@ fi
 
 BATS_TEST_FILENAME="$1"
 if [[ -z "$BATS_TEST_FILENAME" ]]; then
-  echo "usage: bats-exec-test <filename>" >&2
+  printf 'usage: bats-exec-test <filename>\n' >&2
   exit 1
 elif [[ ! -f "$BATS_TEST_FILENAME" ]]; then
-  echo "bats: $BATS_TEST_FILENAME does not exist" >&2
+  printf 'bats: %s does not exist\n' "$BATS_TEST_FILENAME" >&2
   exit 1
 else
   shift
@@ -38,7 +38,7 @@ load() {
   fi
 
   if [[ ! -f "$filename" ]]; then
-    echo "bats: $filename does not exist" >&2
+    printf 'bats: %s does not exist\n' "$filename" >&2
     exit 1
   fi
 
@@ -74,7 +74,7 @@ skip() {
 bats_test_begin() {
   BATS_TEST_DESCRIPTION="$1"
   if [[ -n "$BATS_EXTENDED_SYNTAX" ]]; then
-    echo "begin $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
+    printf 'begin %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
   fi
   setup
 }
@@ -132,21 +132,21 @@ bats_print_stack_trace() {
     bats_frame_lineno "$frame" 'lineno'
 
     if [[ $index -eq 1 ]]; then
-      echo -n "# ("
+      printf '# ('
     else
-      echo -n "#  "
+      printf '#  '
     fi
 
     local fn
     bats_frame_function "$frame" 'fn'
     if [[ "$fn" != "$BATS_TEST_NAME" ]]; then
-      echo -n "from function \`$fn' "
+      printf "from function \`%s' " "$fn"
     fi
 
     if [[ $index -eq $count ]]; then
-      echo "in test file $filename, line $lineno)"
+      printf 'in test file %s, line %d)\n' "$filename" "$lineno"
     else
-      echo "in file $filename, line $lineno,"
+      printf 'in file %s, line %d,\n' "$filename" "$lineno"
     fi
 
     let index+=1
@@ -168,9 +168,9 @@ bats_print_failed_command() {
   printf '%s' "#   \`${failed_command}' "
 
   if [[ $status -eq 1 ]]; then
-    echo "failed"
+    printf 'failed\n'
   else
-    echo "failed with status $status"
+    printf 'failed with status %d\n' "$status"
   fi
 }
 
@@ -286,9 +286,12 @@ bats_exit_trap() {
       BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
       BATS_ERROR_STATUS=1
     fi
-    echo "not ok $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
+    printf 'not ok %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
     bats_print_stack_trace "${BATS_ERROR_STACK_TRACE[@]}" >&3
-    bats_print_failed_command "${BATS_ERROR_STACK_TRACE[${#BATS_ERROR_STACK_TRACE[@]}-1]}" "$BATS_ERROR_STATUS" >&3
+    bats_print_failed_command \
+      "${BATS_ERROR_STACK_TRACE[${#BATS_ERROR_STACK_TRACE[@]}-1]}" \
+      "$BATS_ERROR_STATUS" >&3
+
     while IFS= read -r line; do
       printf '# %s\n' "$line"
     done <"$BATS_OUT" >&3
@@ -297,7 +300,8 @@ bats_exit_trap() {
     fi
     status=1
   else
-    echo "ok ${BATS_TEST_NUMBER} ${BATS_TEST_DESCRIPTION}${skipped}" >&3
+    printf 'ok %d %s%s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" \
+      "$skipped" >&3
     status=0
   fi
 
@@ -306,7 +310,7 @@ bats_exit_trap() {
 }
 
 bats_perform_tests() {
-  echo "1..$#"
+  printf '1..%d\n' "$#"
   test_number=1
   status=0
   for test_name in "$@"; do
@@ -324,7 +328,7 @@ bats_perform_test() {
   if declare -F "$BATS_TEST_NAME" >/dev/null; then
     BATS_TEST_NUMBER="$2"
     if [[ -z "$BATS_TEST_NUMBER" ]]; then
-      echo "1..1"
+      printf '1..1\n'
       BATS_TEST_NUMBER=1
     fi
 
@@ -340,7 +344,7 @@ bats_perform_test() {
     bats_teardown_trap
 
   else
-    echo "bats: unknown test name \`$BATS_TEST_NAME'" >&2
+    printf "bats: unknown test name \`%s'\n" "$BATS_TEST_NAME" >&2
     exit 1
   fi
 }
@@ -407,7 +411,7 @@ if [[ "$#" -eq 0 ]]; then
   bats_evaluate_preprocessed_source
 
   if [[ -n "$BATS_COUNT_ONLY" ]]; then
-    echo "${#BATS_TEST_NAMES[@]}"
+    printf '%d\n' "${#BATS_TEST_NAMES[@]}"
   else
     bats_perform_tests "${BATS_TEST_NAMES[@]}"
   fi

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -111,7 +111,7 @@ clear_to_end_of_line() {
 
 advance() {
   clear_to_end_of_line
-  echo
+  printf '\n'
   clear_color
 }
 

--- a/libexec/bats-core/bats-preprocess
+++ b/libexec/bats-core/bats-preprocess
@@ -43,12 +43,13 @@ while IFS= read -r line; do
     body="${BASH_REMATCH[2]}"
     encode_name "$name" 'encoded_name'
     tests["${#tests[@]}"]="$encoded_name"
-    echo "${encoded_name}() { bats_test_begin \"${name}\" ${index}; ${body}"
+    printf '%s() { bats_test_begin "%s" %d; %s\n' "$encoded_name" "$name" \
+      "$index" "$body"
   else
     printf "%s\n" "$line"
   fi
 done
 
 for test_name in "${tests[@]}"; do
-  echo "bats_test_function ${test_name}"
+  printf 'bats_test_function %s\n' "$test_name"
 done


### PR DESCRIPTION
Per the discussion in #118.

Expanded on guidance from CONTRIBUTING.md regarding avoiding subshells and using `printf -v`. Removed some vestigial language carried over from the mbland/go-script-bash original that doesn't really pertain to Bats.

Once this is in, I'll go ahead and cut v1.1.0, since we've got a few bug fixes (`ERR` trap issues in #110 and directory symlink resolution in #113) and a couple new features queued up (namely `-r` from #109, the new RPM file in #111, and the command line option error output from #45/#46/#118).

cc: @cdevinesr 

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
