### PR TITLE
Add LAVA integration

### DIFF
--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -20,7 +20,7 @@ usage() {
   while IFS= read -r line; do
     printf '%s\n' "$line"
   done <<END_OF_HELP_TEXT
-Usage: $cmd [-cr] [-f <regex>] [-j <jobs>] [-p | -t] <test>...
+Usage: $cmd [-cr] [-f <regex>] [-j <jobs>] [-p | -t | -l] <test>...
        $cmd [-h | -v]
 
   <test> is the path to a Bats test file, or the path to a directory
@@ -33,6 +33,7 @@ Usage: $cmd [-cr] [-f <regex>] [-j <jobs>] [-p | -t] <test>...
   -p, --pretty     Show results in pretty format (default for terminals)
   -r, --recursive  Include tests in subdirectories
   -t, --tap        Show results in TAP format
+  -l, --lava       Show results with LAVA signals
   -v, --version    Display the version number
 
   For more information, see https://github.com/bats-core/bats-core
@@ -87,9 +88,10 @@ done
 set -- "${arguments[@]}"
 arguments=()
 
-unset flags pretty recursive
+unset flags pretty lava recursive
 flags=()
 pretty=
+lava=
 recursive=
 if [[ -z "${CI:-}" && -t 0 && -t 1 ]] && command -v tput >/dev/null; then
   pretty=1
@@ -122,9 +124,15 @@ while [[ "$#" -ne 0 ]]; do
     ;;
   -t|--tap)
     pretty=
+    lava=
     ;;
   -p|--pretty)
     pretty=1
+    lava=
+    ;;
+  -l|--lava)
+    pretty=
+    lava=1
     ;;
   -*)
     abort "Bad command line option '$1'"
@@ -165,6 +173,8 @@ formatter="cat"
 if [[ -n "$pretty" ]]; then
   flags+=("-x")
   formatter="bats-format-tap-stream"
+elif [[ -n "$lava" ]]; then
+  flags+=("-l")
 fi
 
 set -o pipefail execfail

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -26,6 +26,9 @@ while [[ "$#" -ne 0 ]]; do
     extended_syntax_flag='-x'
     flags+=('-x')
     ;;
+  -l)
+    flags+=('-l')
+    ;;
   *)
     break
     ;;

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -4,6 +4,7 @@ set -eET
 BATS_COUNT_ONLY=''
 BATS_TEST_FILTER=''
 BATS_EXTENDED_SYNTAX=''
+BATS_LAVA_SYNTAX=''
 
 while [[ "$#" -ne 0 ]]; do
   case "$1" in
@@ -16,6 +17,9 @@ while [[ "$#" -ne 0 ]]; do
     ;;
   -x)
     BATS_EXTENDED_SYNTAX='-x'
+    ;;
+  -l)
+    BATS_LAVA_SYNTAX='-l'
     ;;
   *)
     break
@@ -84,8 +88,16 @@ bats_test_begin() {
   BATS_TEST_DESCRIPTION="$1"
   if [[ -n "$BATS_EXTENDED_SYNTAX" ]]; then
     printf 'begin %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
+  elif [[ -n "$BATS_LAVA_SYNTAX" ]]; then
+    printf '\n<LAVA_SIGNAL_STARTTC %s>\n' "$BATS_TEST_DESCRIPTION" >&3
   fi
   setup
+}
+
+bats_test_end() {
+  if [[ -n "$BATS_LAVA_SYNTAX" ]]; then
+    printf '\n<LAVA_SIGNAL_ENDTC %s>\n' "$BATS_TEST_DESCRIPTION" >&3
+  fi
 }
 
 bats_test_function() {
@@ -283,7 +295,11 @@ bats_exit_trap() {
       BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
       BATS_ERROR_STATUS=1
     fi
-    printf 'not ok %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
+    if [[ -z "$BATS_LAVA_SYNTAX" ]]; then
+      printf 'not ok %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
+    else
+      printf '\n<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s result=fail>\n' "$BATS_TEST_DESCRIPTION" >&3
+    fi
     bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
     bats_print_failed_command >&3
 
@@ -295,8 +311,19 @@ bats_exit_trap() {
     fi
     status=1
   else
-    printf 'ok %d %s%s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" \
+    if [[ -z "$BATS_LAVA_SYNTAX" ]]; then
+      printf 'ok %d %s%s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" \
       "$skipped" >&3
+    else
+      # It is valid to have a measurement without units, but not a units without a measuremnt
+      if [[ "$measurement" != "" ]] && [[ "$units" != "" ]]; then
+        printf '\n<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s MEASUREMENT=%s UNITS=%s>\n' "$BATS_TEST_DESCRIPTION" "$measurement" "$units" >&3
+      elif [[ "$measurement" != "" ]]; then
+        printf '\n<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s MEASUREMENT=%s>\n' "$BATS_TEST_DESCRIPTION" "$measurement" >&3
+      else
+        printf '\n<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s result=pass>\n' "$BATS_TEST_DESCRIPTION" >&3
+      fi
+    fi
     status=0
   fi
 
@@ -332,6 +359,7 @@ bats_perform_test() {
   trap 'bats_error_trap' err
   trap 'bats_teardown_trap' exit
   "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
+  bats_test_end >>"$BATS_OUT" 2>&1
   BATS_TEST_COMPLETED=1
   trap 'bats_exit_trap' exit
   bats_teardown_trap

--- a/man/bats.1
+++ b/man/bats.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BATS" "1" "July 2018" "" ""
+.TH "BATS" "1" "April 2019" "" ""
 .
 .SH "NAME"
 \fBbats\fR \- Bash Automated Testing System
@@ -60,6 +60,10 @@ Include tests in subdirectories
 Show results in TAP format
 .
 .TP
+\fB\-l\fR, \fB\-\-lava\fR
+Show results in LAVA format
+.
+.TP
 \fB\-v\fR, \fB\-\-version\fR
 Display the version number
 .
@@ -81,7 +85,7 @@ $ bats addition\.bats
 .IP "" 0
 .
 .P
-If Bats is not connected to a terminal\-\-in other words, if you run it from a continuous integration system or redirect its output to a file\-\-the results are displayed in human\-readable, machine\-parsable TAP format\. You can force TAP output from a terminal by invoking Bats with the \fB\-\-tap\fR option\.
+If Bats is not connected to a terminal\-\-in other words, if you run it from a continuous integration system or redirect its output to a file\-\-the results are displayed in human\-readable, machine\-parsable TAP format, unless the \fB\-\-lava\fR option is used\. You can force TAP output from a terminal by invoking Bats with the \fB\-\-tap\fR option\. Similarly, LAVA output can be forced from a terminal with the \fB\-\-lava\fR option\.
 .
 .IP "" 4
 .

--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -59,6 +59,8 @@ OPTIONS
     Include tests in subdirectories
   * `-t`, `--tap`:
     Show results in TAP format
+  * `-l`, `--lava`:
+    Show results in LAVA format
   * `-v`, `--version`:
     Display the version number
 
@@ -79,8 +81,9 @@ an "X" if it fails.
 If Bats is not connected to a terminal--in other words, if you run it
 from a continuous integration system or redirect its output to a
 file--the results are displayed in human-readable, machine-parsable
-TAP format. You can force TAP output from a terminal by invoking Bats
-with the `--tap` option.
+TAP format, unless the `--lava` option is used. You can force TAP output
+from a terminal by invoking Bats with the `--tap` option. Similarly,
+LAVA output can be forced from a terminal with the `--lava` option.
 
     $ bats --tap addition.bats
     1..2


### PR DESCRIPTION
Add -l|--lava option which follows the -t style, but emitting different
kind of output, suitable for being captured by LAVA.

Signed-off-by: Andrzej Pietrasiewicz <andrzej.p@collabora.com>

- [*] I have reviewed the [Contributor Guidelines][contributor].
- [*] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
