### PR TITLE
bats: support parallel execution of tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ ARG bashver=latest
 
 FROM bash:${bashver}
 
-RUN ln -s /opt/bats/bin/bats /usr/sbin/bats
+# Install parallel and accept the citation notice (we aren't using this in a
+# context where it make sense to cite GNU Parallel).
+RUN apk add --no-cache parallel && \
+    mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 
+RUN ln -s /opt/bats/bin/bats /usr/sbin/bats
 COPY . /opt/bats/
 
 ENTRYPOINT ["bash", "/usr/sbin/bats"]

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ supports:
 
 ```
 Bats x.y.z
-Usage: bats [-cr] [-f <regex>] [-p | -t] <test>...
+Usage: bats [-cr] [-f <regex>] [-j <jobs>] [-p | -t] <test>...
        bats [-h | -v]
 
   <test> is the path to a Bats test file, or the path to a directory
@@ -188,6 +188,7 @@ Usage: bats [-cr] [-f <regex>] [-p | -t] <test>...
   -c, --count      Count the number of test cases without running any tests
   -f, --filter     Filter test cases by names matching the regular expression
   -h, --help       Display this help message
+  -j, --jobs       Number of parallel jobs to run (requires GNU parallel)
   -p, --pretty     Show results in pretty format (default for terminals)
   -r, --recursive  Include tests in subdirectories
   -t, --tap        Show results in TAP format
@@ -225,6 +226,21 @@ option.
     1..2
     ok 1 addition using bc
     ok 2 addition using dc
+
+### Parallel Execution
+
+By default, Bats will execute your tests serially. However, Bats supports
+parallel execution of tests (provided you have [GNU parallel][gnu-parallel] or
+a compatible replacement installed) using the `--jobs` parameter. This can
+result in your tests completing faster (depending on your tests and the testing
+hardware).
+
+Ordering of parallised tests is not guaranteed, so this mode may break suites
+with dependencies between tests (or tests that write to shared locations). When
+enabling `--jobs` for the first time be sure to re-run bats multiple times to
+identify any inter-test dependencies or non-deterministic test behaviour.
+
+[gnu-parallel]: https://www.gnu.org/software/parallel/
 
 ## Writing tests
 

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -20,7 +20,7 @@ usage() {
   while IFS= read -r line; do
     printf '%s\n' "$line"
   done <<END_OF_HELP_TEXT
-Usage: $cmd [-cr] [-f <regex>] [-p | -t] <test>...
+Usage: $cmd [-cr] [-f <regex>] [-j <jobs>] [-p | -t] <test>...
        $cmd [-h | -v]
 
   <test> is the path to a Bats test file, or the path to a directory
@@ -29,6 +29,7 @@ Usage: $cmd [-cr] [-f <regex>] [-p | -t] <test>...
   -c, --count      Count the number of test cases without running any tests
   -f, --filter     Filter test cases by names matching the regular expression
   -h, --help       Display this help message
+  -j, --jobs       Number of parallel jobs to run (requires GNU parallel)
   -p, --pretty     Show results in pretty format (default for terminals)
   -r, --recursive  Include tests in subdirectories
   -t, --tap        Show results in TAP format
@@ -111,6 +112,10 @@ while [[ "$#" -ne 0 ]]; do
   -f|--filter)
     shift
     flags+=('-f' "$1")
+    ;;
+  -j|--jobs)
+    shift
+    flags+=('-j' "$1")
     ;;
   -r|--recursive)
     recursive=1

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -39,6 +39,11 @@ Usage: $cmd [-cr] [-f <regex>] [-p | -t] <test>...
 END_OF_HELP_TEXT
 }
 
+expand_link() {
+  readlink="$(type -p greadlink readlink | head -1)"
+  "$readlink" -f "$1"
+}
+
 expand_path() {
   local path="${1%/}"
   local dirname="${path%/*}"
@@ -54,10 +59,11 @@ expand_path() {
   printf -v "$result" '%s/%s' "$dirname" "${path##*/}"
 }
 
+BATS_LIBEXEC="$(dirname "$(expand_link "$BASH_SOURCE")")"
 export BATS_CWD="$PWD"
 export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
 export BATS_TEST_FILTER=
-export PATH="$BATS_ROOT/libexec/bats-core:$PATH"
+export PATH="$BATS_LIBEXEC:$PATH"
 
 arguments=()
 

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -156,15 +156,11 @@ for filename in "${arguments[@]}"; do
   fi
 done
 
-if [[ "${#filenames[@]}" -eq 1 ]]; then
-  command='bats-exec-test'
-else
-  command='bats-exec-suite'
+formatter="cat"
+if [[ -n "$pretty" ]]; then
+  flags+=("-x")
+  formatter="bats-format-tap-stream"
 fi
 
 set -o pipefail execfail
-if [[ -z "$pretty" ]]; then
-  exec "$command" "${flags[@]}" "${filenames[@]}"
-else
-  exec "$command" -x "${flags[@]}" "${filenames[@]}" | bats-format-tap-stream
-fi
+exec bats-exec-suite "${flags[@]}" "${filenames[@]}" | "$formatter"

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -12,9 +12,9 @@ while [[ "$#" -ne 0 ]]; do
     count_only_flag=1
     ;;
   -f)
-    filter="$2"
-    flags+=('-f' "$filter")
     shift
+    filter="$1"
+    flags+=('-f' "$filter")
     ;;
   -x)
     extended_syntax_flag='-x'
@@ -29,53 +29,46 @@ done
 
 trap 'kill 0; exit 1' int
 
-count=0
+all_tests=()
 for filename in "$@"; do
-  while IFS= read -r line; do
-    if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
-      test_name="${BASH_REMATCH[1]#[\'\"]}"
-      test_name="${test_name%[\'\"]}"
-      if [[ -z "$filter" || "$test_name" =~ $filter ]]; then
-        ((++count))
-      fi
+  if  [[ ! -f "$filename" ]]; then
+    printf 'bats: %s does not exist\n' "$filename" >&2
+    exit 1
+  fi
+
+  test_names=()
+  test_dupes=()
+  while read -r line; do
+    if [[ ! "$line" =~ ^bats_test_function\  ]]; then
+      continue
     fi
-  done <"$filename"
+    line="${line%$'\r'}"
+    line="${line#* }"
+
+    all_tests+=( "$(printf "%s\t%s" "$filename" "$line")" )
+    if [[ " ${test_names[*]} " == *" $line "* ]]; then
+      test_dupes+=("$line")
+      continue
+    fi
+    test_names+=("$line")
+  done < <(BATS_TEST_FILTER="$filter" bats-preprocess "$filename")
+
+  if [[ "${#test_dupes[@]}" -ne 0 ]]; then
+    printf 'bats warning: duplicate test name(s) in %s: %s\n' "$filename" "${test_dupes[*]}" >&2
+  fi
 done
 
 if [[ -n "$count_only_flag" ]]; then
-  printf '%d\n' "$count"
+  printf '%d\n' "${#all_tests[@]}"
   exit
 fi
 
-printf '1..%d\n' "$count"
 status=0
-offset=0
-for filename in "$@"; do
-  index=0
-  {
-    IFS= read -r # 1..n
-    while IFS= read -r line; do
-      case "$line" in
-      'begin '* )
-        ((++index))
-        printf '%s\n' "${line/ $index / $(($offset + $index)) }"
-        ;;
-      'ok '* | 'not ok '* )
-        if [[ -z "$extended_syntax_flag" ]]; then
-          ((++index))
-        fi
-        printf '%s\n' "${line/ $index / $(($offset + $index)) }"
-        if [[ "${line:0:6}" == 'not ok' ]]; then
-          status=1
-        fi
-        ;;
-      * )
-        printf '%s\n' "$line"
-        ;;
-      esac
-    done
-  } < <( bats-exec-test "${flags[@]}" "$filename" )
-  offset=$(($offset + $index))
-done
+printf '1..%d\n' "${#all_tests[@]}"
 
+test_number=1
+while IFS=$'\t' read -r filename test_name; do
+  bats-exec-test "${flags[@]}" "$filename" "$test_name" "$test_number" || status=1
+  ((++test_number))
+done < <(printf '%s\n' "${all_tests[@]}" | grep -v '^$')
 exit "$status"

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -4,6 +4,8 @@ set -e
 count_only_flag=''
 extended_syntax_flag=''
 filter=''
+num_jobs=1
+have_gnu_parallel=
 flags=()
 
 while [[ "$#" -ne 0 ]]; do
@@ -16,6 +18,10 @@ while [[ "$#" -ne 0 ]]; do
     filter="$1"
     flags+=('-f' "$filter")
     ;;
+  -j)
+    shift
+    num_jobs="$1"
+    ;;
   -x)
     extended_syntax_flag='-x'
     flags+=('-x')
@@ -26,6 +32,13 @@ while [[ "$#" -ne 0 ]]; do
   esac
   shift
 done
+
+if ( type -p parallel &>/dev/null ); then
+  have_gnu_parallel=1
+elif [[ "$num_jobs" != 1 ]]; then
+  printf 'bats: cannot execute "%s" jobs without GNU parallel\n' "$num_jobs" >&2
+  exit 1
+fi
 
 trap 'kill 0; exit 1' int
 
@@ -66,9 +79,23 @@ fi
 status=0
 printf '1..%d\n' "${#all_tests[@]}"
 
-test_number=1
-while IFS=$'\t' read -r filename test_name; do
-  bats-exec-test "${flags[@]}" "$filename" "$test_name" "$test_number" || status=1
-  ((++test_number))
-done < <(printf '%s\n' "${all_tests[@]}" | grep -v '^$')
+# No point on continuing if there's no tests.
+if [[ "${#all_tests[@]}" == 0 ]]; then
+  exit
+fi
+
+if [[ "$num_jobs" != 1 ]]; then
+  # Only use GNU parallel when we want parallel execution -- there is a small
+  # amount of overhead using it over a simple loop in the serial case.
+  set -o pipefail
+  printf '%s\n' "${all_tests[@]}" | grep -v '^$' | \
+    parallel -qk -j "$num_jobs" --colsep="\t" -- bats-exec-test "${flags[@]}" '{1}' '{2}' '{#}' || status=1
+else
+  # Just do it serially.
+  test_number=1
+  while IFS=$'\t' read -r filename test_name; do
+    bats-exec-test "${flags[@]}" "$filename" "$test_name" "$test_number" || status=1
+    ((++test_number))
+  done < <(printf '%s\n' "${all_tests[@]}" | grep -v '^$')
+fi
 exit "$status"

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -5,22 +5,17 @@ BATS_COUNT_ONLY=''
 BATS_TEST_FILTER=''
 BATS_EXTENDED_SYNTAX=''
 
-# Command and flags used by bats_perform_tests when it re-invokes bats-exec-test
-# in a new process to run bats_perform_test.
-BATS_PERFORM_TEST_CMD=("$0")
-
 while [[ "$#" -ne 0 ]]; do
   case "$1" in
   -c)
     BATS_COUNT_ONLY=1
     ;;
   -f)
-    BATS_TEST_FILTER="$2"
     shift
+    BATS_TEST_FILTER="$1"
     ;;
   -x)
     BATS_EXTENDED_SYNTAX='-x'
-    BATS_PERFORM_TEST_CMD+=('-x')
     ;;
   *)
     break
@@ -30,14 +25,13 @@ while [[ "$#" -ne 0 ]]; do
 done
 
 BATS_TEST_FILENAME="$1"
+shift
 if [[ -z "$BATS_TEST_FILENAME" ]]; then
   printf 'usage: bats-exec-test <filename>\n' >&2
   exit 1
 elif [[ ! -f "$BATS_TEST_FILENAME" ]]; then
   printf 'bats: %s does not exist\n' "$BATS_TEST_FILENAME" >&2
   exit 1
-else
-  shift
 fi
 
 BATS_TEST_DIRNAME="${BATS_TEST_FILENAME%/*}"
@@ -310,58 +304,37 @@ bats_exit_trap() {
   exit "$status"
 }
 
-bats_perform_tests() {
-  local test_number=1
-  local status=0
-
-  printf '1..%d\n' "$#"
-
-  for test_name in "$@"; do
-    if ! "${BATS_PERFORM_TEST_CMD[@]}" "$BATS_TEST_FILENAME" "$test_name" \
-      "$test_number"; then
-      status=1
-    fi
-    ((++test_number))
-  done
-  exit "$status"
-}
-
 bats_perform_test() {
   BATS_TEST_NAME="$1"
-  if declare -F "$BATS_TEST_NAME" >/dev/null; then
-    BATS_TEST_NUMBER="$2"
-    if [[ -z "$BATS_TEST_NUMBER" ]]; then
-      printf '1..1\n'
-      BATS_TEST_NUMBER=1
-    fi
+  BATS_TEST_NUMBER="$2"
 
-    # Some versions of Bash will reset BASH_LINENO to the first line of the
-    # function when the ERR trap fires. All versions of Bash appear to reset it
-    # on an unbound variable access error. bats_debug_trap will fire both before
-    # the offending line is executed, and when the error is triggered.
-    # Consequently, we use `BATS_LINENO` to point to the line number seen by the
-    # first call to bats_debug_trap, _before_ the ERR trap or unbound variable
-    # access fires.
-    BATS_CURRENT_LINENO=0
-    BATS_LINENO=0
-    BATS_STACK_TRACE=()
-
-    BATS_TEST_COMPLETED=
-    BATS_TEST_SKIPPED=
-    BATS_TEARDOWN_COMPLETED=
-    BATS_ERROR_STATUS=
-    trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
-    trap 'bats_error_trap' err
-    trap 'bats_teardown_trap' exit
-    "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
-    BATS_TEST_COMPLETED=1
-    trap 'bats_exit_trap' exit
-    bats_teardown_trap
-
-  else
+  if ! declare -F "$BATS_TEST_NAME" &>/dev/null; then
     printf "bats: unknown test name \`%s'\n" "$BATS_TEST_NAME" >&2
     exit 1
   fi
+
+  # Some versions of Bash will reset BASH_LINENO to the first line of the
+  # function when the ERR trap fires. All versions of Bash appear to reset it
+  # on an unbound variable access error. bats_debug_trap will fire both before
+  # the offending line is executed, and when the error is triggered.
+  # Consequently, we use `BATS_LINENO` to point to the line number seen by the
+  # first call to bats_debug_trap, _before_ the ERR trap or unbound variable
+  # access fires.
+  BATS_CURRENT_LINENO=0
+  BATS_LINENO=0
+  BATS_STACK_TRACE=()
+
+  BATS_TEST_COMPLETED=
+  BATS_TEST_SKIPPED=
+  BATS_TEARDOWN_COMPLETED=
+  BATS_ERROR_STATUS=
+  trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
+  trap 'bats_error_trap' err
+  trap 'bats_teardown_trap' exit
+  "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
+  BATS_TEST_COMPLETED=1
+  trap 'bats_exit_trap' exit
+  bats_teardown_trap
 }
 
 if [[ -z "$TMPDIR" ]]; then
@@ -376,40 +349,13 @@ BATS_OUT="${BATS_TMPNAME}.out"
 
 bats_preprocess_source() {
   BATS_TEST_SOURCE="${BATS_TMPNAME}.src"
-  . bats-preprocess <<< "$(< "$BATS_TEST_FILENAME")"$'\n' > "$BATS_TEST_SOURCE"
+  bats-preprocess "$BATS_TEST_FILENAME" >"$BATS_TEST_SOURCE"
   trap 'bats_cleanup_preprocessed_source' err exit
   trap 'bats_cleanup_preprocessed_source; exit 1' int
-
-  bats_detect_duplicate_test_case_names
 }
 
 bats_cleanup_preprocessed_source() {
   rm -f "$BATS_TEST_SOURCE"
-}
-
-bats_detect_duplicate_test_case_names() {
-  local test_names=()
-  local test_dupes=()
-  local line
-
-  while read -r line; do
-    if [[ ! "$line" =~ ^bats_test_function\  ]]; then
-      continue
-    fi
-    line="${line%$'\r'}"
-    line="${line#* }"
-
-    if [[ " ${test_names[*]} " == *" $line "* ]]; then
-      test_dupes+=("$line")
-      continue
-    fi
-    test_names+=("$line")
-  done <"$BATS_TEST_SOURCE"
-
-  if [[ "${#test_dupes[@]}" -ne 0 ]]; then
-    printf 'bats warning: duplicate test name(s) in %s: %s\n' \
-      "$BATS_TEST_FILENAME" "${test_dupes[*]}" >&2
-  fi
 }
 
 bats_evaluate_preprocessed_source() {
@@ -421,20 +367,7 @@ bats_evaluate_preprocessed_source() {
 
 exec 3<&1
 
-# When bats-exec-test is invoked by bats or bats-exec-suite, bats_perform_tests
-# reinvokes bats-exec-suite to run a single test case via bats_perform_test in a
-# new process. This is necessary so that `set -e` and all the traps set by
-# `bats_perform_test` don't interfere with the parent bats-exec-test process.
-if [[ "$#" -eq 0 ]]; then
-  bats_preprocess_source
-  bats_evaluate_preprocessed_source
-
-  if [[ -n "$BATS_COUNT_ONLY" ]]; then
-    printf '%d\n' "${#BATS_TEST_NAMES[@]}"
-  else
-    bats_perform_tests "${BATS_TEST_NAMES[@]}"
-  fi
-else
-  bats_evaluate_preprocessed_source
-  bats_perform_test "$@"
-fi
+# Run the given test.
+bats_preprocess_source
+bats_evaluate_preprocessed_source
+bats_perform_test "$@"

--- a/libexec/bats-core/bats-preprocess
+++ b/libexec/bats-core/bats-preprocess
@@ -31,24 +31,27 @@ bats_encode_test_name() {
   printf -v "$2" '%s' "$result"
 }
 
+test_file="$1"
 tests=()
 
-while IFS= read -r line; do
-  line="${line//$'\r'}"
-  if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
-    name="${BASH_REMATCH[1]#[\'\"]}"
-    name="${name%[\'\"]}"
-    body="${BASH_REMATCH[2]}"
-    bats_encode_test_name "$name" 'encoded_name'
-    printf '%s() { bats_test_begin "%s"; %s\n' "$encoded_name" "$name" "$body"
+{
+  while IFS= read -r line; do
+    line="${line//$'\r'}"
+    if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
+      name="${BASH_REMATCH[1]#[\'\"]}"
+      name="${name%[\'\"]}"
+      body="${BASH_REMATCH[2]}"
+      bats_encode_test_name "$name" 'encoded_name'
+      printf '%s() { bats_test_begin "%s"; %s\n' "$encoded_name" "$name" "$body" || :
 
-    if [[ -z "$BATS_TEST_FILTER" || "$name" =~ $BATS_TEST_FILTER ]]; then
-      tests+=("$encoded_name")
+      if [[ -z "$BATS_TEST_FILTER" || "$name" =~ $BATS_TEST_FILTER ]]; then
+        tests+=("$encoded_name")
+      fi
+    else
+      printf '%s\n' "$line"
     fi
-  else
-    printf '%s\n' "$line"
-  fi
-done
+  done
+} <<< "$(< "$test_file")"$'\n'
 
 for test_name in "${tests[@]}"; do
   printf 'bats_test_function %s\n' "$test_name"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -263,7 +263,8 @@ fixtures bats
 }
 
 @test "extended syntax" {
-  run bats-exec-test -x "$FIXTURE_ROOT/failing_and_passing.bats"
+  emulate_bats_env
+  run bats-exec-suite -x "$FIXTURE_ROOT/failing_and_passing.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'begin 1 a failing test' ]
   [ "${lines[2]}" = 'not ok 1 a failing test' ]

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -467,3 +467,19 @@ END_OF_ERR_MSG
   [ "${lines[5]}" = '# bar' ]
   [ "${lines[6]}" = '# baz' ]
 }
+
+@test "parallel test execution with --jobs" {
+  type -p parallel &>/dev/null || skip "--jobs requires GNU parallel"
+
+  SECONDS=0
+  run bats --jobs 10 "$FIXTURE_ROOT/parallel.bats"
+  duration="$SECONDS"
+  [ "$status" -eq 0 ]
+  # Make sure the lines are in-order.
+  [[ "${lines[0]}" == "1..10" ]]
+  for t in {1..10}; do
+    [[ "${lines[$t]}" == "ok $t slow test $t" ]]
+  done
+  # In theory it should take 3s, but let's give it bit of extra time instead.
+  [[ "$duration" -lt 20 ]]
+}

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -284,10 +284,10 @@ fixtures bats
 }
 
 @test "pretty formatter bails on invalid tap" {
-  run bats --tap "$FIXTURE_ROOT/invalid_tap.bats"
-  [ $status -eq 1 ]
-  [ "${lines[0]}" = "This isn't TAP!" ]
-  [ "${lines[1]}" = "Good day to you" ]
+  run bats-format-tap-stream < <(printf "This isn't TAP.\nGood day to you.\n")
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "This isn't TAP." ]
+  [ "${lines[1]}" = "Good day to you." ]
 }
 
 @test "single-line tests" {

--- a/test/fixtures/bats/invalid_tap.bats
+++ b/test/fixtures/bats/invalid_tap.bats
@@ -1,7 +1,0 @@
-echo "This isn't TAP!"
-echo "Good day to you"
-exit 1
-
-@test "truth" {
-  true
-}

--- a/test/fixtures/bats/parallel.bats
+++ b/test/fixtures/bats/parallel.bats
@@ -1,0 +1,39 @@
+@test "slow test 1" {
+  sleep 3s
+}
+
+@test "slow test 2" {
+  sleep 3s
+}
+
+@test "slow test 3" {
+  sleep 3s
+}
+
+@test "slow test 4" {
+  sleep 3s
+}
+
+@test "slow test 5" {
+  sleep 3s
+}
+
+@test "slow test 6" {
+  sleep 3s
+}
+
+@test "slow test 7" {
+  sleep 3s
+}
+
+@test "slow test 8" {
+  sleep 3s
+}
+
+@test "slow test 9" {
+  sleep 3s
+}
+
+@test "slow test 10" {
+  sleep 3s
+}

--- a/test/fixtures/suite/parallel/parallel1.bats
+++ b/test/fixtures/suite/parallel/parallel1.bats
@@ -1,0 +1,1 @@
+../../bats/parallel.bats

--- a/test/fixtures/suite/parallel/parallel2.bats
+++ b/test/fixtures/suite/parallel/parallel2.bats
@@ -1,0 +1,1 @@
+../../bats/parallel.bats

--- a/test/fixtures/suite/parallel/parallel3.bats
+++ b/test/fixtures/suite/parallel/parallel3.bats
@@ -1,0 +1,1 @@
+../../bats/parallel.bats

--- a/test/fixtures/suite/parallel/parallel4.bats
+++ b/test/fixtures/suite/parallel/parallel4.bats
@@ -1,0 +1,1 @@
+../../bats/parallel.bats

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -52,6 +52,7 @@ fixtures suite
 }
 
 @test "extended syntax in suite" {
+  emulate_bats_env
   FLUNK=1 run bats-exec-suite -x "$FIXTURE_ROOT/multiple/"*.bats
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..3" ]

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -126,3 +126,23 @@ fixtures suite
   [ "${lines[1]}" = 'ok 1 baz in a' ]
   [ "${lines[2]}" = 'ok 2 bar_in_b' ]
 }
+
+@test "parallel suite execution with --jobs" {
+  type -p parallel &>/dev/null || skip "--jobs requires GNU parallel"
+
+  SECONDS=0
+  run bats --jobs 40 "$FIXTURE_ROOT/parallel"
+  duration="$SECONDS"
+  [ "$status" -eq 0 ]
+  # Make sure the lines are in-order.
+  [[ "${lines[0]}" == "1..40" ]]
+  i=0
+  for s in {1..4}; do
+    for t in {1..10}; do
+      ((++i))
+      [[ "${lines[$i]}" == "ok $i slow test $t" ]]
+    done
+  done
+  # In theory it should take 3s, but let's give it bit of extra time instead.
+  [[ "$duration" -lt 20 ]]
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,3 +1,9 @@
+emulate_bats_env() {
+  export BATS_CWD="$PWD"
+  export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
+  export BATS_TEST_FILTER=
+}
+
 fixtures() {
   FIXTURE_ROOT="$BATS_TEST_DIRNAME/fixtures/$1"
   RELATIVE_FIXTURE_ROOT="${FIXTURE_ROOT#$BATS_CWD/}"


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

This allows for tests to be run in parallel, by using GNU parallel (if
available). It's a fairly trivial extension (though it required a fair
amount of work in order for it to be usable).

Most well-behaved bats tests (where they aren't writing to shared data
between test executions) are able to be executed in parallel, but to
date bats has always executed them in serial. This is incredibly
wasteful for trivially parallelisable tests, and can result in fairly
inflated test times for no good reason. Parallel exeuction is done
suite-wide, so it makes no difference how the tests are structured.
    
Unfortunately, because some suites might be implicitly serial (like
bats' own test suite) we cannot make the default mode execute in
parallel. In addition, there is currently no way of tagging that a
*specific* test has to be run in serial (so that the rest can be run in
parallel) -- but that can be done in future work.

Fixes #171 
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]: https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md