### PR TITLE
Makes appveyor version semver compliant

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 'v1.1.0.{build}'
+version: 'v1.1.0+appveyor.{build}'
 
 build: off
 


### PR DESCRIPTION
Semver is Major.Minor.Patch-Prerelease+Build

This change makes the appveyor build version be semver compliant.
The build number is prefixed with plus (`+`) sign to indicate the build
metadata segment of semver version number.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
