### PR TITLE
fix doc error in fd 3 redirect-and-close example (fixes #176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ service that will run indefinitely), Bats will be similarly blocked for the same
 amount of time.
 
 **To prevent this from happening, close FD 3 explicitly when running any command
-that may launch long-running child processes**, e.g. `command_name 3>- &`.
+that may launch long-running child processes**, e.g. `command_name 3>&-` .
 
 ### Printing to the terminal
 


### PR DESCRIPTION
Fixes documentation error regarding https://github.com/bats-core/bats-core#file-descriptor-3-read-this-if-bats-hangs at https://github.com/bats-core/bats-core/issues/176 
(closes #176)

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
