### PR TITLE
[RFC] Include per-test timing information in the test runner output

### DIFF
--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -90,11 +90,7 @@ bats_test_begin() {
   BATS_SETUP_START_TS=$(date +%s)
   setup
   BATS_SETUP_END_TS=$(date +%s)
-
-  echo ${BATS_SETUP_END_TS}
-  echo ${BATS_SETUP_START_TS}
   BATS_SETUP_DURATION=$((${BATS_SETUP_END_TS} - ${BATS_SETUP_START_TS}))
-  echo ${BATS_SETUP_DURATION}
 
   # We log test start timestamp here so setup call time is excluded from test
   # timing information
@@ -250,9 +246,9 @@ bats_error_trap() {
     if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
       BATS_ERROR_STATUS=1
     fi
-    BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
     BATS_TEST_END_TS=$(date +%s)
     BATS_TEST_DURATION=$((${BATS_TEST_END_TS} - ${BATS_TEST_START_TS}))
+    BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
     trap - debug
   fi
 }

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -238,6 +238,8 @@ bats_error_trap() {
       BATS_ERROR_STATUS=1
     fi
     BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
+    BATS_END_TS=$(date +%s)
+    BATS_TEST_DURATION=$(expr ${BATS_END_TS} - ${BATS_START_TS})
     trap - debug
   fi
 }
@@ -283,7 +285,7 @@ bats_exit_trap() {
       BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
       BATS_ERROR_STATUS=1
     fi
-    printf 'not ok %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
+    printf 'not ok %d %s (duration %ss)\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" "${BATS_TEST_DURATION}" >&3
     bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
     bats_print_failed_command >&3
 
@@ -295,8 +297,8 @@ bats_exit_trap() {
     fi
     status=1
   else
-    printf 'ok %d %s%s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" \
-      "$skipped" >&3
+    printf 'ok %d %s%s (duration %ss)\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" \
+      "$skipped" "${BATS_TEST_DURATION}" >&3
     status=0
   fi
 
@@ -328,10 +330,16 @@ bats_perform_test() {
   BATS_TEST_SKIPPED=
   BATS_TEARDOWN_COMPLETED=
   BATS_ERROR_STATUS=
+
   trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
   trap 'bats_error_trap' err
   trap 'bats_teardown_trap' exit
+
+  BATS_START_TS=$(date +%s)
   "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
+  BATS_END_TS=$(date +%s)
+  BATS_TEST_DURATION=$(expr ${BATS_END_TS} - ${BATS_START_TS})
+
   BATS_TEST_COMPLETED=1
   trap 'bats_exit_trap' exit
   bats_teardown_trap

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -280,10 +280,10 @@ bats_exit_trap() {
       skipped+=" $BATS_TEST_SKIPPED"
     fi
 
-    timing_info=$(printf ' (setup: %ss, test: %ss)' "${BATS_SETUP_DURATION}" \
+    timing_info=$(printf ' | setup: %ss, test: %ss' "${BATS_SETUP_DURATION}" \
     "${BATS_TEST_DURATION}")
   else
-    timing_info=$(printf ' # (setup: %ss, test: %ss)' "${BATS_SETUP_DURATION}" \
+    timing_info=$(printf ' # setup: %ss, test: %ss' "${BATS_SETUP_DURATION}" \
     "${BATS_TEST_DURATION}")
   fi
 

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -246,8 +246,6 @@ bats_error_trap() {
     if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
       BATS_ERROR_STATUS=1
     fi
-    BATS_TEST_END_TS=$(date +%s)
-    BATS_TEST_DURATION=$((${BATS_TEST_END_TS} - ${BATS_TEST_START_TS}))
     BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
     trap - debug
   fi
@@ -256,6 +254,13 @@ bats_error_trap() {
 bats_teardown_trap() {
   bats_error_trap
   local status=0
+
+  # Also set BATS_TEST_END_TS if not already set (e.g. on test failure)
+  # NOTE: We can't call that in "bash_error_trap" since it causes a segfault
+  if [ ${BATS_TEST_END_TS} -eq 0 ]; then
+      BATS_TEST_END_TS=$(date +%s)
+      BATS_TEST_DURATION=$((${BATS_TEST_END_TS} - ${BATS_TEST_START_TS}))
+  fi
 
   BATS_TEARDOWN_START_TS=$(date +%s)
   teardown >>"$BATS_OUT" 2>&1 || status="$?"

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -256,7 +256,11 @@ bats_error_trap() {
 bats_teardown_trap() {
   bats_error_trap
   local status=0
+
+  BATS_TEARDOWN_START_TS=$(date +%s)
   teardown >>"$BATS_OUT" 2>&1 || status="$?"
+  BATS_TEARDOWN_END_TS=$(date +%s)
+  BATS_TEARDOWN_DURATION=$((${BATS_TEARDOWN_END_TS} - ${BATS_TEARDOWN_START_TS}))
 
   if [[ $status -eq 0 ]]; then
     BATS_TEARDOWN_COMPLETED=1
@@ -280,11 +284,13 @@ bats_exit_trap() {
       skipped+=" $BATS_TEST_SKIPPED"
     fi
 
-    timing_info=$(printf ' | setup: %ss, test: %ss' "${BATS_SETUP_DURATION}" \
-    "${BATS_TEST_DURATION}")
+    timing_info=$(printf ' | setup: %ss, test: %ss, teardown: %ss' \
+      "${BATS_SETUP_DURATION}" "${BATS_TEST_DURATION}" \
+      "${BATS_TEARDOWN_DURATION}")
   else
-    timing_info=$(printf ' # setup: %ss, test: %ss' "${BATS_SETUP_DURATION}" \
-    "${BATS_TEST_DURATION}")
+    timing_info=$(printf ' # setup: %ss, test: %ss, teardown: %ss' \
+      "${BATS_SETUP_DURATION}" "${BATS_TEST_DURATION}" \
+      "${BATS_TEARDOWN_DURATION}")
   fi
 
   if [[ -z "$BATS_TEST_COMPLETED" || -z "$BATS_TEARDOWN_COMPLETED" ]]; then

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -354,6 +354,17 @@ bats_perform_test() {
   BATS_TEARDOWN_COMPLETED=
   BATS_ERROR_STATUS=
 
+  BATS_SETUP_START_TS=0
+  BATS_SETUP_END_TS=0
+  BATS_TEST_START_TS=0
+  BATS_TEST_END_TS=0
+  BATS_TEARDOWN_START_TS=0
+  BATS_TEARDOWN_END_TS=0
+
+  BATS_SETUP_DURATION=0
+  BATS_TEST_DURATION=0
+  BATS_TEARDOWN_DURATION=0
+
   trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
   trap 'bats_error_trap' err
   trap 'bats_teardown_trap' exit

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -77,6 +77,7 @@ teardown() {
 skip() {
   BATS_TEST_SKIPPED="${1:-1}"
   BATS_TEST_COMPLETED=1
+  BATS_TEST_DURATION=0
   exit 0
 }
 

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -89,7 +89,11 @@ bats_test_begin() {
   BATS_SETUP_START_TS=$(date +%s)
   setup
   BATS_SETUP_END_TS=$(date +%s)
-  BATS_SETUP_DURATION=$(expr ${BATS_SETUP_END_TS} - ${BATS_SETUP_START_TS})
+
+  echo ${BATS_SETUP_END_TS}
+  echo ${BATS_SETUP_START_TS}
+  BATS_SETUP_DURATION=$((${BATS_SETUP_END_TS} - ${BATS_SETUP_START_TS}))
+  echo ${BATS_SETUP_DURATION}
 
   # We log test start timestamp here so setup call time is excluded from test
   # timing information
@@ -247,7 +251,7 @@ bats_error_trap() {
     fi
     BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
     BATS_TEST_END_TS=$(date +%s)
-    BATS_TEST_DURATION=$(expr ${BATS_TEST_END_TS} - ${BATS_TEST_START_TS})
+    BATS_TEST_DURATION=$((${BATS_TEST_END_TS} - ${BATS_TEST_START_TS}))
     trap - debug
   fi
 }
@@ -348,7 +352,7 @@ bats_perform_test() {
 
   "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
   BATS_TEST_END_TS=$(date +%s)
-  BATS_TEST_DURATION=$(expr ${BATS_TEST_END_TS} - ${BATS_TEST_START_TS})
+  BATS_TEST_DURATION=$((${BATS_TEST_END_TS} - ${BATS_TEST_START_TS}))
 
   BATS_TEST_COMPLETED=1
   trap 'bats_exit_trap' exit

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -85,7 +85,15 @@ bats_test_begin() {
   if [[ -n "$BATS_EXTENDED_SYNTAX" ]]; then
     printf 'begin %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
   fi
+
+  BATS_SETUP_START_TS=$(date +%s)
   setup
+  BATS_SETUP_END_TS=$(date +%s)
+  BATS_SETUP_DURATION=$(expr ${BATS_SETUP_END_TS} - ${BATS_SETUP_START_TS})
+  
+  # We log test start timestamp here so setup call time is excluded from test
+  # timing information
+  BATS_TEST_START_TS=$(date +%s)
 }
 
 bats_test_function() {
@@ -238,8 +246,8 @@ bats_error_trap() {
       BATS_ERROR_STATUS=1
     fi
     BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
-    BATS_END_TS=$(date +%s)
-    BATS_TEST_DURATION=$(expr ${BATS_END_TS} - ${BATS_START_TS})
+    BATS_TEST_END_TS=$(date +%s)
+    BATS_TEST_DURATION=$(expr ${BATS_TEST_END_TS} - ${BATS_TEST_START_TS})
     trap - debug
   fi
 }
@@ -285,7 +293,7 @@ bats_exit_trap() {
       BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
       BATS_ERROR_STATUS=1
     fi
-    printf 'not ok %d %s (duration %ss)\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" "${BATS_TEST_DURATION}" >&3
+    printf 'not ok %d %s (setup: %ss, test: %ss)\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" "${BATS_SETUP_DURATION}" "${BATS_TEST_DURATION}" >&3
     bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
     bats_print_failed_command >&3
 
@@ -297,8 +305,8 @@ bats_exit_trap() {
     fi
     status=1
   else
-    printf 'ok %d %s%s (duration %ss)\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" \
-      "$skipped" "${BATS_TEST_DURATION}" >&3
+    printf 'ok %d %s%s (setup: %ss, test: %ss)\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" \
+      "$skipped" "${BATS_SETUP_DURATION}" "${BATS_TEST_DURATION}" >&3
     status=0
   fi
 
@@ -335,10 +343,9 @@ bats_perform_test() {
   trap 'bats_error_trap' err
   trap 'bats_teardown_trap' exit
 
-  BATS_START_TS=$(date +%s)
   "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
-  BATS_END_TS=$(date +%s)
-  BATS_TEST_DURATION=$(expr ${BATS_END_TS} - ${BATS_START_TS})
+  BATS_TEST_END_TS=$(date +%s)
+  BATS_TEST_DURATION=$(expr ${BATS_TEST_END_TS} - ${BATS_TEST_START_TS})
 
   BATS_TEST_COMPLETED=1
   trap 'bats_exit_trap' exit

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -90,7 +90,7 @@ bats_test_begin() {
   setup
   BATS_SETUP_END_TS=$(date +%s)
   BATS_SETUP_DURATION=$(expr ${BATS_SETUP_END_TS} - ${BATS_SETUP_START_TS})
-  
+
   # We log test start timestamp here so setup call time is excluded from test
   # timing information
   BATS_TEST_START_TS=$(date +%s)
@@ -293,7 +293,9 @@ bats_exit_trap() {
       BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
       BATS_ERROR_STATUS=1
     fi
-    printf 'not ok %d %s (setup: %ss, test: %ss)\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" "${BATS_SETUP_DURATION}" "${BATS_TEST_DURATION}" >&3
+    printf 'not ok %d %s (setup: %ss, test: %ss)\n' "$BATS_TEST_NUMBER" \
+      "$BATS_TEST_DESCRIPTION" "${BATS_SETUP_DURATION}" \
+      "${BATS_TEST_DURATION}" >&3
     bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
     bats_print_failed_command >&3
 
@@ -305,8 +307,9 @@ bats_exit_trap() {
     fi
     status=1
   else
-    printf 'ok %d %s%s (setup: %ss, test: %ss)\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" \
-      "$skipped" "${BATS_SETUP_DURATION}" "${BATS_TEST_DURATION}" >&3
+    printf 'ok %d %s%s (setup: %ss, test: %ss)\n' "$BATS_TEST_NUMBER" \
+      "$BATS_TEST_DESCRIPTION" "$skipped" "${BATS_SETUP_DURATION}" \
+      "${BATS_TEST_DURATION}" >&3
     status=0
   fi
 

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -275,6 +275,7 @@ bats_exit_trap() {
   local line
   local status
   local skipped=''
+  local timing_info=''
   trap - err exit
 
   if [[ -n "$BATS_TEST_SKIPPED" ]]; then
@@ -282,6 +283,12 @@ bats_exit_trap() {
     if [[ "$BATS_TEST_SKIPPED" != '1' ]]; then
       skipped+=" $BATS_TEST_SKIPPED"
     fi
+
+    timing_info=$(printf ' (setup: %ss, test: %ss)' "${BATS_SETUP_DURATION}" \
+    "${BATS_TEST_DURATION}")
+  else
+    timing_info=$(printf ' # (setup: %ss, test: %ss)' "${BATS_SETUP_DURATION}" \
+    "${BATS_TEST_DURATION}")
   fi
 
   if [[ -z "$BATS_TEST_COMPLETED" || -z "$BATS_TEARDOWN_COMPLETED" ]]; then
@@ -298,9 +305,8 @@ bats_exit_trap() {
       BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
       BATS_ERROR_STATUS=1
     fi
-    printf 'not ok %d %s (setup: %ss, test: %ss)\n' "$BATS_TEST_NUMBER" \
-      "$BATS_TEST_DESCRIPTION" "${BATS_SETUP_DURATION}" \
-      "${BATS_TEST_DURATION}" >&3
+    printf 'not ok %d %s%s\n' "$BATS_TEST_NUMBER" \
+      "$BATS_TEST_DESCRIPTION" "${timing_info}" >&3
     bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
     bats_print_failed_command >&3
 
@@ -312,9 +318,8 @@ bats_exit_trap() {
     fi
     status=1
   else
-    printf 'ok %d %s%s (setup: %ss, test: %ss)\n' "$BATS_TEST_NUMBER" \
-      "$BATS_TEST_DESCRIPTION" "$skipped" "${BATS_SETUP_DURATION}" \
-      "${BATS_TEST_DURATION}" >&3
+    printf 'ok %d %s%s%s\n' "$BATS_TEST_NUMBER" \
+      "$BATS_TEST_DESCRIPTION" "$skipped" "${timing_info}" >&3
     status=0
   fi
 

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -55,7 +55,15 @@ skip() {
     reason=": $reason"
   fi
   go_to_column 0
-  buffer ' - %s (skipped%s)' "$name" "$reason"
+
+
+  if [ -z "$test_duration" ]; then
+    buffer ' - %s (skipped%s)' "$name" "$reason"
+  else
+    buffer ' - %s (skipped%s | setup: %ss, test: %ss)' "$name" "$reason" \
+      "$setup_duration" "$test_duration"
+  fi
+
   advance
 }
 
@@ -170,7 +178,7 @@ while IFS= read -r line; do
     ;;
   'ok '* )
     # Parse out test timing information
-    duration_expr="ok $index (.*) \(setup: (.*)s, test: (.*)s\)?"
+    duration_expr="ok $index (.*) setup: (.*)s, test: (.*)s"
     if [[ "$line" =~ $duration_expr ]]; then
       setup_duration=${BASH_REMATCH[2]}
       test_duration=${BASH_REMATCH[3]}
@@ -179,7 +187,7 @@ while IFS= read -r line; do
       test_duration=
     fi
 
-    skip_expr="ok $index (.*) # skip ?(([[:print:]]*))?"
+    skip_expr="ok $index (.*) # skip ?(([[:print:]]*))? \|"
     if [[ "$line" =~ $skip_expr ]]; then
       ((++skipped))
       skip "${BASH_REMATCH[2]}"
@@ -189,7 +197,7 @@ while IFS= read -r line; do
     ;;
   'not ok '* )
     # Parse out test timing information
-    duration_expr="ok $index (.*) \(setup: (.*)s, test: (.*)s\)?"
+    duration_expr="ok $index (.*) setup: (.*)s, test: (.*)s"
     if [[ "$line" =~ $duration_expr ]]; then
       setup_duration=${BASH_REMATCH[2]}
       test_duration=${BASH_REMATCH[3]}

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -10,7 +10,8 @@ if [[ "$header" =~ $header_pattern ]]; then
   failures=0
   skipped=0
   name=
-  duration=
+  setup_duration=
+  test_duration=
   count_column_width=$(( ${#count} * 2 + 2 ))
 else
   # If the first line isn't a TAP plan, print it and pass the rest through
@@ -38,10 +39,10 @@ begin() {
 pass() {
   go_to_column 0
 
-  if [ -z "$duration" ]; then
+  if [ -z "$test_duration" ]; then
     buffer ' ✓ %s' "$name"
   else
-    buffer ' ✓ %s (%ss)' "$name" "$duration"
+    buffer ' ✓ %s (setup: %ss, test: %ss)' "$name" "$setup_duration" "$test_duration"
   fi
 
   advance
@@ -61,10 +62,10 @@ fail() {
   go_to_column 0
   set_color 1 bold
 
-  if [ -z "$duration" ]; then
+  if [ -z "$test_duration" ]; then
     buffer ' ✗ %s' "$name"
   else
-    buffer ' ✗ %s (%ss)' "$name" "$duration"
+    buffer ' ✗ %s (setup: %ss, test: %ss)' "$name" "$setup_duration" "$test_duration"
   fi
 
   advance
@@ -167,11 +168,13 @@ while IFS= read -r line; do
     ;;
   'ok '* )
     # Parse out test timing information
-    duration_expr="ok $index (.*) \(duration (.*)s\)?"
+    duration_expr="ok $index (.*) \(setup: (.*)s, test: (.*)s\)?"
     if [[ "$line" =~ $duration_expr ]]; then
-      duration=${BASH_REMATCH[2]}
+      setup_duration=${BASH_REMATCH[2]}
+      test_duration=${BASH_REMATCH[3]}
     else
-      duration=
+      setup_duration=
+      test_duration=
     fi
 
     skip_expr="ok $index (.*) # skip ?(([[:print:]]*))?"
@@ -184,11 +187,13 @@ while IFS= read -r line; do
     ;;
   'not ok '* )
     # Parse out test timing information
-    duration_expr="ok $index (.*) \(duration (.*)s\)?"
+    duration_expr="ok $index (.*) \(setup: (.*)s, test: (.*)s\)?"
     if [[ "$line" =~ $duration_expr ]]; then
-      duration=${BASH_REMATCH[2]}
+      setup_duration=${BASH_REMATCH[2]}
+      test_duration=${BASH_REMATCH[3]}
     else
-      duration=
+      setup_duration=
+      test_duration=
     fi
 
     ((++failures))

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -10,6 +10,7 @@ if [[ "$header" =~ $header_pattern ]]; then
   failures=0
   skipped=0
   name=
+  duration=
   count_column_width=$(( ${#count} * 2 + 2 ))
 else
   # If the first line isn't a TAP plan, print it and pass the rest through
@@ -36,7 +37,13 @@ begin() {
 
 pass() {
   go_to_column 0
-  buffer ' ✓ %s' "$name"
+
+  if [ -z "$duration" ]; then
+    buffer ' ✓ %s' "$name"
+  else
+    buffer ' ✓ %s (%ss)' "$name" "$duration"
+  fi
+
   advance
 }
 
@@ -53,7 +60,13 @@ skip() {
 fail() {
   go_to_column 0
   set_color 1 bold
-  buffer ' ✗ %s' "$name"
+
+  if [ -z "$duration" ]; then
+    buffer ' ✗ %s' "$name"
+  else
+    buffer ' ✗ %s (%ss)' "$name" "$duration"
+  fi
+
   advance
 }
 
@@ -153,6 +166,14 @@ while IFS= read -r line; do
     flush
     ;;
   'ok '* )
+    # Parse out test timing information
+    duration_expr="ok $index (.*) \(duration (.*)s\)?"
+    if [[ "$line" =~ $duration_expr ]]; then
+      duration=${BASH_REMATCH[2]}
+    else
+      duration=
+    fi
+
     skip_expr="ok $index (.*) # skip ?(([[:print:]]*))?"
     if [[ "$line" =~ $skip_expr ]]; then
       ((++skipped))
@@ -162,6 +183,14 @@ while IFS= read -r line; do
     fi
     ;;
   'not ok '* )
+    # Parse out test timing information
+    duration_expr="ok $index (.*) \(duration (.*)s\)?"
+    if [[ "$line" =~ $duration_expr ]]; then
+      duration=${BASH_REMATCH[2]}
+    else
+      duration=
+    fi
+
     ((++failures))
     fail
     ;;

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -12,6 +12,7 @@ if [[ "$header" =~ $header_pattern ]]; then
   name=
   setup_duration=
   test_duration=
+  teardown_duration=
   count_column_width=$(( ${#count} * 2 + 2 ))
 else
   # If the first line isn't a TAP plan, print it and pass the rest through
@@ -42,8 +43,8 @@ pass() {
   if [ -z "$test_duration" ]; then
     buffer ' ✓ %s' "$name"
   else
-    buffer ' ✓ %s (setup: %ss, test: %ss)' "$name" "$setup_duration" \
-      "$test_duration"
+    buffer ' ✓ %s (setup: %ss, test: %ss, teardown: %ss)' "$name" \
+      "$setup_duration" "$test_duration" "$teardown_duration"
   fi
 
   advance
@@ -60,8 +61,8 @@ skip() {
   if [ -z "$test_duration" ]; then
     buffer ' - %s (skipped%s)' "$name" "$reason"
   else
-    buffer ' - %s (skipped%s | setup: %ss, test: %ss)' "$name" "$reason" \
-      "$setup_duration" "$test_duration"
+    buffer ' - %s (skipped%s | setup: %ss, test: %ss, teardown: %ss)' "$name" \
+      "$reason" "$setup_duration" "$test_duration" "$teardown_duration"
   fi
 
   advance
@@ -74,8 +75,8 @@ fail() {
   if [ -z "$test_duration" ]; then
     buffer ' ✗ %s' "$name"
   else
-    buffer ' ✗ %s (setup: %ss, test: %ss)' "$name" "$setup_duration" \
-      "$test_duration"
+    buffer ' ✗ %s (setup: %ss, test: %ss, teardown: %ss)' "$name" \
+      "$setup_duration" "$test_duration" "$teardown_duration"
   fi
 
   advance
@@ -178,13 +179,15 @@ while IFS= read -r line; do
     ;;
   'ok '* )
     # Parse out test timing information
-    duration_expr="ok $index (.*) setup: (.*)s, test: (.*)s"
+    duration_expr="ok $index (.*) setup: (.*)s, test: (.*)s, teardown: (.*)s"
     if [[ "$line" =~ $duration_expr ]]; then
       setup_duration=${BASH_REMATCH[2]}
       test_duration=${BASH_REMATCH[3]}
+      teardown_duration=${BASH_REMATCH[4]}
     else
       setup_duration=
       test_duration=
+      teardown_duration=
     fi
 
     skip_expr="ok $index (.*) # skip ?(([[:print:]]*))? \|"
@@ -197,13 +200,15 @@ while IFS= read -r line; do
     ;;
   'not ok '* )
     # Parse out test timing information
-    duration_expr="ok $index (.*) setup: (.*)s, test: (.*)s"
+    duration_expr="ok $index (.*) setup: (.*)s, test: (.*)s, teardown: (.*)s"
     if [[ "$line" =~ $duration_expr ]]; then
       setup_duration=${BASH_REMATCH[2]}
       test_duration=${BASH_REMATCH[3]}
+      teardown_duration=${BASH_REMATCH[4]}
     else
       setup_duration=
       test_duration=
+      teardown_duration=
     fi
 
     ((++failures))

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -42,7 +42,8 @@ pass() {
   if [ -z "$test_duration" ]; then
     buffer ' ✓ %s' "$name"
   else
-    buffer ' ✓ %s (setup: %ss, test: %ss)' "$name" "$setup_duration" "$test_duration"
+    buffer ' ✓ %s (setup: %ss, test: %ss)' "$name" "$setup_duration" \
+      "$test_duration"
   fi
 
   advance
@@ -65,7 +66,8 @@ fail() {
   if [ -z "$test_duration" ]; then
     buffer ' ✗ %s' "$name"
   else
-    buffer ' ✗ %s (setup: %ss, test: %ss)' "$name" "$setup_duration" "$test_duration"
+    buffer ' ✗ %s (setup: %ss, test: %ss)' "$name" "$setup_duration" \
+      "$test_duration"
   fi
 
   advance


### PR DESCRIPTION
This pull request updates bats-core code base so per-test timing information is included by default in the tap test runner output.

Test related timing information comes very handy when debugging various timing related test issues. I do know that a similar end result could be achieved by writing a custom wrapper function or similar, but this would require more changes to the test cases and I believe this is a pretty basic test framework functionality which should / can live in the core.

Example output:

``timing.bats``

```bash
@test "test timing 1" {
	sleep 2
	echo "pass"
}

@test "test timing 2" {
	sleep 3
	echo "pass"
}

@test "test timing 3" {
	sleep 2
	echo "pass"
}

@test "test timing 4" {
	sleep 2
	echo "fail"
	exit 2
}
```

```bash
bin/bats timing.bats --tap
1..4
done
ok 1 test timing 1 (duration 2s)
done
ok 2 test timing 2 (duration 3s)
done
ok 3 test timing 3 (duration 2s)
not ok 4 test timing 4 (duration 2s)
# (in test file /data/st2tests/cli/timing.bats, line 25)
#   `exit 2' failed with status 2
# fail
```

This pull request is just a quick naive implementation go get the discussion going. To finish it and make it fully "production" ready, it will likely need at least the following changes:

1. Add a global flag for including test timing information in the output
2. Include test timing information in the default friendly test result formatter
3. Update TAP test formatter so timing information is included as part of a TAP diagnostic line (this way it will conform to TAP specification).
4. Right now test timing includes time it took for optional ``setup`` function to complete. We probably want to separate this and include timing for the test case itself and timing for the setup function separately.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
