### PR TITLE
Don't clobber IFS

### DIFF
--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -61,18 +61,26 @@ load() {
 }
 
 run() {
-  local origFlags="$-"
-  set +eET
-  local origIFS="$IFS"
+  local e E T
+  [[ ! "$-" =~ e ]] || e=1
+  [[ ! "$-" =~ E ]] || E=1
+  [[ ! "$-" =~ T ]] || T=1
+  set +e
+  set +E
+  set +T
   # 'output', 'status', 'lines' are global variables available to tests.
   # shellcheck disable=SC2034
   output="$("$@" 2>&1)"
   # shellcheck disable=SC2034
   status="$?"
   # shellcheck disable=SC2034,SC2206
-  IFS=$'\n' lines=($output)
-  IFS="$origIFS"
-  set "-$origFlags"
+  lines=()
+  while read -r; do
+    lines+=("$REPLY")
+  done < <(printf '%s\n' "$lines")
+  [ -z "$e" ] || set -e
+  [ -z "$E" ] || set -E
+  [ -z "$T" ] || set -T
 }
 
 setup() {


### PR DESCRIPTION
I originally had a test that looked like this:
```
FLAGS="a a h i l p r s"

@test "all allowed global flags" {
  run bash -c '( FOO=$@; echo "testuser1"; echo "$PASS"; sleep 3; <<lots of stuff>>) |telnet localhost 1111' $FLAGS
  for j in ${FLAGS}; do
    echo "Flag is: $j"
    [[ ${output} =~ $BAR ]]
  done
}
```
But it would fail:
Output: 
```
not ok 4 all allowed global flags
# (in test file tests/flags.bats, line 46)
#   `[[ ${output} =~ $BAR ]]' failed
# Flag is: a a h i l p r s
```
With that for loop, I expected $j to be a single char, not the entire string. Working with a helper from #bash on Freenode, he identified that the run command clobbers IFS and it isn't reset properly. He also went on to state that, as written, the IFS code could cause further issues:
```
touch 'derpity derp' 'da teedly dum'
output=$'line1\n*\nline3'
IFS=$'\n' lines=($output)
declare -p lines
```
yields:
```
[0]="line1" [1]="da teedly dum" [2]="derpity derp" [3]="line3"
```

This works in 3.2 and higher (something like ```mapfile -t lines <<<"$output"```  would be suitable for 4.0+). 

Feel free to improve on this as you see fit, but hopefully this is of use to someone.

- [X ] I have reviewed the [Contributor Guidelines][contributor].
- [ X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
