### PR TITLE
Add duration tracking option for each test

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ supports:
 
 ```
 Bats x.y.z
-Usage: bats [-c] [-r] [-p | -t] <test> [<test> ...]
+Usage: bats [-c] [-r] [-p | -t] [-d] <test> [<test> ...]
 
   <test> is the path to a Bats test file, or the path to a directory
   containing Bats test files.
@@ -190,6 +190,7 @@ Usage: bats [-c] [-r] [-p | -t] <test> [<test> ...]
   -p, --pretty     Show results in pretty format (default for terminals)
   -r, --recursive  Include tests in subdirectories
   -t, --tap        Show results in TAP format
+  -d, --duration   Track duration of each test in YAML when using TAP format
   -v, --version    Display the version number
 ```
 

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -7,7 +7,7 @@ version() {
 
 usage() {
   version
-  printf 'Usage: bats [-c] [-r] [-p | -t] <test> [<test> ...]\n'
+  printf 'Usage: bats [-c] [-r] [-p | -t] [-d] <test> [<test> ...]\n'
 }
 
 abort() {
@@ -31,6 +31,7 @@ help() {
   -p, --pretty     Show results in pretty format (default for terminals)
   -r, --recursive  Include tests in subdirectories
   -t, --tap        Show results in TAP format
+  -d, --duration   Track duration of each test in YAML when using TAP format
   -v, --version    Display the version number
 
   For more information, see https://github.com/bats-core/bats-core
@@ -109,6 +110,9 @@ if [[ "${#options[@]}" -ne 0 ]]; then
     "p" | "pretty" )
       pretty=1
       ;;
+    "d" | "duration" )
+      duration_flag="-d"
+      ;;
     * )
       abort "Bad command line option '-$option'"
       ;;
@@ -149,7 +153,7 @@ fi
 
 set -o pipefail execfail
 if [[ -z "$pretty" ]]; then
-  exec "$command" $count_flag "${filenames[@]}"
+  exec "$command" $count_flag $duration_flag "${filenames[@]}"
 else
   extended_syntax_flag="-x"
   formatter="bats-format-tap-stream"

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -13,6 +13,12 @@ if [[ "$1" = "-x" ]]; then
   shift
 fi
 
+duration_flag=""
+if [ "$1" = "-d" ]; then
+  duration_flag="-d"
+  shift
+fi
+
 trap "kill 0; exit 1" int
 
 count=0
@@ -29,6 +35,9 @@ if [[ -n "$count_only_flag" ]]; then
   exit
 fi
 
+if [[ -n "$duration_flag" ]]; then
+  printf 'TAP version 13\n'
+fi
 printf '1..%d\n' "$count"
 status=0
 offset=0
@@ -56,7 +65,7 @@ for filename in "$@"; do
         ;;
       esac
     done
-  } < <( bats-exec-test $extended_syntax_flag "$filename" )
+  } < <( bats-exec-test $extended_syntax_flag $duration_flag "$filename" )
   offset=$(($offset + $index))
 done
 

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -13,6 +13,12 @@ if [[ "$1" = "-x" ]]; then
   shift
 fi
 
+BATS_RECORD_DURATION=""
+if [ "$1" = "-d" ]; then
+  BATS_RECORD_DURATION="$1"
+  shift
+fi
+
 BATS_TEST_FILENAME="$1"
 if [[ -z "$BATS_TEST_FILENAME" ]]; then
   printf 'usage: bats-exec-test <filename>\n' >&2
@@ -244,6 +250,17 @@ bats_error_trap() {
   fi
 }
 
+get_mills_since_epoch() {
+  local ms_since_epoch=$(date +%s%N)
+  if [[ "$ms_since_epoch" == *N ]]; then
+        ms_since_epoch=$(( $(date +%s) * 1000 ))
+  else
+        ms_since_epoch=$(( ms_since_epoch / 1000000 ))
+  fi
+
+  printf "%d\n" "$ms_since_epoch"
+}
+
 bats_teardown_trap() {
   bats_error_trap
   local status=0
@@ -255,6 +272,8 @@ bats_teardown_trap() {
     BATS_ERROR_STATUS="$status"
     BATS_ERROR_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
   fi
+
+  BATS_TEST_DURATION=$(( $(get_mills_since_epoch) - BATS_TEST_START_TIME ))
 
   bats_exit_trap
 }
@@ -305,16 +324,25 @@ bats_exit_trap() {
     status=0
   fi
 
+  if [[ -z $BATS_EXTENDED_SYNTAX && -n $BATS_RECORD_DURATION && -n $BATS_TEST_DURATION ]]; then
+    printf "  ---\n" >&3
+    printf "  duration_ms: %d\n" "$BATS_TEST_DURATION" >&3
+    printf "  ...\n" >&3
+  fi
+
   rm -f "$BATS_OUT"
   exit "$status"
 }
 
 bats_perform_tests() {
+  if [[ -n "$BATS_RECORD_DURATION" ]]; then
+    printf 'TAP version 13\n'
+  fi
   printf '1..%d\n' "$#"
   test_number=1
   status=0
   for test_name in "$@"; do
-    if ! "$0" $BATS_EXTENDED_SYNTAX "$BATS_TEST_FILENAME" "$test_name" \
+    if ! "$0" $BATS_EXTENDED_SYNTAX $BATS_RECORD_DURATION "$BATS_TEST_FILENAME" "$test_name" \
       "$test_number"; then
       status=1
     fi
@@ -328,16 +356,20 @@ bats_perform_test() {
   if declare -F "$BATS_TEST_NAME" >/dev/null; then
     BATS_TEST_NUMBER="$2"
     if [[ -z "$BATS_TEST_NUMBER" ]]; then
+      if [[ -n "$BATS_RECORD_DURATION" ]]; then
+        printf 'TAP version 13\n'
+      fi
       printf '1..1\n'
       BATS_TEST_NUMBER=1
     fi
 
     BATS_TEST_COMPLETED=""
+    BATS_TEST_START_TIME=$(get_mills_since_epoch)
     BATS_TEARDOWN_COMPLETED=""
     BATS_ERROR_STATUS=""
     trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
     trap "bats_error_trap" err
-    trap "bats_teardown_trap" exit
+    trap "bats_teardown_trap $BATS_RECORD_DURATION" exit
     "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
     BATS_TEST_COMPLETED=1
     trap "bats_exit_trap" exit

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -467,3 +467,23 @@ END_OF_ERR_MSG
   [ "${lines[5]}" = '# bar' ]
   [ "${lines[6]}" = '# baz' ]
 }
+
+@test "tests with durations" {
+  run bats -td $FIXTURE_ROOT/passing_failing_and_skipping.bats
+  [ "$status" -eq 1 ]
+  
+  [ "${lines[0]}"       =  'TAP version 13' ]
+  [ "${lines[2]}"       =  'ok 1 a passing test' ]
+  [ "${lines[3]}"       =  '  ---' ]
+  [ "${lines[4]:0:15}"  =  '  duration_ms: ' ]
+  [ "${lines[5]}"       =  '  ...' ]
+  [ "${lines[6]}"       =  'ok 2 a skipping test # skip' ]
+  [ "${lines[7]}"       =  '  ---' ]
+  [ "${lines[8]:0:15}"  =  '  duration_ms: ' ]
+  [ "${lines[9]}"       =  '  ...' ]
+  [ "${lines[10]}"      =  'not ok 3 a failing test' ]
+  [ "${lines[11]:0:15}" =  '# (in test file' ]
+  [ "${lines[13]}"      =  '  ---' ]
+  [ "${lines[14]:0:15}" =  '  duration_ms: ' ]
+  [ "${lines[15]}"      =  '  ...' ]
+}


### PR DESCRIPTION
In some validation cases, it makes sense to track the duration of each
test to understand which ones are executing quickly and which ones are
executing slowly.  Trends may be built up over time to see how duration
changes given the other changes being tested.

Rebasing from harschware/bats/yaml_durations.

Because this adds a YAML block to the TAP output, the TAP producer needs
to write "TAP version 13" as the first line.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
