### PR TITLE
bats: replace "readlink -f" dependency

### DIFF
--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -41,8 +41,30 @@ END_OF_HELP_TEXT
 }
 
 expand_link() {
-  readlink="$(type -p greadlink readlink | head -1)"
-  "$readlink" -f "$1"
+  IFS='/' read -ra parts <<<"$1"
+
+  # Starting point.
+  local path="/"
+  [[ "$1" =~ ^/ ]] || path="."
+
+  # Process each component.
+  for part in "${parts[@]}"
+  do
+    # All components must exist.
+    [ -e "$path/$part" ] || return 1
+
+    # If it's a link, we need to resolve it first.
+    [ -L "$path/$part" ] && part="$(readlink "$path/$part")"
+
+    # If the component starts with "/" we stomp the existing $path.
+    [[ "$part" =~ ^/ ]] && path=""
+
+    # Add the component to the path.
+    path+="/$part"
+  done
+
+  # Remove any duplicate slashes.
+  echo "$path" | tr -s /
 }
 
 expand_path() {


### PR DESCRIPTION
Rather than depending on GNU coreutils, we reimplement "readlink -f" (or
to be more accurate, "readlink -e") ourselves in bash to work around the
lack of GNU tools on OS X.

Fixes #214
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
