### PR TITLE
Fix incorrect FD3 redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ service that will run indefinitely), Bats will be similarly blocked for the same
 amount of time.
 
 **To prevent this from happening, close FD 3 explicitly when running any command
-that may launch long-running child processes**, e.g. `command_name 3>- &`.
+that may launch long-running child processes**, e.g. `command_name 3>&- &`.
 
 ### Printing to the terminal
 


### PR DESCRIPTION
The proposed FD3 redirection in the README will create a file named "-" in the current directory.

- [ x ] I have reviewed the [Contributor Guidelines][contributor].
- [ x ] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
