### PR TITLE
add todo and done features

### DIFF
--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -89,6 +89,10 @@ skip() {
   exit 0
 }
 
+todo() {
+  BATS_TEST_TODO="${1:-1}"
+}
+
 bats_test_begin() {
   BATS_TEST_DESCRIPTION="$1"
   if [[ -n "$BATS_EXTENDED_SYNTAX" ]]; then
@@ -272,12 +276,23 @@ bats_exit_trap() {
   local line
   local status
   local skipped=''
+  local todo=''
+  local done_=''
   trap - ERR EXIT
 
   if [[ -n "$BATS_TEST_SKIPPED" ]]; then
     skipped=' # skip'
     if [[ "$BATS_TEST_SKIPPED" != '1' ]]; then
       skipped+=" $BATS_TEST_SKIPPED"
+    fi
+  fi
+
+  if [[ -n "$BATS_TEST_TODO" ]]; then
+    todo=" # todo"
+    done_=" # done"
+    if [[ "$BATS_TEST_TODO" != '1' ]]; then
+      todo+=" $BATS_TEST_TODO"
+      done_+=" $BATS_TEST_TODO"
     fi
   fi
 
@@ -295,7 +310,8 @@ bats_exit_trap() {
       BATS_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
       BATS_ERROR_STATUS=1
     fi
-    printf 'not ok %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
+    printf 'not ok %d %s%s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" \
+      "$todo" >&3
     bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
     bats_print_failed_command >&3
 
@@ -307,8 +323,8 @@ bats_exit_trap() {
     fi
     status=1
   else
-    printf 'ok %d %s%s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" \
-      "$skipped" >&3
+    printf 'ok %d %s%s%s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" \
+      "$skipped" "$done_" >&3
     status=0
   fi
 

--- a/libexec/bats-core/bats-format-tap-stream
+++ b/libexec/bats-core/bats-format-tap-stream
@@ -10,6 +10,8 @@ if [[ "$header" =~ $header_pattern ]]; then
   passed=0
   failures=0
   skipped=0
+  done_=0
+  todo=0
   name=
   count_column_width=$(( ${#count} * 2 + 2 ))
 else
@@ -51,6 +53,26 @@ skip() {
   advance
 }
 
+todo_print() {
+  local reason="$1"
+  if [[ -n "$reason" ]]; then
+    reason=": $reason"
+  fi
+  go_to_column 0
+  buffer " - %s (todo%s)" "$name" "$reason"
+  advance
+}
+
+done_print() {
+  local reason="$1"
+  if [[ -n "$reason" ]]; then
+      reason=": $reason"
+  fi
+  go_to_column 0
+  buffer " ✓ %s (done%s)" "$name" "$reason"
+  advance
+}
+
 fail() {
   go_to_column 0
   set_color 1 bold
@@ -77,6 +99,14 @@ summary() {
 
   if [[ "$skipped" -gt 0 ]]; then
     buffer ', %d skipped' "$skipped"
+  fi
+
+  if [[ "$todo" -gt 0 ]]; then
+    buffer ", %d todo" "$todo"
+  fi
+
+  if [[ "$done_" -gt 0 ]]; then
+    buffer ", %d done" "$done_"
   fi
 
   not_run=$((count - passed - failures - skipped))
@@ -162,17 +192,27 @@ while IFS= read -r line; do
     ;;
   'ok '* )
     skip_expr="ok $index (.*) # skip ?(([[:print:]]*))?"
+    done_expr="ok $index (.*) # done ?(([[:print:]]*))?"
     if [[ "$line" =~ $skip_expr ]]; then
       ((++skipped))
       skip "${BASH_REMATCH[2]}"
+    elif [[ "$line" =~ $done_expr ]]; then
+      ((++done_))
+      done_print "${BASH_REMATCH[2]}"
     else
       ((++passed))
       pass
     fi
     ;;
   'not ok '* )
-    ((++failures))
-    fail
+    todo_expr="not ok $index (.*) # todo ?(([[:print:]]*))?"
+    if [[ "$line" =~ $todo_expr ]]; then  
+      ((++todo))
+      todo_print "${BASH_REMATCH[2]}"
+    else
+      ((++failures))
+      fail
+    fi 
     ;;
   '# '* )
     log "${line:2}"

--- a/test/fixtures/todo.bats
+++ b/test/fixtures/todo.bats
@@ -1,0 +1,19 @@
+@test "a test marked todo that fails" {
+  todo
+  false
+}
+
+@test "a test marked todo with a reason that fails" {
+  todo "a reason"
+  false
+}
+
+@test "a test marked todo that passes" {
+  todo
+  true
+}
+
+@test "a test marked todo with a reason that passes" {
+  todo "a reason"
+  true
+}


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

This is a continuation of PR38 (https://github.com/bats-core/bats-core/pull/38). Unfortunately, that PR was so old and I encountered some problems rebasing against master, so it was faster for me to start from scratch.

I have added the todo directive as described in the TAP specification - https://testanything.org/tap-version-13-specification.html

The syntax is similar to the skip directive:
```
@test "todo test that passes" {
  todo "this todo is done"
  return 0
}

@test "todo test that fails" {
  todo "this todo is outstanding"
  return 1
}
```
This results in
```
 ✓ todo test that passes (done: this todo is done)
 - todo test that fails (todo: this todo is outstanding)
   (in test file todo.tap, line 7)
     `todo "this todo is outstanding"' failed

2 tests, 0 failures, 1 todo, 1 done
```
and in TAP format:
```
1..2
ok 1 todo test that passes # done this todo is done
not ok 2 todo test that fails # todo this todo is outstanding
# (in test file todo.tap, line 7)
#   `todo "this todo is outstanding"' failed
```