### PR TITLE
Don't glob output

### DIFF
--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -32,7 +32,7 @@ load() {
 run() {
   trap bats_interrupt_trap_in_run INT
   local origFlags="$-"
-  set +eET
+  set -f +eET
   local origIFS="$IFS"
   # 'output', 'status', 'lines' are global variables available to tests.
   # shellcheck disable=SC2034

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -986,3 +986,18 @@ EOF
   [[ "${lines[5]}" == "# Received SIGINT, aborting ..." ]]
   [[ "${lines[6]}" == "# bats warning: Executed 2 instead of expected 1 tests" ]]
 }
+
+
+@test "single star in output is not treated as a glob" {
+  star(){ echo '*'; }
+  
+  run star
+  [ "${lines[0]}" = '*' ]
+}
+
+@test "multiple stars in output are not treated as a glob" {
+  stars(){ echo '**'; }
+  
+  run stars
+  [ "${lines[0]}" = '**' ]
+}


### PR DESCRIPTION
If the output contains shell metacharacters, like '*', it can get
mangled by shell globbing. Turn it off for test runs.

Signed-off-by: Horst H. von Brand <vonbrand@inf.utfsm.cl>

fixes #156, fixes #281

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
