### PR TITLE
Fix wrong line numbers of errors in bash < 4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,12 +492,13 @@ commit [0360811][].  It was created via `git clone --bare` and `git push
 [bats-orig]: https://github.com/sstephenson/bats
 [0360811]: https://github.com/sstephenson/bats/commit/03608115df2071fff4eaaff1605768c275e5f81f
 
-This [bats-core repo](https://github.com/bats-core/bats-core) is now the official Bats project.
+This [bats-core repo](https://github.com/bats-core/bats-core) is the community-maintained Bats project.
 
 ### Why was this fork created?
 
-The original Bats repository is no longer maintained and write access to it could not be obtained. This fork allowed ongoing maintenance and forward progress for Bats.
+There was an initial [call for maintainers][call-maintain] for the original Bats repository, but write access to it could not be obtained. With development activity stalled, this fork allowed ongoing maintenance and forward progress for Bats.
 
+[call-maintain]: https://github.com/sstephenson/bats/issues/150
 
 ## Copyright
 

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -214,8 +214,9 @@ bats_debug_trap() {
   if [[ "$BASH_SOURCE" != "$1" ]]; then
     # The last entry in the stack trace is not useful when en error occured:
     # It is either duplicated (kinda correct) or has wrong line number (Bash < 4.4)
-    # Therefore we use capture the stacktrace but use it only after the next debug
-    # trap fired. Expansion is required for empty arrays otherwise erroring
+    # Therefore we capture the stacktrace but use it only after the next debug
+    # trap fired.
+    # Expansion is required for empty arrays which otherwise error
     BATS_CURRENT_STACK_TRACE=( "${BATS_STACK_TRACE[@]+"${BATS_STACK_TRACE[@]}"}" )
     bats_capture_stack_trace
   fi
@@ -227,7 +228,7 @@ bats_debug_trap() {
 #
 # For this reason, we call `bats_error_trap` at the very beginning of
 # `bats_teardown_trap` (the `DEBUG` trap for the call will fix the stack trace)
-#  and check the value of `$BATS_TEST_COMPLETED` before taking other actions.
+# and check the value of `$BATS_TEST_COMPLETED` before taking other actions.
 # We also adjust the exit status value if needed.
 #
 # See `bats_exit_trap` for an additional EXIT error handling case when `$?`

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -212,9 +212,12 @@ bats_trim_filename() {
 
 bats_debug_trap() {
   if [[ "$BASH_SOURCE" != "$1" ]]; then
+    # The last entry in the stack trace is not useful when en error occured:
+    # It is either duplicated (kinda correct) or has wrong line number (Bash < 4.4)
+    # Therefore we use capture the stacktrace but use it only after the next debug
+    # trap fired. Expansion is required for empty arrays otherwise erroring
+    BATS_CURRENT_STACK_TRACE=( "${BATS_STACK_TRACE[@]+"${BATS_STACK_TRACE[@]}"}" )
     bats_capture_stack_trace
-    BATS_LINENO="$BATS_CURRENT_LINENO"
-    BATS_CURRENT_LINENO="${BASH_LINENO[0]}"
   fi
 }
 
@@ -223,10 +226,9 @@ bats_debug_trap() {
 # set `$?` properly. See #72 and #81 for details.
 #
 # For this reason, we call `bats_error_trap` at the very beginning of
-# `bats_teardown_trap` (the `DEBUG` trap for the call will move
-# `BATS_CURRENT_LINENO` to `BATS_LINENO`) and check the value of
-# `$BATS_TEST_COMPLETED` before taking other actions. We also adjust the exit
-# status value if needed.
+# `bats_teardown_trap` (the `DEBUG` trap for the call will fix the stack trace)
+#  and check the value of `$BATS_TEST_COMPLETED` before taking other actions.
+# We also adjust the exit status value if needed.
 #
 # See `bats_exit_trap` for an additional EXIT error handling case when `$?`
 # isn't set properly during `teardown()` errors.
@@ -237,7 +239,7 @@ bats_error_trap() {
     if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
       BATS_ERROR_STATUS=1
     fi
-    BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
+    BATS_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
     trap - debug
   fi
 }
@@ -280,7 +282,7 @@ bats_exit_trap() {
       # If instead the test fails, and the `teardown()` error happens while
       # `bats_teardown_trap` runs as the EXIT trap, the test will fail with no
       # output, since there's no way to reach the `bats_exit_trap` call.
-      BATS_STACK_TRACE[0]="$BATS_LINENO ${BATS_STACK_TRACE[0]#* }"
+      BATS_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
       BATS_ERROR_STATUS=1
     fi
     printf 'not ok %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
@@ -317,18 +319,17 @@ bats_perform_test() {
   # function when the ERR trap fires. All versions of Bash appear to reset it
   # on an unbound variable access error. bats_debug_trap will fire both before
   # the offending line is executed, and when the error is triggered.
-  # Consequently, we use `BATS_LINENO` to point to the line number seen by the
+  # Consequently, we use `BATS_CURRENT_STACK_TRACE` recorded by the
   # first call to bats_debug_trap, _before_ the ERR trap or unbound variable
   # access fires.
-  BATS_CURRENT_LINENO=0
-  BATS_LINENO=0
   BATS_STACK_TRACE=()
+  BATS_CURRENT_STACK_TRACE=()
 
   BATS_TEST_COMPLETED=
   BATS_TEST_SKIPPED=
   BATS_TEARDOWN_COMPLETED=
   BATS_ERROR_STATUS=
-  trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
+  trap 'bats_debug_trap "$BASH_SOURCE"' debug
   trap 'bats_error_trap' err
   trap 'bats_teardown_trap' exit
   "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -62,7 +62,6 @@ fixtures bats
 
 @test "tap passing and skipping tests" {
   run filter_control_sequences bats --tap "$FIXTURE_ROOT/passing_and_skipping.bats"
-  echo "$output"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..3" ]
   [ "${lines[1]}" = "ok 1 a passing test" ]
@@ -487,7 +486,6 @@ END_OF_ERR_MSG
 
 @test "report correct line on unset variables" {
   run bats "$FIXTURE_ROOT/unbound_variable.bats"
-  echo "$output"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 5 ]
   [ "${lines[1]}" = 'not ok 1 access unbound variable' ]
@@ -497,7 +495,6 @@ END_OF_ERR_MSG
 
 @test "report correct line on external function calls" {
   run bats "$FIXTURE_ROOT/external_function_calls.bats"
-  echo "$output"
   [ "$status" -eq 1 ]
   numTests=$((3*4))
   [ "${#lines[@]}" -gt $((numTests * 3 + 1)) ]

--- a/test/fixtures/bats/external_function_calls.bats
+++ b/test/fixtures/bats/external_function_calls.bats
@@ -1,0 +1,65 @@
+load test_helper
+
+# Test various combinations that may fail line# detection
+# Tests are designed so the first statement succeeds and 2nd fails
+# All are same line# so checking can be automated
+
+@test "Call true function && false" {
+    help_me
+    help_me && false
+}
+
+@test "Call true function && return 1" {
+    help_me
+    help_me && return 1
+}
+
+@test "Call true function and invert" {
+    help_me
+    ! help_me
+}
+
+@test "Call false function || false" {
+    ! failing_helper
+    failing_helper || false 
+}
+
+@test "Call false function && return 1" {
+    ! failing_helper
+    failing_helper || return 1
+}
+
+@test "Call false function" {
+    ! failing_helper
+    failing_helper
+}
+
+@test "Call return_0 function && false" {
+    return_0
+    return_0 && false
+}
+
+@test "Call return_0 function && return 1" {
+    return_0
+    return_0 && return 1
+}
+
+@test "Call return_0 function and invert" {
+    return_0
+    ! return_0
+}
+
+@test "Call return_1 function || false" {
+    ! return_1
+    return_1 || false 
+}
+
+@test "Call return_1 function && return 1" {
+    ! return_1
+    return_1 || return 1
+}
+
+@test "Call return_1 function" {
+    ! return_1
+    return_1
+}

--- a/test/fixtures/bats/test_helper.bash
+++ b/test/fixtures/bats/test_helper.bash
@@ -5,3 +5,15 @@ help_me() {
 failing_helper() {
   false
 }
+
+return_0() {
+  # Just return 0. Intentional assignment to boost line numbers
+  result=0
+  return $result
+}
+
+return_1() {
+  # Just return 0. Intentional assignment to boost line numbers
+  result=1
+  return $result
+}

--- a/test/fixtures/bats/unbound_variable.bats
+++ b/test/fixtures/bats/unbound_variable.bats
@@ -1,0 +1,7 @@
+set -u
+
+@test "access unbound variable" {
+    unset unset_variable
+    # Add a line for checking line#
+    foo=$unset_variable
+}


### PR DESCRIPTION
The last entry in the stack trace is unreliable, so don't use the last
stack trace at all similar to the LINENO used before.

Fixes #228

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
