### PR TITLE
Add a default workdir to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,6 @@ RUN apk add --no-cache parallel && \
 RUN ln -s /opt/bats/bin/bats /usr/sbin/bats
 COPY . /opt/bats/
 
+WORKDIR /code/
+
 ENTRYPOINT ["bash", "/usr/sbin/bats"]

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ To run Bats' internal test suite (which is in the container image at
 To run a test suite from your local machine, mount in a volume and direct Bats
 to its path inside the container:
 
-    $ docker run -it -v "$(pwd):/code" bats/bats:latest /code/test
+    $ docker run -it -v "$(pwd):/code" bats/bats:latest test
 
 This is a minimal Docker image. If more tools are required this can be used as a 
 base image in a Dockerfile using `FROM <Docker image>`.  In the future there may 


### PR DESCRIPTION
This way we don't need to use the full path of the mounted folder
as long as we mount to the default working directory which is
`/code/` according to the README.