### PR TITLE
Need ncurses for pretty printing to work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM bash:${bashver}
 
 # Install parallel and accept the citation notice (we aren't using this in a
 # context where it make sense to cite GNU Parallel).
-RUN apk add --no-cache parallel && \
+RUN apk add --no-cache parallel ncurses && \
     mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 
 RUN ln -s /opt/bats/bin/bats /usr/sbin/bats


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

As the title says. Without ncurses, the output defaults to "TAP", even on an interactive console:

```
$ docker run -it bats/bats:latest /opt/bats/test
1..78
ok 1 no arguments prints message and usage instructions
ok 2 invalid option prints message and usage instructions
ok 3 -v and --version print version number
ok 4 -h and --help print help
ok 5 invalid filename prints an error
ok 6 empty test file runs zero tests
ok 7 one passing test
ok 8 summary passing tests
...
```

with ncurses:

```
$ docker run -it bats/bats:latest /opt/bats/test
 ✓ no arguments prints message and usage instructions
 ✓ invalid option prints message and usage instructions
 ✓ -v and --version print version number
 ✓ -h and --help print help
 ✓ invalid filename prints an error
 ✓ empty test file runs zero tests
 ✓ one passing test
 ✓ summary passing tests
...
```

Note that -p and --pretty do not work without ncurses.

I don't know if ncurses is actually needed or not, but bats checks for it [here]:

`command -v tput`

[here]: https://github.com/dlorch/bats-core/blob/master/libexec/bats-core/bats#L94

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
