### PR TITLE
test: add Bash 5 as test target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,10 @@ services:
 
 script:
 - |
-  set -e
   if [[ "${TRAVIS_OS_NAME:-}" == 'linux' && -n "${BASHVER}" ]]; then
-    docker build --build-arg bashver="${BASHVER}" --tag "bats/bats:bash-${BASHVER}" .
-    docker run -it "bash:${BASHVER}" --version
-    time docker run -it "bats/bats:bash-${BASHVER}" --tap /opt/bats/test
+    docker build --build-arg bashver="${BASHVER}" --tag "bats/bats:bash-${BASHVER}" . &&
+      docker run -it "bash:${BASHVER}" --version &&
+      time docker run -it "bats/bats:bash-${BASHVER}" --tap /opt/bats/test
   else
     time bin/bats --tap test
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - BASHVER=4.2
   - BASHVER=4.3
   - BASHVER=4.4
+  - BASHVER=5
 
 matrix:
   include:
@@ -21,10 +22,11 @@ services:
 
 script:
 - |
-  if [[ "$TRAVIS_OS_NAME" == 'linux' && -n "$BASHVER" ]]; then
-    docker build --build-arg bashver=${BASHVER} --tag bats/bats:bash-${BASHVER} .
-    docker run -it bash:${BASHVER} --version
-    time docker run -it bats/bats:bash-${BASHVER} --tap /opt/bats/test
+  set -e
+  if [[ "${TRAVIS_OS_NAME:-}" == 'linux' && -n "${BASHVER}" ]]; then
+    docker build --build-arg bashver="${BASHVER}" --tag "bats/bats:bash-${BASHVER}" .
+    docker run -it "bash:${BASHVER}" --version
+    time docker run -it "bats/bats:bash-${BASHVER}" --tap /opt/bats/test
   else
     time bin/bats --tap test
   fi


### PR DESCRIPTION
This PR adds the stable Bash 5 release.

It also corrects variable quoting inconsistencies, and adds `set -e` to the test script in case of a failure to build the image. This is documented as a [possible breaking flag to Travis (?!)](https://docs.travis-ci.com/user/common-build-problems/#my-build-fails-unexpectedly) but passes happily in my tests.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
