### PR TITLE
Reimplement load to be more useable and consistent

### DIFF
--- a/test/bats.bats
+++ b/test/bats.bats
@@ -196,6 +196,11 @@ fixtures bats
   [ $status -eq 0 ]
 }
 
+@test "load sources relative scripts with filename extension" {
+  HELPER_NAME="test_helper.bash" run bats "$FIXTURE_ROOT/load.bats"
+  [ $status -eq 0 ]
+}
+
 @test "load aborts if the specified script does not exist" {
   HELPER_NAME="nonexistent" run bats "$FIXTURE_ROOT/load.bats"
   [ $status -eq 1 ]
@@ -209,6 +214,19 @@ fixtures bats
 @test "load aborts if the script, specified by an absolute path, does not exist" {
   HELPER_NAME="${FIXTURE_ROOT}/nonexistent" run bats "$FIXTURE_ROOT/load.bats"
   [ $status -eq 1 ]
+}
+
+@test "load relative script with ambiguous name" {
+  HELPER_NAME="ambiguous" run bats "$FIXTURE_ROOT/load.bats"
+  [ $status -eq 0 ]
+}
+
+@test "load supports scripts on the PATH" {
+  path_dir="$BATS_TMPNAME/path"
+  mkdir -p "$path_dir"
+  cp "${FIXTURE_ROOT}/test_helper.bash" "${path_dir}/on_path"
+  PATH="${path_dir}:$PATH"  HELPER_NAME="on_path" run bats "$FIXTURE_ROOT/load.bats"
+  [ $status -eq 0 ]
 }
 
 @test "output is discarded for passing tests and printed for failing tests" {

--- a/test/fixtures/bats/ambiguous
+++ b/test/fixtures/bats/ambiguous
@@ -1,0 +1,5 @@
+# Helper to detect regressions in load's lookup ordering.
+# An exact name match should be prioritized over name.bash.
+
+echo "Should not have loaded this file!" >&2
+exit 1

--- a/test/fixtures/bats/ambiguous.bash
+++ b/test/fixtures/bats/ambiguous.bash
@@ -1,0 +1,6 @@
+# Helper to detect regressions in load's lookup ordering.
+# An exact name match should be prioritized over name.bash.
+
+echo "This is the expected file to load."
+
+help_me() { :; }


### PR DESCRIPTION
The existing behavior of `load` accepts absolute paths or relative paths - without a `.bash` suffix. This is inconsistent and confusing, both because the `.bash` suffix is arbitrary but also because absolute paths don't have the same constraint.

`load` is re-implemented to behave as a more consistent shorthand for `source`-ing files relative to `BATS_TEST_DIRNAME`, while falling back to `source` the argument as-is if the relative path does not resolve. The `.bash` suffix behavior is preserved for backwards compatibility, but any relative path is now supported. In addition (since `source` supports this natively) scripts on the system `PATH` can also be `load`-ed.

Fixes #79

---

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
