### PR TITLE
Optimize stack trace capture

### DIFF
--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -100,34 +100,32 @@ bats_test_function() {
   BATS_TEST_NAMES+=("$test_name")
 }
 
-BATS_CURRENT_STACK_TRACE=()
+# Avoid a bug in Bash < 4.4-rc2 where "${BATS_CURRENT_STACK_TRACE[@]}" will
+# throw an unbound variable error when empty by initializing it with 'main'.
+BATS_CURRENT_STACK_TRACE=('main')
 BATS_PREVIOUS_STACK_TRACE=()
 BATS_ERROR_STACK_TRACE=()
 
 bats_capture_stack_trace() {
-  if [[ "${#BATS_CURRENT_STACK_TRACE[@]}" -ne 0 ]]; then
-    BATS_PREVIOUS_STACK_TRACE=("${BATS_CURRENT_STACK_TRACE[@]}")
-  fi
+  BATS_PREVIOUS_STACK_TRACE=("${BATS_CURRENT_STACK_TRACE[@]}")
   BATS_CURRENT_STACK_TRACE=()
 
-  local test_pattern=" $BATS_TEST_NAME $BATS_TEST_SOURCE"
-  local setup_pattern=" setup $BATS_TEST_SOURCE"
-  local teardown_pattern=" teardown $BATS_TEST_SOURCE"
-
-  local source_file
-  local frame
+  local test_file
+  local funcname
   local i
 
   for ((i=2; i != ${#FUNCNAME[@]}; ++i)); do
     # Use BATS_TEST_SOURCE if necessary to work around Bash < 4.4 bug whereby
     # calling an exported function erases the test file's BASH_SOURCE entry.
-    source_file="${BASH_SOURCE[$i]:-$BATS_TEST_SOURCE}"
-    frame="${BASH_LINENO[$((i-1))]} ${FUNCNAME[$i]} $source_file"
-    BATS_CURRENT_STACK_TRACE+=("$frame")
-    if [[ "$frame" == *"$test_pattern"     || \
-          "$frame" == *"$setup_pattern"    || \
-          "$frame" == *"$teardown_pattern" ]]; then
-      break
+    test_file="${BASH_SOURCE[$i]:-$BATS_TEST_SOURCE}"
+    funcname="${FUNCNAME[$i]}"
+    BATS_CURRENT_STACK_TRACE+=("${BASH_LINENO[$((i-1))]} $funcname $test_file")
+    if [[ "$test_file" == "$BATS_TEST_SOURCE" ]]; then
+      case "$funcname" in
+      "$BATS_TEST_NAME"|setup|teardown)
+        break
+        ;;
+      esac
     fi
   done
 }

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -80,7 +80,6 @@ teardown() {
   return 0
 }
 
-BATS_TEST_SKIPPED=''
 skip() {
   BATS_TEST_SKIPPED="${1:-1}"
   BATS_TEST_COMPLETED=1
@@ -100,26 +99,19 @@ bats_test_function() {
   BATS_TEST_NAMES+=("$test_name")
 }
 
-# Avoid a bug in Bash < 4.4-rc2 where "${BATS_CURRENT_STACK_TRACE[@]}" will
-# throw an unbound variable error when empty by initializing it with 'main'.
-BATS_CURRENT_STACK_TRACE=('main')
-BATS_PREVIOUS_STACK_TRACE=()
-BATS_ERROR_STACK_TRACE=()
-
 bats_capture_stack_trace() {
-  BATS_PREVIOUS_STACK_TRACE=("${BATS_CURRENT_STACK_TRACE[@]}")
-  BATS_CURRENT_STACK_TRACE=()
-
   local test_file
   local funcname
   local i
+
+  BATS_STACK_TRACE=()
 
   for ((i=2; i != ${#FUNCNAME[@]}; ++i)); do
     # Use BATS_TEST_SOURCE if necessary to work around Bash < 4.4 bug whereby
     # calling an exported function erases the test file's BASH_SOURCE entry.
     test_file="${BASH_SOURCE[$i]:-$BATS_TEST_SOURCE}"
     funcname="${FUNCNAME[$i]}"
-    BATS_CURRENT_STACK_TRACE+=("${BASH_LINENO[$((i-1))]} $funcname $test_file")
+    BATS_STACK_TRACE+=("${BASH_LINENO[$((i-1))]} $funcname $test_file")
     if [[ "$test_file" == "$BATS_TEST_SOURCE" ]]; then
       case "$funcname" in
       "$BATS_TEST_NAME"|setup|teardown)
@@ -228,6 +220,8 @@ bats_trim_filename() {
 bats_debug_trap() {
   if [[ "$BASH_SOURCE" != "$1" ]]; then
     bats_capture_stack_trace
+    BATS_LINENO="$BATS_CURRENT_LINENO"
+    BATS_CURRENT_LINENO="${BASH_LINENO[0]}"
   fi
 }
 
@@ -237,8 +231,8 @@ bats_debug_trap() {
 #
 # For this reason, we call `bats_error_trap` at the very beginning of
 # `bats_teardown_trap` (the `DEBUG` trap for the call will move
-# `BATS_CURRENT_STACK_TRACE` to `BATS_PREVIOUS_STACK_TRACE`) and check the value
-# of `$BATS_TEST_COMPLETED` before taking other actions. We also adjust the exit
+# `BATS_CURRENT_LINENO` to `BATS_LINENO`) and check the value of
+# `$BATS_TEST_COMPLETED` before taking other actions. We also adjust the exit
 # status value if needed.
 #
 # See `bats_exit_trap` for an additional EXIT error handling case when `$?`
@@ -250,7 +244,7 @@ bats_error_trap() {
     if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
       BATS_ERROR_STATUS=1
     fi
-    BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
+    BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
     trap - debug
   fi
 }
@@ -264,7 +258,6 @@ bats_teardown_trap() {
     BATS_TEARDOWN_COMPLETED=1
   elif [[ -n "$BATS_TEST_COMPLETED" ]]; then
     BATS_ERROR_STATUS="$status"
-    BATS_ERROR_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
   fi
 
   bats_exit_trap
@@ -284,7 +277,7 @@ bats_exit_trap() {
   fi
 
   if [[ -z "$BATS_TEST_COMPLETED" || -z "$BATS_TEARDOWN_COMPLETED" ]]; then
-    if [[ "${#BATS_ERROR_STACK_TRACE[@]}" -eq 0 ]]; then
+    if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
       # For some versions of bash, `$?` may not be set properly for some error
       # conditions before triggering the EXIT trap directly (see #72 and #81).
       # Thanks to the `BATS_TEARDOWN_COMPLETED` signal, this will pinpoint such
@@ -294,13 +287,12 @@ bats_exit_trap() {
       # If instead the test fails, and the `teardown()` error happens while
       # `bats_teardown_trap` runs as the EXIT trap, the test will fail with no
       # output, since there's no way to reach the `bats_exit_trap` call.
-      BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
+      BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
       BATS_ERROR_STATUS=1
     fi
     printf 'not ok %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
-    bats_print_stack_trace "${BATS_ERROR_STACK_TRACE[@]}" >&3
-    bats_print_failed_command \
-      "${BATS_ERROR_STACK_TRACE[${#BATS_ERROR_STACK_TRACE[@]}-1]}" \
+    bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
+    bats_print_failed_command "${BATS_STACK_TRACE[${#BATS_STACK_TRACE[@]}-1]}" \
       "$BATS_ERROR_STATUS" >&3
 
     while IFS= read -r line; do
@@ -345,7 +337,19 @@ bats_perform_test() {
       BATS_TEST_NUMBER=1
     fi
 
+    # Some versions of Bash will reset BASH_LINENO to the first line of the
+    # function when the ERR trap fires. All versions of Bash appear to reset it
+    # on an unbound variable access error. bats_debug_trap will fire both before
+    # the offending line is executed, and when the error is triggered.
+    # Consequently, we use `BATS_LINENO` to point to the line number seen by the
+    # first call to bats_debug_trap, _before_ the ERR trap or unbound variable
+    # access fires.
+    BATS_CURRENT_LINENO=0
+    BATS_LINENO=0
+    BATS_STACK_TRACE=()
+
     BATS_TEST_COMPLETED=
+    BATS_TEST_SKIPPED=
     BATS_TEARDOWN_COMPLETED=
     BATS_ERROR_STATUS=
     trap "bats_debug_trap \"\$BASH_SOURCE\"" debug

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -130,9 +130,6 @@ bats_capture_stack_trace() {
       break
     fi
   done
-
-  bats_frame_filename "${BATS_CURRENT_STACK_TRACE[0]}" 'BATS_SOURCE'
-  bats_frame_lineno "${BATS_CURRENT_STACK_TRACE[0]}" 'BATS_LINENO'
 }
 
 bats_print_stack_trace() {

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -157,8 +157,7 @@ bats_print_stack_trace() {
 }
 
 bats_print_failed_command() {
-  local frame="$1"
-  local status="$2"
+  local frame="${BATS_STACK_TRACE[${#BATS_STACK_TRACE[@]}-1]}"
   local filename
   local lineno
   local failed_line
@@ -170,10 +169,10 @@ bats_print_failed_command() {
   bats_strip_string "$failed_line" 'failed_command'
   printf '%s' "#   \`${failed_command}' "
 
-  if [[ $status -eq 1 ]]; then
+  if [[ "$BATS_ERROR_STATUS" -eq 1 ]]; then
     printf 'failed\n'
   else
-    printf 'failed with status %d\n' "$status"
+    printf 'failed with status %d\n' "$BATS_ERROR_STATUS"
   fi
 }
 
@@ -292,8 +291,7 @@ bats_exit_trap() {
     fi
     printf 'not ok %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
     bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
-    bats_print_failed_command "${BATS_STACK_TRACE[${#BATS_STACK_TRACE[@]}-1]}" \
-      "$BATS_ERROR_STATUS" >&3
+    bats_print_failed_command >&3
 
     while IFS= read -r line; do
       printf '# %s\n' "$line"


### PR DESCRIPTION
With these changes, the current test suite runs O(0.2s-0.3s) faster on a Mid 2015 Macbook Pro with a 2.5GHz Intel Core i7 with 16GB RAM. Not all of the optimizations have the same degree of impact, but all make the code a little less complex and a bit more readable.

Most notably, there is now only the `BATS_STACK_TRACE` variable, rather than `BATS_CURRENT_STACK_TRACE`, `BATS_PREVIOUS_STACK_TRACE`, and `BATS_ERROR_STACK_TRACE`. The only difference between the two previous stacks was the line number of the frame at the top of each. The stack trace is captured both before a command runs and after it triggers the `ERR` or `EXIT` trap.  Depending on the Bash version or type of error, the `BASH_LINENO` would change when capturing the second stack trace. We now manage that difference via `BATS_LINENO` and `BATS_CURRENT_LINENO`.

Note that these timings are a little different than the ones in the commit messages, since I rebooted the machine before collecting these in order to ensure there was as little interference as possible from other processes and memory pressure.

Bash 3.2.57(1)-release before:

```
  real    0m6.532s
  user    0m3.351s
  sys     0m1.939s
```

Bash 3.2.57(1)-release after:

```
  real    0m6.223s
  user    0m3.046s
  sys     0m1.934s
```

Bash 4.2.23(1)-release before:

```
  real    0m6.893s
  user    0m3.290s
  sys     0m2.069s
```

Bash 4.2.23(1)-release after:

```
  real    0m6.660s
  user    0m3.081s
  sys     0m2.053s
```

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
