### PR TITLE
Expose new env variable to tests: BATS_JOB_SLOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,10 @@ There are several global variables you can use to introspect on Bats tests:
 * `$BATS_TEST_DESCRIPTION` is the description of the current test case.
 * `$BATS_TEST_NUMBER` is the (1-based) index of the current test case in the
   test file.
+* `$BATS_JOB_SLOT` is the (1-based) job slot number being used. Only set
+  relevant when running tests in parallel (`--jobs` flag), otherwise set to 1. 
+  See GNU Parallel's documentation on the `{%}` replacement string 
+  for more details.
 * `$BATS_TMPDIR` is the location to a directory that may be used to store
   temporary files.
 

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -93,7 +93,7 @@ if [[ "$num_jobs" != 1 ]]; then
   # amount of overhead using it over a simple loop in the serial case.
   set -o pipefail
   printf '%s\n' "${all_tests[@]}" | grep -v '^$' | \
-    parallel -qk -j "$num_jobs" --colsep="\t" -- bats-exec-test "${flags[@]}" '{1}' '{2}' '{#}' || status=1
+    parallel -qk -j "$num_jobs" --colsep="\t" -- bats-exec-test "${flags[@]}" '{1}' '{2}' '{#}' '{%}' || status=1
 else
   # Just do it serially.
   test_number=0
@@ -103,7 +103,7 @@ else
       filename="${test_line%%$'\t'*}"
       test_name="${test_line##*$'\t'}"
       ((++test_number))
-      bats-exec-test "${flags[@]}" "$filename" "$test_name" "$test_number" || status=1
+      bats-exec-test "${flags[@]}" "$filename" "$test_name" "$test_number" 1 || status=1
     fi
   done
   if [[ "${test_number}" != "${test_count}" ]]; then

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -320,6 +320,7 @@ bats_exit_trap() {
 bats_perform_test() {
   BATS_TEST_NAME="$1"
   BATS_TEST_NUMBER="$2"
+  BATS_JOB_SLOT="$3"
 
   if ! declare -F "$BATS_TEST_NAME" &>/dev/null; then
     printf "bats: unknown test name \`%s'\n" "$BATS_TEST_NAME" >&2


### PR DESCRIPTION
This new variable is set to the job slot number (`{%}` replacement string from GNU
Parallel) when running tests in parallel (`--jobs` flag). Otherwise it's set to
1 for consistency.

In situations in which tests have resource conflicts when running in parallel
(i.e. tests need dedicated resources) BATS_JOB_SLOT can be used to establish
what resources the test should use.

Dedicated resources will be created per slot beforehand, and the tests will know
which resource to use based on their slot number, guaranteeing no clashes.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
