### PR TITLE
Always use upper case signal names to avoid locale dependent errors

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -336,6 +336,21 @@ The following are intended to prevent too-compact code:
 
 [printf-vs-echo]: https://unix.stackexchange.com/a/65819
 
+### Signal names
+
+Always use upper case signal names (e.g. `trap - INT EXIT`) to avoid locale 
+dependent errors. In some locales (for example Turkish, see 
+[Turkish dotless i](https://en.wikipedia.org/wiki/Dotted_and_dotless_I)) lower 
+case signal names cause Bash to error. An example of the problem:
+
+```bash
+$ echo "tr_TR.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen tr_TR.UTF-8 # Ubuntu derivatives
+$ LC_CTYPE=tr_TR.UTF-8 LC_MESSAGES=C bash -c 'trap - int && echo success'
+bash: line 0: trap: int: invalid signal specification
+$ LC_CTYPE=tr_TR.UTF-8 LC_MESSAGES=C bash -c 'trap - INT && echo success'
+success
+```
+
 ### Gotchas
 
 - If you wish to use command substitution to initialize a `local` variable, and

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -40,7 +40,7 @@ elif [[ "$num_jobs" != 1 ]]; then
   exit 1
 fi
 
-trap 'kill 0; exit 1' int
+trap 'kill 0; exit 1' INT
 
 all_tests=()
 for filename in "$@"; do

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -238,7 +238,7 @@ bats_error_trap() {
       BATS_ERROR_STATUS=1
     fi
     BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
-    trap - debug
+    trap - DEBUG
   fi
 }
 
@@ -260,7 +260,7 @@ bats_exit_trap() {
   local line
   local status
   local skipped=''
-  trap - err exit
+  trap - ERR EXIT
 
   if [[ -n "$BATS_TEST_SKIPPED" ]]; then
     skipped=' # skip'
@@ -328,12 +328,12 @@ bats_perform_test() {
   BATS_TEST_SKIPPED=
   BATS_TEARDOWN_COMPLETED=
   BATS_ERROR_STATUS=
-  trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
-  trap 'bats_error_trap' err
-  trap 'bats_teardown_trap' exit
+  trap "bats_debug_trap \"\$BASH_SOURCE\"" DEBUG
+  trap 'bats_error_trap' ERR
+  trap 'bats_teardown_trap' EXIT
   "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
   BATS_TEST_COMPLETED=1
-  trap 'bats_exit_trap' exit
+  trap 'bats_exit_trap' EXIT
   bats_teardown_trap
 }
 
@@ -350,8 +350,8 @@ BATS_OUT="${BATS_TMPNAME}.out"
 bats_preprocess_source() {
   BATS_TEST_SOURCE="${BATS_TMPNAME}.src"
   bats-preprocess "$BATS_TEST_FILENAME" >"$BATS_TEST_SOURCE"
-  trap 'bats_cleanup_preprocessed_source' err exit
-  trap 'bats_cleanup_preprocessed_source; exit 1' int
+  trap 'bats_cleanup_preprocessed_source' ERR EXIT
+  trap 'bats_cleanup_preprocessed_source; exit 1' INT
 }
 
 bats_cleanup_preprocessed_source() {


### PR DESCRIPTION
Lower case signal names cause errors under Turkish locale (see [Turkish dotless i](https://en.wikipedia.org/wiki/Dotted_and_dotless_I) for the reasons).  Reproduce the issue:

```sh
$ locale-gen tr_TR.UTF-8 # Ubuntu derivatives
$ LC_CTYPE=tr_TR.UTF-8 LC_MESSAGES=C bash -c 'trap - int'
bash: line 0: trap: int: invalid signal specification
```

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md