### PR TITLE
Update Docker infrastructure for bats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apk add --no-cache parallel ncurses && \
     mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 
 RUN ln -s /opt/bats/bin/bats /usr/local/bin/bats
-WORKDIR /opt/bats
-COPY . .
+COPY . /opt/bats/
+
+WORKDIR /code/
 
 ENTRYPOINT ["bash", "bats"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ FROM bash:${bashver}
 RUN apk add --no-cache parallel ncurses && \
     mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 
-RUN ln -s /opt/bats/bin/bats /usr/sbin/bats
-COPY . /opt/bats/
+RUN ln -s /opt/bats/bin/bats /usr/local/bin/bats
+WORKDIR /opt/bats
+COPY . .
 
-ENTRYPOINT ["bash", "/usr/sbin/bats"]
+ENTRYPOINT ["bash", "bats"]

--- a/README.md
+++ b/README.md
@@ -169,10 +169,14 @@ To run Bats' internal test suite (which is in the container image at
 
     $ docker run -it bats/bats:latest /opt/bats/test
 
-To run a test suite from your local machine, mount in a volume and direct Bats
-to its path inside the container:
+To run a test suite from a directory called `test` in the current directory of
+your local machine, mount in a volume and direct Bats to its path inside the
+container:
 
-    $ docker run -it -v "$(pwd):/opt/bats" bats/bats:latest /opt/bats/test
+    $ docker run -it -v "${PWD}:/code" bats/bats:latest test
+
+> `/code` is the working directory of the Docker image. "${PWD}/test" is the
+> location of the test directory on the local machine.
 
 This is a minimal Docker image. If more tools are required this can be used as a
 base image in a Dockerfile using `FROM <Docker image>`.  In the future there may
@@ -180,7 +184,8 @@ be images based on Debian, and/or with more tools installed (`curl` and `openssl
 for example). If you require a specific configuration please search and +1 an
 issue or [raise a new issue](https://github.com/bats-core/bats-core/issues).
 
-Further usage examples are in [the wiki](https://github.com/bats-core/bats-core/wiki/Docker-Usage-Examples).
+Further usage examples are in
+[the wiki](https://github.com/bats-core/bats-core/wiki/Docker-Usage-Examples).
 
 ## Usage
 
@@ -277,10 +282,10 @@ with dependencies between tests (or tests that write to shared locations). When
 enabling `--jobs` for the first time be sure to re-run bats multiple times to
 identify any inter-test dependencies or non-deterministic test behaviour.
 
-If your code relies on variables from the environment, or from `setup_file()`, 
-you need to specify `--parallel-preserve-environment` as well. Note that this 
-requires running `parallel --record-env` first as a setup step as GNU Parallel 
-will refuse to run without. Only environment variables that were **not** set 
+If your code relies on variables from the environment, or from `setup_file()`,
+you need to specify `--parallel-preserve-environment` as well. Note that this
+requires running `parallel --record-env` first as a setup step as GNU Parallel
+will refuse to run without. Only environment variables that were **not** set
 during this setup step will be preserved!
 
 [gnu-parallel]: https://www.gnu.org/software/parallel/
@@ -404,7 +409,7 @@ after each test case, respectively. Use these to load fixtures, set up your
 environment, and clean up when you're done.
 
 You can also define `setup_file` and `teardown_file`, which will run once per file,
-before the first and after the last test, respectively. 
+before the first and after the last test, respectively.
 __WARNING__ these will not be run in parallel mode!
 
 

--- a/docker-compose.override.dist
+++ b/docker-compose.override.dist
@@ -1,0 +1,8 @@
+# Copy this file to docker-compose.override.yml
+version: '3.6'
+services:
+    bats:
+        entrypoint:
+            - "bash"
+networks:
+    default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.6'
+services:
+    bats:
+        build:
+            context: "."
+            dockerfile: "Dockerfile"
+        networks:
+            - "default"
+        user: "root"
+        volumes:
+            - "./:/opt/bats"
+networks:
+    default:


### PR DESCRIPTION
Bats is no longer installed in `/usr/sbin`, bats isn't a sbin candidate. It is
moved to `/usr/local/bin`. This should not have any side effects as
`/usr/local/bin` should be in ones PATH.

Have a default docker-compose.yml for users that they can use to easily play
with docker-compose.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
