### PR TITLE
WIP: Add a --trace feature

### DIFF
--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -20,7 +20,7 @@ usage() {
   while IFS= read -r line; do
     printf '%s\n' "$line"
   done <<END_OF_HELP_TEXT
-Usage: $cmd [-cr] [-f <regex>] [-p | -t] <test>...
+Usage: $cmd [-crx] [-f <regex>] [-p | -t] <test>...
        $cmd [-h | -v]
 
   <test> is the path to a Bats test file, or the path to a directory
@@ -33,6 +33,7 @@ Usage: $cmd [-cr] [-f <regex>] [-p | -t] <test>...
   -r, --recursive  Include tests in subdirectories
   -t, --tap        Show results in TAP format
   -v, --version    Display the version number
+  -x, --trace      Display Bash commands with file:line info as they're executed
 
   For more information, see https://github.com/bats-core/bats-core
 
@@ -61,7 +62,7 @@ export PATH="$BATS_ROOT/libexec/bats-core:$PATH"
 
 arguments=()
 
-# Unpack single-character options bundled together, e.g. -cr, -pr.
+# Unpack single-character options bundled together, e.g. -cr, -pr, -tx.
 for arg in "$@"; do
   if [[ "$arg" =~ ^-[^-]. ]]; then
     index=1
@@ -114,6 +115,9 @@ while [[ "$#" -ne 0 ]]; do
     ;;
   -p|--pretty)
     pretty=1
+    ;;
+  -x|--trace)
+    flags+=('--trace')
     ;;
   -*)
     abort "Bad command line option '$1'"

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -16,6 +16,9 @@ while [[ "$#" -ne 0 ]]; do
     flags+=('-f' "$filter")
     shift
     ;;
+  --trace)
+    flags+=('--trace')
+    ;;
   -x)
     extended_syntax_flag='-x'
     flags+=('-x')

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -222,34 +222,30 @@ bats_trim_filename() {
 }
 
 bats_debug_trap() {
-  local status="$?"
-
   if [[ "$BASH_SOURCE" != "$1" ]]; then
     bats_capture_stack_trace
     BATS_LINENO="$BATS_CURRENT_LINENO"
     BATS_CURRENT_LINENO="${BASH_LINENO[0]}"
 
     if [[ -n "$BATS_TRACE" ]]; then
-      bats_emit_trace "$status"
+      bats_emit_trace
     fi
   fi
 }
 
 bats_emit_trace() {
-  local status="$?"
-
   case "$BASH_COMMAND" in
   '"$BATS_TEST_NAME" >> "$BATS_OUT" 2>&1'|'bats_test_begin '*)
     return
     ;;
   esac
 
-  # If `status` is nonzero but the command is the same, then this DEBUG trap
-  # is firing before the ERR trap of a failing command. Since we've printed
+  # If the `BASH_COMMAND` is the same, but `BATS_CURRENT_LINENO` is less than or
+  # equal to `BATS_LINENO` (the previous trap's `BASH_LINENO`), then this DEBUG
+  # trap is firing before the ERR trap of a failing command. Since we've printed
   # the command before it failed, we don't want to print it a second time.
-  if [[ "$status" -eq 0 && \
-        ( "$BASH_COMMAND" != "$BATS_PREVIOUS_COMMAND" || \
-          "$BATS_LINENO" -lt "$BATS_CURRENT_LINENO" ) ]]; then
+  if [[ "$BASH_COMMAND" != "$BATS_PREVIOUS_COMMAND" || \
+        "$BATS_LINENO" -lt "$BATS_CURRENT_LINENO" ]]; then
     local filename="${BASH_SOURCE[2]}"
 
     if [[ "$filename" == "$BATS_TEST_SOURCE" ]]; then

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -4,7 +4,7 @@ set -eET
 BATS_COUNT_ONLY=''
 BATS_TEST_FILTER=''
 BATS_EXTENDED_SYNTAX=''
-BATS_TRACE="${BATS_TRACE:-}"
+BATS_TRACE=''
 
 # Command and flags used by bats_perform_tests when it re-invokes bats-exec-test
 # in a new process to run bats_perform_test.
@@ -22,6 +22,10 @@ while [[ "$#" -ne 0 ]]; do
   -x)
     BATS_EXTENDED_SYNTAX='-x'
     BATS_PERFORM_TEST_CMD+=('-x')
+    ;;
+  --trace)
+    BATS_TRACE=1
+    BATS_PERFORM_TEST_CMD+=('--trace')
     ;;
   *)
     break

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -129,11 +129,11 @@ bats_capture_stack_trace() {
     source_file="${BASH_SOURCE[$i]:-$BATS_TEST_SOURCE}"
     frame="${BASH_LINENO[$((i-1))]} ${FUNCNAME[$i]} $source_file"
     BATS_CURRENT_STACK_TRACE+=("$frame")
-    if [[ "$frame" == *"$test_pattern"     || \
-          "$frame" == *"$setup_pattern"    || \
-          "$frame" == *"$teardown_pattern" ]]; then
+    case "$frame" in
+    *"$test_pattern"|*"$setup_pattern"|*"$teardown_pattern")
       break
-    fi
+      ;;
+    esac
   done
 
   bats_frame_filename "${BATS_CURRENT_STACK_TRACE[0]}" 'BATS_SOURCE'
@@ -236,12 +236,17 @@ bats_trim_filename() {
 }
 
 bats_debug_trap() {
-  if [[ "$BASH_SOURCE" != "$1" && \
-        "$BASH_COMMAND" != '"$BATS_TEST_NAME" >> "$BATS_OUT" 2>&1' &&
-        "${BASH_COMMAND%% *}" != 'bats_test_begin' ]]; then
+  local status="$?"
+
+  if [[ "$BASH_SOURCE" != "$1" ]]; then
+    case "$BASH_COMMAND" in
+    '"$BATS_TEST_NAME" >> "$BATS_OUT"'*|'bats_test_begin '*|"${FUNCNAME[1]} "*)
+      return
+      ;;
+    esac
     bats_capture_stack_trace
 
-    if [[ -n "$BATS_TRACE"  ]]; then
+    if [[ -n "$BATS_TRACE" && "$status" -eq 0 ]]; then
       printf '# %s:%d: %s\n' "${BATS_SOURCE#$PWD/}" "$BATS_LINENO" \
         "$BASH_COMMAND" >&3
     fi

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -108,6 +108,8 @@ bats_test_function() {
 BATS_CURRENT_STACK_TRACE=()
 BATS_PREVIOUS_STACK_TRACE=()
 BATS_ERROR_STACK_TRACE=()
+BATS_PREVIOUS_FUNCNAME_SIZE=100
+BATS_PREVIOUS_COMMAND=''
 
 bats_capture_stack_trace() {
   if [[ "${#BATS_CURRENT_STACK_TRACE[@]}" -ne 0 ]]; then
@@ -238,19 +240,35 @@ bats_trim_filename() {
 bats_debug_trap() {
   local status="$?"
 
-  if [[ "$BASH_SOURCE" != "$1" ]]; then
+  # Avoid capturing a stack trace for the beginning of a function definition
+  # by comparing the current and previous stack sizes.
+  if [[ "$BASH_SOURCE" != "$1" && \
+        "${#FUNCNAME[@]}" -le "$BATS_PREVIOUS_FUNCNAME_SIZE" ]]; then
     case "$BASH_COMMAND" in
-    '"$BATS_TEST_NAME" >> "$BATS_OUT"'*|'bats_test_begin '*|"${FUNCNAME[1]} "*)
+    '"$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1'|'bats_test_begin '*)
       return
       ;;
     esac
     bats_capture_stack_trace
 
-    if [[ -n "$BATS_TRACE" && "$status" -eq 0 ]]; then
-      printf '# %s:%d: %s\n' "${BATS_SOURCE#$PWD/}" "$BATS_LINENO" \
-        "$BASH_COMMAND" >&3
+    # If `status` is nonzero but the command is the same, then this DEBUG trap
+    # is firing before the ERR trap of a failing command. Since we've printed
+    # the command before it failed, we don't want to print it a second time.
+    if [[ -n "$BATS_TRACE" ]]; then
+      local prev_lineno
+
+      bats_frame_lineno "${BATS_PREVIOUS_STACK_TRACE[0]}" 'prev_lineno'
+
+      if [[ "$status" -eq 0 || \
+            "$BASH_COMMAND" != "$BATS_PREVIOUS_COMMAND" ||
+            "$BATS_LINENO" -gt "$prev_lineno" ]]; then
+        printf '# %s:%d: %s\n' "${BATS_SOURCE#$PWD/}" "$BATS_LINENO" \
+          "$BASH_COMMAND" >&3
+      fi
+      BATS_PREVIOUS_COMMAND="$BASH_COMMAND"
     fi
   fi
+  BATS_PREVIOUS_FUNCNAME_SIZE="${#FUNCNAME[@]}"
 }
 
 # For some versions of Bash, the `ERR` trap may not always fire for every

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -232,12 +232,12 @@ bats_trim_filename() {
 }
 
 bats_debug_trap() {
-  if [[ "$BASH_SOURCE" != "$1" ]]; then
+  if [[ "$BASH_SOURCE" != "$1" && \
+        "$BASH_COMMAND" != '"$BATS_TEST_NAME" >> "$BATS_OUT" 2>&1' &&
+        "${BASH_COMMAND%% *}" != 'bats_test_begin' ]]; then
     bats_capture_stack_trace
 
-    if [[ -n "$BATS_TRACE" && \
-          "$BASH_COMMAND" != '"$BATS_TEST_NAME" >> "$BATS_OUT" 2>&1' &&
-          "${BASH_COMMAND%% *}" != 'bats_test_begin' ]]; then
+    if [[ -n "$BATS_TRACE"  ]]; then
       printf '# %s:%d: %s\n' "${BATS_SOURCE#$PWD/}" "$BATS_LINENO" \
         "$BASH_COMMAND" >&3
     fi

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -4,6 +4,7 @@ set -eET
 BATS_COUNT_ONLY=''
 BATS_TEST_FILTER=''
 BATS_EXTENDED_SYNTAX=''
+BATS_TRACE="${BATS_TRACE:-}"
 
 # Command and flags used by bats_perform_tests when it re-invokes bats-exec-test
 # in a new process to run bats_perform_test.
@@ -233,6 +234,13 @@ bats_trim_filename() {
 bats_debug_trap() {
   if [[ "$BASH_SOURCE" != "$1" ]]; then
     bats_capture_stack_trace
+
+    if [[ -n "$BATS_TRACE" && \
+          "$BASH_COMMAND" != '"$BATS_TEST_NAME" >> "$BATS_OUT" 2>&1' &&
+          "${BASH_COMMAND%% *}" != 'bats_test_begin' ]]; then
+      printf '# %s:%d: %s\n' "${BATS_SOURCE#$PWD/}" "$BATS_LINENO" \
+        "$BASH_COMMAND" >&3
+    fi
   fi
 }
 

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -466,3 +466,35 @@ END_OF_ERR_MSG
   [ "${lines[5]}" = '# bar' ]
   [ "${lines[6]}" = '# baz' ]
 }
+
+@test "trace a passing test case" {
+  TEST_RESULT='PASS' run bats --trace "$FIXTURE_ROOT/trace.bats"
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 5 ]
+
+  local file="$RELATIVE_FIXTURE_ROOT/trace.bats"
+
+  [ "${lines[1]}" = \
+    "# $file:6: run printf 'The TEST_RESULT is: %s\n' \"\$TEST_RESULT\"" ]
+  [ "${lines[2]}" = "# $file:7: evaluate_result \"\$output\"" ]
+  [ "${lines[3]}" = "# $file:2: [ \"\$1\" = 'The TEST_RESULT is: PASS' ]" ]
+  [ "${lines[4]}" = 'ok 1 traced test case' ]
+}
+
+@test "trace a failing test case" {
+  TEST_RESULT='FAIL' run bats -x "$FIXTURE_ROOT/trace.bats"
+  [ "$status" -eq 1 ]
+  [ "${#lines[@]}" -eq 8 ]
+
+  local file="$RELATIVE_FIXTURE_ROOT/trace.bats"
+
+  [ "${lines[1]}" = \
+    "# $file:6: run printf 'The TEST_RESULT is: %s\n' \"\$TEST_RESULT\"" ]
+  [ "${lines[2]}" = "# $file:7: evaluate_result \"\$output\"" ]
+  [ "${lines[3]}" = "# $file:2: [ \"\$1\" = 'The TEST_RESULT is: PASS' ]" ]
+  [ "${lines[4]}" = 'not ok 1 traced test case' ]
+  [ "${lines[5]}" = \
+    "# (from function \`evaluate_result' in file $file, line 2," ]
+  [ "${lines[6]}" = "#  in test file $file, line 7)" ]
+  [ "${lines[7]}" = "#   \`evaluate_result \"\$output\"' failed" ]
+}

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -498,3 +498,30 @@ END_OF_ERR_MSG
   [ "${lines[6]}" = "#  in test file $file, line 7)" ]
   [ "${lines[7]}" = "#   \`evaluate_result \"\$output\"' failed" ]
 }
+
+@test "trace a test case calling a recursive function" {
+  run bats -x "$FIXTURE_ROOT/trace-recursive.bats"
+  emit_debug_output
+
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 17 ]
+
+  local file="$RELATIVE_FIXTURE_ROOT/trace-recursive.bats"
+
+  [ "${lines[1]}" = "# $file:16: do_recurse 2" ]
+  [ "${lines[2]}" = "# $file:2: local value=\"\$1\"" ]
+  [ "${lines[3]}" = "# $file:3: [[ \"\$value\" -eq 0 ]]" ]
+  [ "${lines[4]}" = "# $file:9: printf 'Recursing...\n'" ]
+  [ "${lines[5]}" = "# $file:10: printf 'Recursing...\n'" ]
+  [ "${lines[6]}" = "# $file:11: do_recurse \"\$((--value))\"" ]
+  [ "${lines[7]}" = "# $file:2: local value=\"\$1\"" ]
+  [ "${lines[8]}" = "# $file:3: [[ \"\$value\" -eq 0 ]]" ]
+  [ "${lines[9]}" = "# $file:9: printf 'Recursing...\n'" ]
+  [ "${lines[10]}" = "# $file:10: printf 'Recursing...\n'" ]
+  [ "${lines[11]}" = "# $file:11: do_recurse \"\$((--value))\"" ]
+  [ "${lines[12]}" = "# $file:2: local value=\"\$1\"" ]
+  [ "${lines[13]}" = "# $file:3: [[ \"\$value\" -eq 0 ]]" ]
+  [ "${lines[14]}" = "# $file:4: return" ]
+  [ "${lines[15]}" = "# $file:17: :" ]
+  [ "${lines[16]}" = "ok 1 traced test case with recursion" ]
+}

--- a/test/fixtures/bats/trace-recursive.bats
+++ b/test/fixtures/bats/trace-recursive.bats
@@ -1,0 +1,18 @@
+do_recurse() {
+  local value="$1"
+  if [[ "$value" -eq 0 ]]; then
+    return
+  else
+    # These statements validate that the first one isn't misinterpreted by
+    # bats_debug_trap as a failing command, since $? will be 1 and BASH_COMMAND
+    # will look identical, but on two successive lines.
+    printf 'Recursing...\n'
+    printf 'Recursing...\n'
+    do_recurse "$((--value))"
+  fi
+}
+
+@test "traced test case with recursion" {
+  do_recurse 2
+  :
+}

--- a/test/fixtures/bats/trace-recursive.bats
+++ b/test/fixtures/bats/trace-recursive.bats
@@ -4,8 +4,8 @@ do_recurse() {
     return
   else
     # These statements validate that the first one isn't misinterpreted by
-    # bats_debug_trap as a failing command, since $? will be 1 and BASH_COMMAND
-    # will look identical, but on two successive lines.
+    # bats_emit_trace as a failing command, since BASH_COMMAND will look
+    # identical, but on two successive lines.
     printf 'Recursing...\n'
     printf 'Recursing...\n'
     do_recurse "$((--value))"

--- a/test/fixtures/bats/trace.bats
+++ b/test/fixtures/bats/trace.bats
@@ -1,0 +1,8 @@
+evaluate_result() {
+  [ "$1" = 'The TEST_RESULT is: PASS' ]
+}
+
+@test "traced test case" {
+  run printf 'The TEST_RESULT is: %s\n' "$TEST_RESULT"
+  evaluate_result "$output"
+}


### PR DESCRIPTION
Closes #136. The final implementation will set the BATS_TRACE variable via a command-line flag, but setting `BATS_TRACE=1 bin/bats ...` will work.

This did require explicitly filtering out the line from `bats_perform_test` that executes the test case; somehow the `"$BATS_SOURCE" != "$1"` condition doesn't filter it. If I (or anyone else) can think of a cleaner way to filter out this line than quoting it directly, I'm all for it.

Two minor caveats:

- If a command fails, it will be printed twice. Then, of course, it'll appear in the failure output, for a total of three times.
- When using the pretty formatter, the first line of the trace from a test case will overlap with the line printing the name of the test case before execution begins.

Also, I still need to add tests, of course.

cc: @gtkramer

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
