### PR TITLE
Style tweaks and other minor cleanups

### DIFF
--- a/bin/bats
+++ b/bin/bats
@@ -2,18 +2,12 @@
 
 set -e
 
-export BATS_READLINK='true'
+BATS_READLINK='true'
 if command -v 'greadlink' >/dev/null; then
   BATS_READLINK='greadlink'
 elif command -v 'readlink' >/dev/null; then
   BATS_READLINK='readlink'
 fi
-
-bats_resolve_link() {
-  if ! "$BATS_READLINK" "$1"; then
-    return 0
-  fi
-}
 
 bats_resolve_absolute_root_dir() {
   local cwd="$PWD"
@@ -35,7 +29,7 @@ bats_resolve_absolute_root_dir() {
     fi
 
     if [[ -L "$target_name" ]]; then
-      path="$(bats_resolve_link "$target_name")"
+      path="$("$BATS_READLINK" "$target_name")"
     else
       printf -v "$result" -- '%s' "${PWD%/*}"
       set +P "-$original_shell_options"

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -137,16 +137,16 @@ for filename in "${arguments[@]}"; do
     shopt -s nullglob
     if [[ "$recursive" -eq 1 ]]; then
       while IFS= read -r -d $'\0' file; do
-        filenames["${#filenames[@]}"]="$file"
+        filenames+=("$file")
       done < <(find "$filename" -type f -name "*.bats" -print0 | sort -z)
     else
       for suite_filename in "$filename"/*.bats; do
-        filenames["${#filenames[@]}"]="$suite_filename"
+        filenames+=("$suite_filename")
       done
     fi
     shopt -u nullglob
   else
-    filenames["${#filenames[@]}"]="$filename"
+    filenames+=("$filename")
   fi
 done
 

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -84,7 +84,7 @@ unset flags pretty recursive
 flags=()
 pretty=
 recursive=
-if [[ -z "${CI:-}" && -t 0 && -t 1 ]]; then
+if [[ -z "${CI:-}" && -t 0 && -t 1 ]] && command -v tput >/dev/null; then
   pretty=1
 fi
 

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -138,7 +138,7 @@ for filename in "${arguments[@]}"; do
     if [[ "$recursive" -eq 1 ]]; then
       while IFS= read -r -d $'\0' file; do
         filenames+=("$file")
-      done < <(find "$filename" -type f -name "*.bats" -print0 | sort -z)
+      done < <(find "$filename" -type f -name '*.bats' -print0 | sort -z)
     else
       for suite_filename in "$filename"/*.bats; do
         filenames+=("$suite_filename")
@@ -151,9 +151,9 @@ for filename in "${arguments[@]}"; do
 done
 
 if [[ "${#filenames[@]}" -eq 1 ]]; then
-  command="bats-exec-test"
+  command='bats-exec-test'
 else
-  command="bats-exec-suite"
+  command='bats-exec-suite'
 fi
 
 set -o pipefail execfail

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -36,7 +36,7 @@ for filename in "$@"; do
       test_name="${BASH_REMATCH[1]#[\'\"]}"
       test_name="${test_name%[\'\"]}"
       if [[ -z "$filter" || "$test_name" =~ $filter ]]; then
-        let count+=1
+        ((++count))
       fi
     fi
   done <"$filename"
@@ -57,12 +57,12 @@ for filename in "$@"; do
     while IFS= read -r line; do
       case "$line" in
       "begin "* )
-        let index+=1
+        ((++index))
         printf '%s\n' "${line/ $index / $(($offset + $index)) }"
         ;;
       "ok "* | "not ok "* )
         if [[ -z "$extended_syntax_flag" ]]; then
-          let index+=1
+          ((++index))
         fi
         printf '%s\n' "${line/ $index / $(($offset + $index)) }"
         if [[ "${line:0:6}" == "not ok" ]]; then

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -27,7 +27,7 @@ while [[ "$#" -ne 0 ]]; do
   shift
 done
 
-trap "kill 0; exit 1" int
+trap 'kill 0; exit 1' int
 
 count=0
 for filename in "$@"; do
@@ -56,16 +56,16 @@ for filename in "$@"; do
     IFS= read -r # 1..n
     while IFS= read -r line; do
       case "$line" in
-      "begin "* )
+      'begin '* )
         ((++index))
         printf '%s\n' "${line/ $index / $(($offset + $index)) }"
         ;;
-      "ok "* | "not ok "* )
+      'ok '* | 'not ok '* )
         if [[ -z "$extended_syntax_flag" ]]; then
           ((++index))
         fi
         printf '%s\n' "${line/ $index / $(($offset + $index)) }"
-        if [[ "${line:0:6}" == "not ok" ]]; then
+        if [[ "${line:0:6}" == 'not ok' ]]; then
           status=1
         fi
         ;;

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -123,7 +123,7 @@ bats_capture_stack_trace() {
     # calling an exported function erases the test file's BASH_SOURCE entry.
     source_file="${BASH_SOURCE[$i]:-$BATS_TEST_SOURCE}"
     frame="${BASH_LINENO[$((i-1))]} ${FUNCNAME[$i]} $source_file"
-    BATS_CURRENT_STACK_TRACE["${#BATS_CURRENT_STACK_TRACE[@]}"]="$frame"
+    BATS_CURRENT_STACK_TRACE+=("$frame")
     if [[ "$frame" = *"$test_pattern"     || \
           "$frame" = *"$setup_pattern"    || \
           "$frame" = *"$teardown_pattern" ]]; then

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -282,7 +282,7 @@ bats_exit_trap() {
   trap - err exit
 
   if [[ -n "$BATS_TEST_SKIPPED" ]]; then
-    skipped=" # skip"
+    skipped=' # skip'
     if [[ "$BATS_TEST_SKIPPED" != '1' ]]; then
       skipped+=" $BATS_TEST_SKIPPED"
     fi
@@ -350,15 +350,15 @@ bats_perform_test() {
       BATS_TEST_NUMBER=1
     fi
 
-    BATS_TEST_COMPLETED=""
-    BATS_TEARDOWN_COMPLETED=""
-    BATS_ERROR_STATUS=""
+    BATS_TEST_COMPLETED=
+    BATS_TEARDOWN_COMPLETED=
+    BATS_ERROR_STATUS=
     trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
-    trap "bats_error_trap" err
-    trap "bats_teardown_trap" exit
+    trap 'bats_error_trap' err
+    trap 'bats_teardown_trap' exit
     "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
     BATS_TEST_COMPLETED=1
-    trap "bats_exit_trap" exit
+    trap 'bats_exit_trap' exit
     bats_teardown_trap
 
   else
@@ -368,7 +368,7 @@ bats_perform_test() {
 }
 
 if [[ -z "$TMPDIR" ]]; then
-  BATS_TMPDIR="/tmp"
+  BATS_TMPDIR='/tmp'
 else
   BATS_TMPDIR="${TMPDIR%/}"
 fi
@@ -380,8 +380,8 @@ BATS_OUT="${BATS_TMPNAME}.out"
 bats_preprocess_source() {
   BATS_TEST_SOURCE="${BATS_TMPNAME}.src"
   . bats-preprocess <<< "$(< "$BATS_TEST_FILENAME")"$'\n' > "$BATS_TEST_SOURCE"
-  trap "bats_cleanup_preprocessed_source" err exit
-  trap "bats_cleanup_preprocessed_source; exit 1" int
+  trap 'bats_cleanup_preprocessed_source' err exit
+  trap 'bats_cleanup_preprocessed_source; exit 1' int
 
   bats_detect_duplicate_test_case_names
 }

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -165,7 +165,7 @@ bats_print_stack_trace() {
       printf 'in file %s, line %d,\n' "$filename" "$lineno"
     fi
 
-    let index+=1
+    ((++index))
   done
 }
 
@@ -336,7 +336,7 @@ bats_perform_tests() {
       "$test_number"; then
       status=1
     fi
-    let test_number+=1
+    ((++test_number))
   done
   exit "$status"
 }

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -47,7 +47,7 @@ load() {
   local name="$1"
   local filename
 
-  if [[ "${name:0:1}" = "/" ]]; then
+  if [[ "${name:0:1}" == '/' ]]; then
     filename="${name}"
   else
     filename="$BATS_TEST_DIRNAME/${name}.bash"
@@ -124,9 +124,9 @@ bats_capture_stack_trace() {
     source_file="${BASH_SOURCE[$i]:-$BATS_TEST_SOURCE}"
     frame="${BASH_LINENO[$((i-1))]} ${FUNCNAME[$i]} $source_file"
     BATS_CURRENT_STACK_TRACE+=("$frame")
-    if [[ "$frame" = *"$test_pattern"     || \
-          "$frame" = *"$setup_pattern"    || \
-          "$frame" = *"$teardown_pattern" ]]; then
+    if [[ "$frame" == *"$test_pattern"     || \
+          "$frame" == *"$setup_pattern"    || \
+          "$frame" == *"$teardown_pattern" ]]; then
       break
     fi
   done
@@ -203,7 +203,7 @@ bats_frame_filename() {
   local __bff_filename="${1#* }"
   __bff_filename="${__bff_filename#* }"
 
-  if [[ "$__bff_filename" = "$BATS_TEST_SOURCE" ]]; then
+  if [[ "$__bff_filename" == "$BATS_TEST_SOURCE" ]]; then
     __bff_filename="$BATS_TEST_FILENAME"
   fi
   printf -v "$2" '%s' "$__bff_filename"

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -150,7 +150,7 @@ trap finish EXIT
 while IFS= read -r line; do
   case "$line" in
   "begin "* )
-    let index+=1
+    ((++index))
     name="${line#* $index }"
     buffer begin
     flush
@@ -158,14 +158,14 @@ while IFS= read -r line; do
   "ok "* )
     skip_expr="ok $index (.*) # skip ?(([[:print:]]*))?"
     if [[ "$line" =~ $skip_expr ]]; then
-      let skipped+=1
+      ((++skipped))
       buffer skip "${BASH_REMATCH[2]}"
     else
       buffer pass
     fi
     ;;
   "not ok "* )
-    let failures+=1
+    ((++failures))
     buffer fail
     ;;
   "# "* )

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -27,16 +27,16 @@ update_screen_width
 
 begin() {
   go_to_column 0
-  printf_with_truncation $(( $count_column_left - 1 )) '   %s' "$name"
+  buffer_with_truncation $(( $count_column_left - 1 )) '   %s' "$name"
   clear_to_end_of_line
   go_to_column $count_column_left
-  printf "%${#count}s/${count}" "$index"
+  buffer "%${#count}s/${count}" "$index"
   go_to_column 1
 }
 
 pass() {
   go_to_column 0
-  printf ' ✓ %s' "$name"
+  buffer ' ✓ %s' "$name"
   advance
 }
 
@@ -46,42 +46,42 @@ skip() {
     reason=": $reason"
   fi
   go_to_column 0
-  printf ' - %s (skipped%s)' "$name" "$reason"
+  buffer ' - %s (skipped%s)' "$name" "$reason"
   advance
 }
 
 fail() {
   go_to_column 0
   set_color 1 bold
-  printf ' ✗ %s' "$name"
+  buffer ' ✗ %s' "$name"
   advance
 }
 
 log() {
   set_color 1
-  printf '   %s\n' "$1"
+  buffer '   %s\n' "$1"
   clear_color
 }
 
 summary() {
-  printf '\n%d test' "$count"
+  buffer '\n%d test' "$count"
   if [[ "$count" -ne 1 ]]; then
-    printf 's'
+    buffer 's'
   fi
 
-  printf ', %d failure' "$failures"
+  buffer ', %d failure' "$failures"
   if [[ "$failures" -ne 1 ]]; then
-    printf 's'
+    buffer 's'
   fi
 
   if [[ "$skipped" -gt 0 ]]; then
-    printf ', %d skipped' "$skipped"
+    buffer ', %d skipped' "$skipped"
   fi
 
-  printf '\n'
+  buffer '\n'
 }
 
-printf_with_truncation() {
+buffer_with_truncation() {
   local width="$1"
   shift
   local string
@@ -89,24 +89,24 @@ printf_with_truncation() {
   printf -v 'string' -- "$@"
 
   if [[ "${#string}" -gt "$width" ]]; then
-    printf '%s...' "${string:0:$(( $width - 4 ))}"
+    buffer '%s...' "${string:0:$(( $width - 4 ))}"
   else
-    printf '%s' "$string"
+    buffer '%s' "$string"
   fi
 }
 
 go_to_column() {
   local column="$1"
-  printf '\x1B[%dG' $(( $column + 1 ))
+  buffer '\x1B[%dG' $(( $column + 1 ))
 }
 
 clear_to_end_of_line() {
-  printf '\x1B[K'
+  buffer '\x1B[K'
 }
 
 advance() {
   clear_to_end_of_line
-  printf '\n'
+  buffer '\n'
   clear_color
 }
 
@@ -117,17 +117,19 @@ set_color() {
   if [[ "$2" == 'bold' ]]; then
     weight=1
   fi
-  printf '\x1B[%d;%dm' $(( 30 + $color )) "$weight"
+  buffer '\x1B[%d;%dm' "$(( 30 + $color ))" "$weight"
 }
 
 clear_color() {
-  printf '\x1B[0m'
+  buffer '\x1B[0m'
 }
 
 _buffer=
 
 buffer() {
-  _buffer="${_buffer}$("$@")"
+  local content
+  printf -v content -- "$@"
+  _buffer+="$content"
 }
 
 flush() {
@@ -147,26 +149,26 @@ while IFS= read -r line; do
   'begin '* )
     ((++index))
     name="${line#* $index }"
-    buffer begin
+    begin
     flush
     ;;
   'ok '* )
     skip_expr="ok $index (.*) # skip ?(([[:print:]]*))?"
     if [[ "$line" =~ $skip_expr ]]; then
       ((++skipped))
-      buffer skip "${BASH_REMATCH[2]}"
+      skip "${BASH_REMATCH[2]}"
     else
-      buffer pass
+      pass
     fi
     ;;
   'not ok '* )
     ((++failures))
-    buffer fail
+    fail
     ;;
   '# '* )
-    buffer log "${line:2}"
+    log "${line:2}"
     ;;
   esac
 done
 
-buffer summary
+summary

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -3,7 +3,7 @@ set -e
 
 # Just stream the TAP output (sans extended syntax) if tput is missing
 if ! command -v tput >/dev/null; then
-  exec grep -v "^begin "
+  exec grep -v '^begin '
 fi
 
 header_pattern='[0-9]+\.\.[0-9]+'
@@ -14,11 +14,11 @@ if [[ "$header" =~ $header_pattern ]]; then
   index=0
   failures=0
   skipped=0
-  name=""
+  name=
   count_column_width=$(( ${#count} * 2 + 2 ))
 else
   # If the first line isn't a TAP plan, print it and pass the rest through
-  printf "%s\n" "$header"
+  printf '%s\n' "$header"
   exec cat
 fi
 
@@ -32,7 +32,7 @@ update_screen_width
 
 begin() {
   go_to_column 0
-  printf_with_truncation $(( $count_column_left - 1 )) "   %s" "$name"
+  printf_with_truncation $(( $count_column_left - 1 )) '   %s' "$name"
   clear_to_end_of_line
   go_to_column $count_column_left
   printf "%${#count}s/${count}" "$index"
@@ -41,7 +41,7 @@ begin() {
 
 pass() {
   go_to_column 0
-  printf " ✓ %s" "$name"
+  printf ' ✓ %s' "$name"
   advance
 }
 
@@ -51,39 +51,39 @@ skip() {
     reason=": $reason"
   fi
   go_to_column 0
-  printf " - %s (skipped%s)" "$name" "$reason"
+  printf ' - %s (skipped%s)' "$name" "$reason"
   advance
 }
 
 fail() {
   go_to_column 0
   set_color 1 bold
-  printf " ✗ %s" "$name"
+  printf ' ✗ %s' "$name"
   advance
 }
 
 log() {
   set_color 1
-  printf "   %s\n" "$1"
+  printf '   %s\n' "$1"
   clear_color
 }
 
 summary() {
-  printf "\n%d test" "$count"
+  printf '\n%d test' "$count"
   if [[ "$count" -ne 1 ]]; then
     printf 's'
   fi
 
-  printf ", %d failure" "$failures"
+  printf ', %d failure' "$failures"
   if [[ "$failures" -ne 1 ]]; then
     printf 's'
   fi
 
   if [[ "$skipped" -gt 0 ]]; then
-    printf ", %d skipped" "$skipped"
+    printf ', %d skipped' "$skipped"
   fi
 
-  printf "\n"
+  printf '\n'
 }
 
 printf_with_truncation() {
@@ -94,19 +94,19 @@ printf_with_truncation() {
   printf -v 'string' -- "$@"
 
   if [[ "${#string}" -gt "$width" ]]; then
-    printf "%s..." "${string:0:$(( $width - 4 ))}"
+    printf '%s...' "${string:0:$(( $width - 4 ))}"
   else
-    printf "%s" "$string"
+    printf '%s' "$string"
   fi
 }
 
 go_to_column() {
   local column="$1"
-  printf "\x1B[%dG" $(( $column + 1 ))
+  printf '\x1B[%dG' $(( $column + 1 ))
 }
 
 clear_to_end_of_line() {
-  printf "\x1B[K"
+  printf '\x1B[K'
 }
 
 advance() {
@@ -122,40 +122,40 @@ set_color() {
   if [[ "$2" == 'bold' ]]; then
     weight=1
   fi
-  printf "\x1B[%d;%dm" $(( 30 + $color )) "$weight"
+  printf '\x1B[%d;%dm' $(( 30 + $color )) "$weight"
 }
 
 clear_color() {
-  printf "\x1B[0m"
+  printf '\x1B[0m'
 }
 
-_buffer=""
+_buffer=
 
 buffer() {
   _buffer="${_buffer}$("$@")"
 }
 
 flush() {
-  printf "%s" "$_buffer"
-  _buffer=""
+  printf '%s' "$_buffer"
+  _buffer=
 }
 
 finish() {
   flush
-  printf "\n"
+  printf '\n'
 }
 
 trap finish EXIT
 
 while IFS= read -r line; do
   case "$line" in
-  "begin "* )
+  'begin '* )
     ((++index))
     name="${line#* $index }"
     buffer begin
     flush
     ;;
-  "ok "* )
+  'ok '* )
     skip_expr="ok $index (.*) # skip ?(([[:print:]]*))?"
     if [[ "$line" =~ $skip_expr ]]; then
       ((++skipped))
@@ -164,11 +164,11 @@ while IFS= read -r line; do
       buffer pass
     fi
     ;;
-  "not ok "* )
+  'not ok '* )
     ((++failures))
     buffer fail
     ;;
-  "# "* )
+  '# '* )
     buffer log "${line:2}"
     ;;
   esac

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# Just stream the TAP output (sans extended syntax) if tput is missing
-if ! command -v tput >/dev/null; then
-  exec grep -v '^begin '
-fi
-
 header_pattern='[0-9]+\.\.[0-9]+'
 IFS= read -r header
 

--- a/libexec/bats-core/bats-preprocess
+++ b/libexec/bats-core/bats-preprocess
@@ -3,7 +3,7 @@ set -e
 
 bats_encode_test_name() {
   local name="$1"
-  local result="test_"
+  local result='test_'
   local hex_code
 
   if [[ ! "$name" =~ [^[:alnum:]\ _-] ]]; then
@@ -22,7 +22,7 @@ bats_encode_test_name() {
       elif [[ "$char" =~ [[:alnum:]] ]]; then
         result+="$char"
       else
-        printf -v 'hex_code' -- "-%02x" \'"$char"
+        printf -v 'hex_code' -- '-%02x' \'"$char"
         result+="$hex_code"
       fi
     done
@@ -46,7 +46,7 @@ while IFS= read -r line; do
       tests+=("$encoded_name")
     fi
   else
-    printf "%s\n" "$line"
+    printf '%s\n' "$line"
   fi
 done
 

--- a/libexec/bats-core/bats-preprocess
+++ b/libexec/bats-core/bats-preprocess
@@ -32,18 +32,15 @@ bats_encode_test_name() {
 }
 
 tests=()
-index=0
 
 while IFS= read -r line; do
   line="${line//$'\r'}"
-  let index+=1
   if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
     name="${BASH_REMATCH[1]#[\'\"]}"
     name="${name%[\'\"]}"
     body="${BASH_REMATCH[2]}"
     bats_encode_test_name "$name" 'encoded_name'
-    printf '%s() { bats_test_begin "%s" %d; %s\n' "$encoded_name" "$name" \
-      "$index" "$body"
+    printf '%s() { bats_test_begin "%s"; %s\n' "$encoded_name" "$name" "$body"
 
     if [[ -z "$BATS_TEST_FILTER" || "$name" =~ $BATS_TEST_FILTER ]]; then
       tests+=("$encoded_name")

--- a/libexec/bats-core/bats-preprocess
+++ b/libexec/bats-core/bats-preprocess
@@ -17,8 +17,8 @@ bats_encode_test_name() {
 
     for ((i=0; i<length; i++)); do
       char="${name:$i:1}"
-      if [[ "$char" = " " ]]; then
-        result+="_"
+      if [[ "$char" == ' ' ]]; then
+        result+='_'
       elif [[ "$char" =~ [[:alnum:]] ]]; then
         result+="$char"
       else


### PR DESCRIPTION
These are almost all pure style changes and other minor refactorings to make the code a bit cleaner. The individual commit titles and comments explain it all.

The one semantic change is the user can now force "pretty" output to a file even if ncurses/`tput`
is missing (commit ec093f1355201675e586f791641043ec06fee6af).

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
