### PR TITLE
Feature/add once per file setup and teardown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM bash:${bashver}
 
 # Install parallel and accept the citation notice (we aren't using this in a
 # context where it make sense to cite GNU Parallel).
-RUN apk add --no-cache parallel && \
+RUN apk add --no-cache parallel ncurses && \
     mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 
 RUN ln -s /opt/bats/bin/bats /usr/sbin/bats

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ There was an initial [call for maintainers][call-maintain] for the original Bats
 
 ## Copyright
 
-© 2017-2018 bats-core organization
+© 2017-2020 bats-core organization
 
 © 2011-2016 Sam Stephenson
 

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -224,6 +224,14 @@ if [[ "${#arguments[@]}" -eq 0 ]]; then
   abort 'Must specify at least one <test>'
 fi
 
+
+if [[ -n "$output" ]]; then
+  if [[ ! -w "${output}" ]]; then
+    abort "Output path ${output} is not writeable"
+  fi
+  export BATS_REPORT_OUTPUT_PATH="$output"
+fi
+
 filenames=()
 for filename in "${arguments[@]}"; do
   expand_path "$filename" 'filename'
@@ -247,14 +255,6 @@ done
 
 # shellcheck source=lib/bats-core/validator.bash
 source "$BATS_ROOT/lib/bats-core/validator.bash"
-
-if [[ -n "$output" ]]; then
-  if [[ ! -w "${output}" ]]; then
-    printf "Error: output path %s is not writeable\n" "${output}" >&2
-    exit 1
-  fi
- export BATS_REPORT_OUTPUT_PATH="$output"
-fi
 
 set -o pipefail execfail
 exec bats-exec-suite "${flags[@]}" "${filenames[@]}" | bats_test_count_validator | "bats-format-${formatter}" "${formatter_flags[@]}"

--- a/shellcheck.sh
+++ b/shellcheck.sh
@@ -16,3 +16,5 @@ done < <(
   )
 
 LC_ALL=C.UTF-8 shellcheck "${targets[@]}"
+
+exit $?

--- a/test/parallell.bats
+++ b/test/parallell.bats
@@ -51,10 +51,11 @@ setup() {
       [[ "${lines[$i]}" == "ok $i slow test $t" ]]
     done
   done
-  # In theory it should take 3s, but let's give it bit of extra time instead.
-  # also check that parallelization happens accross all files instead of 
+  # In theory it should take 3s, but let's give it bit of extra time for load tolerance.
+  # (Since there is no limit to load, we cannot totally avoid erronous failures by limited tolerance.)
+  # Also check that parallelization happens accross all files instead of
   # linearizing between files, which requires at least 12s
-  [[ "$duration" -lt 12 ]]
+  [[ "$duration" -lt 12 ]] || (echo "If this fails on Travis, make sure the failure is repeatable and not due to heavy load."; false)
 }
 
 @test "setup_file is not over parallelized" {


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

This is a partial solution to the ongoing discussion in #39 
One issue remains: failing teardown_file will add a fake failed test case report for teardown_file which duplicates the number of the next test after the file. I think this is okay but I'd like to have feedback on that.

Goals of this PR:
- running setup_file/teardown_file regardless of filters
- running teardown_file even on user abort
- tests see variables that are set in setup_file
- skipping tests if setup_file failed

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
