### PR TITLE
Run tests matting a pattern to aid debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,8 @@ There are several global variables you can use to introspect on Bats tests:
   test file.
 * `$BATS_TMPDIR` is the location to a directory that may be used to store
   temporary files.
+* `$BATS_RUN_PATTERN` is a regular expression describing which tests to run
+  from the test file.
 
 ## Support
 

--- a/libexec/bats-core/bats-preprocess
+++ b/libexec/bats-core/bats-preprocess
@@ -33,6 +33,7 @@ encode_name() {
 
 tests=()
 index=0
+run_test=1
 
 while IFS= read -r line; do
   line="${line//$'\r'}"
@@ -40,9 +41,18 @@ while IFS= read -r line; do
   if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
     name="${BASH_REMATCH[1]#[\'\"]}"
     name="${name%[\'\"]}"
+    if [[ -n "$BATS_RUN_PATTERN" ]]; then
+      if [[ "${name//\"/}" =~ $BATS_RUN_PATTERN ]]; then
+        run_test=1
+      else
+        run_test=0
+      fi
+    fi
     body="${BASH_REMATCH[2]}"
     encode_name "$name" 'encoded_name'
-    tests["${#tests[@]}"]="$encoded_name"
+    if [[ "$run_test" -eq 1 ]]; then
+      tests["${#tests[@]}"]="$encoded_name"
+    fi
     printf '%s() { bats_test_begin "%s" %d; %s\n' "$encoded_name" "$name" \
       "$index" "$body"
   else

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -467,3 +467,11 @@ END_OF_ERR_MSG
   [ "${lines[5]}" = '# bar' ]
   [ "${lines[6]}" = '# baz' ]
 }
+
+@test "BATS_RUN_PATTERN matches tests to run against a pattern" {
+  BATS_RUN_PATTERN='a passing test' run bats -t "$FIXTURE_ROOT/passing_failing_and_skipping.bats"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = '1..1' ]
+  [ "${lines[1]}" = 'ok 1 a passing test' ]
+  [ "${#lines[@]}" -eq 2 ]
+}


### PR DESCRIPTION
To aid debugging when tests fail, users may define the BATS_RUN_PATTERN
variable to define individual tests to run by a regular expression.  Any
test not matching the regular expression is not run.

Rebasing from dougm/bats/run-pattern.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
