### PR TITLE
Added Shellcheck script and CI config. Closes #14.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
 services:
   - docker
 
+before_script:
+ - sudo apt-get install shellcheck
+
 script:
 - |
   if [[ "${TRAVIS_OS_NAME:-}" == 'linux' && -n "${BASHVER}" ]]; then
@@ -27,6 +30,8 @@ script:
       docker run -it "bash:${BASHVER}" --version &&
       time docker run -it "bats/bats:bash-${BASHVER}" --tap /opt/bats/test
   else
+    # @todo: Remove "||true" once all coding standards issues are fixed.
+    ./shellcheck.sh || true
     time bin/bats --tap test
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,23 @@ services:
   - docker
 
 before_script:
- - sudo apt-get install shellcheck
+ - |
+   if [[ "${TRAVIS_OS_NAME:-}" == 'linux' ]]; then
+     sudo apt-get install shellcheck
+   fi
 
 script:
 - |
+  if [[ "${TRAVIS_OS_NAME:-}" == 'linux' ]]; then
+    # @todo: Remove "|| true" once all coding standards issues are fixed.
+    ./shellcheck.sh || true
+  fi
+
   if [[ "${TRAVIS_OS_NAME:-}" == 'linux' && -n "${BASHVER}" ]]; then
     docker build --build-arg bashver="${BASHVER}" --tag "bats/bats:bash-${BASHVER}" . &&
       docker run -it "bash:${BASHVER}" --version &&
       time docker run -it "bats/bats:bash-${BASHVER}" --tap /opt/bats/test
   else
-    # @todo: Remove "||true" once all coding standards issues are fixed.
-    ./shellcheck.sh || true
     time bin/bats --tap test
   fi
 

--- a/shellcheck.sh
+++ b/shellcheck.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+targets=()
+while IFS=  read -r -d $'\0'; do
+    targets+=("$REPLY")
+done < <(
+  find \
+    bin/bats \
+    libexec/bats-core \
+    shellcheck.sh \
+    -type f \
+    -print0
+  )
+
+for file in "${targets[@]}"; do
+  [ -f "${file}" ] && LC_ALL=C.UTF-8 shellcheck "${file}"
+done;


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

This PR adds Shellcheck support to CI through a `shellcheck.sh` script that may also be ran locally with `./shellcheck.sh`.

The check is ran in CI for Linux only - this is faster then installing Shellcheck for different OSes and is sufficient enough (Shellcheck will produce the same results independently of the environment it ran).

Please let me know about this approach and I can adjust the code. We really need coding standards check in PRs :))

Also, please note that the check is always passing in CI - this is to resolve in another PR that would be solely for fixing coding standards.

## Screenshot
This is a screenshot of CI job from this PR that passes the check, but some errors are still need to be fixed (or excluded).

<img width="829" alt="Job__588_1_-_bats-core_bats-core_-_Travis_CI" src="https://user-images.githubusercontent.com/378794/61770476-ae73d200-ae30-11e9-8f4b-53e28590ead9.png">
