### PR TITLE
fix bats.bats test about strict mode

### DIFF
--- a/test/bats.bats
+++ b/test/bats.bats
@@ -322,12 +322,12 @@ fixtures bats
   [ "${lines[3]}" = "ok 3 unquoted name" ]
 }
 
-@test 'ensure compatibility with unofficial Bash strict mode' {
+@test "ensure compatibility with unofficial Bash strict mode" {
   local expected='ok 1 unofficial Bash strict mode conditions met'
 
   # Run Bats under `set -u` to catch as many unset variable accesses as
   # possible.
-  run bash -u "${BATS_TEST_DIRNAME%/*}/bin/bats" \
+  run bash -u bats \
     "$FIXTURE_ROOT/unofficial_bash_strict_mode.bats"
   if [[ "$status" -ne 0 || "${lines[1]}" != "$expected" ]]; then
     cat <<END_OF_ERR_MSG


### PR DESCRIPTION
Run bats, instead of hardcoding a relative path to a binary which might not be there.

This helps to run the tests out of source and to test an installed binary.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

This refs #202 
