### PR TITLE
Update version to 1.2.0-dev

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,12 +15,13 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * The `-f, --filter` flag to run only the tests matching a regular expression  (#126)
 * Optimize stack trace capture (#138)
 * `--jobs n` flag to support parallel execution of tests with GNU parallel (#172)
-* Fix wrong line numbers of errors in bash < 4.4 (#229)
 
 ### Changed
 * AppVeyor builds are now semver-compliant (#123)
 * Add Bash 5 as test target (#181)
+* Always use upper case signal names to avoid locale dependent err… (#215)
 * Fix for tests reading from stdin (#227)
+* Fix wrong line numbers of errors in bash < 4.4 (#229)
 * Remove preprocessed source after test run (#232)
 
 ## [1.1.0] - 2018-07-08

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,11 +12,16 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ### Added
 * docs/CHANGELOG.md and docs/releasing.md (#122)
-* The `-f, --filter` flag to run only the tests matching a regular expression
-  (#126)
+* The `-f, --filter` flag to run only the tests matching a regular expression  (#126)
+* Optimize stack trace capture (#138)
+* `--jobs n` flag to support parallel execution of tests with GNU parallel (#172)
+* Fix wrong line numbers of errors in bash < 4.4 (#229)
 
 ### Changed
 * AppVeyor builds are now semver-compliant (#123)
+* Add Bash 5 as test target (#181)
+* Fix for tests reading from stdin (#227)
+* Remove preprocessed source after test run (#232)
 
 ## [1.1.0] - 2018-07-08
 

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-export BATS_VERSION='1.1.0'
+export BATS_VERSION='1.2.0-dev'
 
 version() {
   printf 'Bats %s\n' "$BATS_VERSION"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bats",
-  "version": "1.1.0",
+  "version": "1.2.0-dev",
   "description": "Bash Automated Testing System",
   "homepage": "https://github.com/bats-core/bats-core#readme",
   "license": "MIT",


### PR DESCRIPTION
This (or some other version) should have been done after 1.1.0 was released as master and the tag deviated.

We could also just set the version to dev.


- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md