### PR TITLE
docs: add document attributes to manpages

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -1,10 +1,23 @@
-RONN := ronn
+# Makefile
+#
+# bats-core manpages
+#
+RONN := ronn -W
 PAGES := bats.1 bats.7
+ORG := bats-core
+MANUAL := 'Bash Automated Testing System'
+ISOFMT := $(shell date -I)
+RM := rm -f
+
+.PHONY: all clean
 
 all: $(PAGES)
 
 bats.1: bats.1.ronn
-	$(RONN) -r $<
+	$(RONN) --date=$(ISOFMT) --manual=$(MANUAL) --organization=$(ORG) --roff $<
 
 bats.7: bats.7.ronn
-	$(RONN) -r $<
+	$(RONN) --date=$(ISOFMT) --manual=$(MANUAL) --organization=$(ORG) --roff $<
+
+clean:
+	$(RM) $(PAGES)

--- a/man/bats.1
+++ b/man/bats.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BATS" "1" "July 2018" "" ""
+.TH "BATS" "1" "May 2019" "bats-core" "Bash Automated Testing System"
 .
 .SH "NAME"
 \fBbats\fR \- Bash Automated Testing System

--- a/man/bats.7
+++ b/man/bats.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BATS" "7" "November 2013" "" ""
+.TH "BATS" "7" "May 2019" "bats-core" "Bash Automated Testing System"
 .
 .SH "NAME"
 \fBbats\fR \- Bats test file format


### PR DESCRIPTION
# :memo: add document attributes to manpages

[![My Branch Status](https://travis-ci.com/virgilwashere/bats-core.svg?branch=manpages)](https://travis-ci.com/virgilwashere/bats-core) ◀️ (mine) 👤 | 🚧 (yours) ▶️ [![Your Branch Status](https://travis-ci.org/bats-core/bats-core.svg?branch=master)](https://travis-ci.org/bats-core/bats-core) 

Use `ronn`'s document attribute options when generating the man pages.

<details>
<summary>ronn options</summary>

```console
Document attributes:
      --date=<date>          published date in YYYY-MM-DD format (bottom-center)
      --manual=<name>        name of the manual (top-center)
      --organization=<name>  publishing group or individual (bottom-left)
```

</details>

<details>
<summary>The Makefile changes:</summary>

```makefile
ORG := bats-core
MANUAL := 'Bash Automated Testing System'
ISOFMT := $(shell date -I)

    $(RONN) --date=$(ISOFMT) --manual=$(MANUAL) --organization=$(ORG) --roff $<
```

</details>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
