### PR TITLE
Fix link resolution for bats

### DIFF
--- a/bin/bats
+++ b/bin/bats
@@ -3,42 +3,71 @@
 set -e
 
 BATS_READLINK='true'
+BATS_REALPATH=''
 if command -v 'greadlink' >/dev/null; then
   BATS_READLINK='greadlink'
 elif command -v 'readlink' >/dev/null; then
   BATS_READLINK='readlink'
 fi
 
+set +e
+if ! $BATS_READLINK -m $0 &>/dev/null; then
+  BATS_REALPATH='realpath'
+fi
+set -e
+
+resolve_path() {
+  local path_to_bats=$1
+  local target_path;
+
+  if [[ -L "$path_to_bats" ]]; then
+    # Busybox has no readlink from coreutils
+    if [[ ! -z "$BATS_REALPATH" ]]; then
+      target_path="$("$BATS_REALPATH" "$path_to_bats")"
+      # we need to traverse the paths
+      target_path="$(dirname "$target_path")" # strip bats
+      target_path="$(dirname "$target_path")" # strip bin
+    else
+      target_path="$("$BATS_READLINK" -m "$path_to_bats/../../")"
+    fi
+  elif [[ -f "$path_to_bats" ]]; then
+    target_path=$(dirname "$path_to_bats");
+    if [[ ! -z "$BATS_REALPATH" ]]; then
+      target_path="$("$BATS_REALPATH" "$target_path")"
+    else
+      target_path="$("$BATS_READLINK" -m "$target_path")"
+    fi
+    target_path="$(dirname "$target_path")" # strip bin
+  elif [[ -d $path_to_bats ]]; then
+    if [[ ! -z "$BATS_REALPATH" ]]; then
+      target_path="$("$BATS_REALPATH" "$path_to_bats")"
+      target_path="$(dirname "$target_path")"
+    else
+      target_path="$("$BATS_READLINK" -m "$path_to_bats/../")"
+    fi
+  fi
+
+  echo "$target_path";
+}
+
 bats_resolve_absolute_root_dir() {
   local cwd="$PWD"
-  local path="$1"
+  local path_to_bats="$1"
   local result="$2"
-  local target_dir
-  local target_name
-  local original_shell_options="$-"
+  local target_path
 
-  # Resolve the parent directory, e.g. /bin => /usr/bin on CentOS (#113).
-  set -P
+  if [[ "$path_to_bats" = $(basename $1) ]] ; then
+    path_to_bats=$(type -p "$path_to_bats")
+  fi
 
-  while true; do
-    target_dir="${path%/*}"
-    target_name="${path##*/}"
-
-    if [[ "$target_dir" != "$path" ]]; then
-      cd "$target_dir"
-    fi
-
-    if [[ -L "$target_name" ]]; then
-      path="$("$BATS_READLINK" "$target_name")"
-    else
-      printf -v "$result" -- '%s' "${PWD%/*}"
-      set +P "-$original_shell_options"
-      cd "$cwd"
-      return
-    fi
-  done
+  target_path="$(resolve_path $path_to_bats)"
+  if [[ "$target_path" == '.' ]];
+  then
+    target_path="$(resolve_path "$target_path")"
+  fi
+  printf -v "$result" -- '%s' "$target_path"
 }
 
 export BATS_ROOT
 bats_resolve_absolute_root_dir "$0" 'BATS_ROOT'
-exec "$BATS_ROOT/libexec/bats-core/bats" "$@"
+exec env BATS_ROOT="$BATS_ROOT" "$BATS_ROOT/libexec/bats-core/bats" "$@"

--- a/bin/bats
+++ b/bin/bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 BATS_READLINK='true'
 BATS_REALPATH=''
@@ -10,17 +10,15 @@ elif command -v 'readlink' >/dev/null; then
   BATS_READLINK='readlink'
 fi
 
-set +e
-if ! $BATS_READLINK -m $0 &>/dev/null; then
+if ! "${BATS_READLINK}" -m $0 &>/dev/null; then
   BATS_REALPATH='realpath'
 fi
-set -e
 
 resolve_path() {
   local path_to_bats=$1
-  local target_path;
+  local target_path
 
-  if [[ -L "$path_to_bats" ]]; then
+  if [[ -L "${path_to_bats}" ]]; then
     # Busybox has no readlink from coreutils
     if [[ ! -z "$BATS_REALPATH" ]]; then
       target_path="$("$BATS_REALPATH" "$path_to_bats")"
@@ -30,15 +28,15 @@ resolve_path() {
     else
       target_path="$("$BATS_READLINK" -m "$path_to_bats/../../")"
     fi
-  elif [[ -f "$path_to_bats" ]]; then
-    target_path=$(dirname "$path_to_bats");
+  elif [[ -f "${path_to_bats}" ]]; then
+    target_path=$(dirname "$path_to_bats")
     if [[ ! -z "$BATS_REALPATH" ]]; then
       target_path="$("$BATS_REALPATH" "$target_path")"
     else
       target_path="$("$BATS_READLINK" -m "$target_path")"
     fi
     target_path="$(dirname "$target_path")" # strip bin
-  elif [[ -d $path_to_bats ]]; then
+  elif [[ -d "${path_to_bats}" ]]; then
     if [[ ! -z "$BATS_REALPATH" ]]; then
       target_path="$("$BATS_REALPATH" "$path_to_bats")"
       target_path="$(dirname "$target_path")"
@@ -47,22 +45,20 @@ resolve_path() {
     fi
   fi
 
-  echo "$target_path";
+  echo "$target_path"
 }
 
 bats_resolve_absolute_root_dir() {
-  local cwd="$PWD"
   local path_to_bats="$1"
   local result="$2"
   local target_path
 
-  if [[ "$path_to_bats" = $(basename $1) ]] ; then
+  if [[ "$path_to_bats" == "$(basename "${path_to_bats}")" ]]; then
     path_to_bats=$(type -p "$path_to_bats")
   fi
 
-  target_path="$(resolve_path $path_to_bats)"
-  if [[ "$target_path" == '.' ]];
-  then
+  target_path=$(resolve_path "${path_to_bats}")
+  if [[ "$target_path" == '.' ]]; then
     target_path="$(resolve_path "$target_path")"
   fi
   printf -v "$result" -- '%s' "$target_path"


### PR DESCRIPTION
This rewrites the old logic a bit by using `type -p`, `readlink -m`  and
on boxes where we don't have coreutils like `readlink` we use `realpath`
to figure out the correct installation directory of bats.

I've also changes the path of the symbolic link so it works on the
default bash image without having sbin (bats isn't a sbin kinda thing).

Also fixes GH#182

Signed-off-by: Wesley Schwengle <wesley@schwengle.net>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
