### PR TITLE
docs: Readme.md, remove self referencing background link

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ See `docs/CHANGELOG.md`.
 
 **Tuesday, September 19, 2017:** This was forked from [Bats][bats-orig] at
 commit [0360811][].  It was created via `git clone --bare` and `git push
---mirror`. See the [Background](#background) section above for more information.
+--mirror`.
 
 [bats-orig]: https://github.com/sstephenson/bats
 [0360811]: https://github.com/sstephenson/bats/commit/03608115df2071fff4eaaff1605768c275e5f81f


### PR DESCRIPTION
Remove link from Background chapter that links to the Background chapter.
Can be confusing since it is basically linking to itself.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
