### PR TITLE
Release automation used in 1.2.0

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# bats-core git releaser
+#
+## Usage: %SCRIPT_NAME% [options]
+##
+## Options:
+##   --major            Major version bump
+##   --minor            Minor version bump
+##   --patch            Patch version bump
+##
+##   -v, --version      Print version
+##   --debug            Enable debug mode
+##   -h, --help         Display this message
+##
+
+set -Eeuo pipefail
+
+DIR=$(cd "$(dirname "${0}")" && pwd)
+THIS_SCRIPT="${DIR}/$(basename "${0}")"
+BATS_VERSION=$(
+  # shellcheck disable=SC1090
+  source <(grep '^export BATS_VERSION=' libexec/bats-core/bats)
+  echo "${BATS_VERSION}"
+)
+declare -r DIR
+declare -r THIS_SCRIPT
+declare -r BATS_VERSION
+
+BUMP_INTERVAL=""
+NEW_BATS_VERSION=""
+
+main() {
+  handle_arguments "${@}"
+
+  if [[ "${BUMP_INTERVAL:-}" == "" ]]; then
+    echo "${BATS_VERSION}"
+    exit 0
+  fi
+
+  local NEW_BATS_VERSION
+  NEW_BATS_VERSION=$(semver bump "${BUMP_INTERVAL}" "${BATS_VERSION}")
+  declare -r NEW_BATS_VERSION
+
+  echo "Releasing: ${BATS_VERSION} to ${NEW_BATS_VERSION}"
+  echo
+
+  replace_in_files
+
+  write_changelog
+
+  git diff --staged
+
+  cat <<EOF
+# To complete the release:
+
+git commit -m "feat: release Bats ${NEW_BATS_VERSION}"
+
+git tag -a -s "${NEW_BATS_VERSION}"
+# Include the docs/CHANGELOG.md notes corresponding to the new version as the
+# tag annotation, except the first line should be: Bats ${NEW_BATS_VERSION} - $(date +%Y-%m-%d)
+# and any Markdown headings should become plain text
+
+git push --follow-tags
+
+# navigate to https://github.com/bats-core/bats-core/releases and follow
+# instuctions in docs/releasing.md
+# - Name the release: Bats ${NEW_BATS_VERSION}
+# - Paste the same notes from the version tag annotation as the description,
+#   except change the first line to read: Released: $(date +%Y-%m-%d).
+EOF
+
+  exit 0
+}
+
+replace_in_files() {
+  declare -a FILE_REPLACEMENTS=(
+    ".appveyor.yml,^version:"
+    "contrib/rpm/bats.spec,^Version:"
+    "libexec/bats-core/bats,^export BATS_VERSION="
+    "package.json,^  \"version\":"
+  )
+
+  for FILE_REPLACEMENT in "${FILE_REPLACEMENTS[@]}"; do
+    FILE="${FILE_REPLACEMENT/,*/}"
+    MATCH="${FILE_REPLACEMENT/*,/}"
+    sed -E -i.bak "/${MATCH}/ { s,${BATS_VERSION},${NEW_BATS_VERSION},g; }" "${FILE}"
+    rm "${FILE}.bak" || true
+    git add -f "${FILE}"
+  done
+}
+
+write_changelog() {
+  local FILE="docs/CHANGELOG.md"
+  sed -E -i.bak "/## \[Unreleased\]/ a \\\n## [${NEW_BATS_VERSION}] - $(date +%Y-%m-%d)" "${FILE}"
+
+  rm "${FILE}.bak" || true
+
+  cp "${FILE}" "${FILE}.new"
+  sed -E -i.bak '/## \[Unreleased\]/,+1d' "${FILE}"
+  git add -f "${FILE}"
+  mv "${FILE}.new" "${FILE}"
+}
+
+handle_arguments() {
+  parse_arguments "${@:-}"
+}
+
+parse_arguments() {
+  local CURRENT_ARG
+
+  if [[ "${#}" == 1 && "${1:-}" == "" ]]; then
+    return 0
+  fi
+
+  while [[ "${#}" -gt 0 ]]; do
+    CURRENT_ARG="${1}"
+
+    case ${CURRENT_ARG} in
+    --major)
+      BUMP_INTERVAL="major"
+      ;;
+    # ---
+    --minor)
+      BUMP_INTERVAL="minor"
+      ;;
+    --patch)
+      BUMP_INTERVAL="patch"
+      ;;
+    -h | --help) usage ;;
+    -v | --version)
+      get_version
+      exit 0
+      ;;
+    --debug)
+      set -xe
+      ;;
+    -*) usage "${CURRENT_ARG}: unknown option" ;;
+    esac
+    shift
+  done
+}
+
+semver() {
+  "${DIR}/semver" "${@:-}"
+}
+
+usage() {
+  sed -n '/^##/,/^$/s/^## \{0,1\}//p' "${THIS_SCRIPT}" | sed "s/%SCRIPT_NAME%/$(basename "${THIS_SCRIPT}")/g"
+  exit 2
+} 2>/dev/null
+
+get_version() {
+  echo "${THIS_SCRIPT_VERSION:-0.1}"
+}
+
+main "${@}"

--- a/contrib/semver
+++ b/contrib/semver
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+
+# v3.0.0
+# https://github.com/fsaintjacques/semver-tool
+
+set -o errexit -o nounset -o pipefail
+
+NAT='0|[1-9][0-9]*'
+ALPHANUM='[0-9]*[A-Za-z-][0-9A-Za-z-]*'
+IDENT="$NAT|$ALPHANUM"
+FIELD='[0-9A-Za-z-]+'
+
+SEMVER_REGEX="\
+^[vV]?\
+($NAT)\\.($NAT)\\.($NAT)\
+(\\-(${IDENT})(\\.(${IDENT}))*)?\
+(\\+${FIELD}(\\.${FIELD})*)?$"
+
+PROG=semver
+PROG_VERSION="3.0.0"
+
+USAGE="\
+Usage:
+  $PROG bump (major|minor|patch|release|prerel <prerel>|build <build>) <version>
+  $PROG compare <version> <other_version>
+  $PROG get (major|minor|patch|release|prerel|build) <version>
+  $PROG --help
+  $PROG --version
+
+Arguments:
+  <version>  A version must match the following regular expression:
+             \"${SEMVER_REGEX}\"
+             In English:
+             -- The version must match X.Y.Z[-PRERELEASE][+BUILD]
+                where X, Y and Z are non-negative integers.
+             -- PRERELEASE is a dot separated sequence of non-negative integers and/or
+                identifiers composed of alphanumeric characters and hyphens (with
+                at least one non-digit). Numeric identifiers must not have leading
+                zeros. A hyphen (\"-\") introduces this optional part.
+             -- BUILD is a dot separated sequence of identifiers composed of alphanumeric
+                characters and hyphens. A plus (\"+\") introduces this optional part.
+
+  <other_version>  See <version> definition.
+
+  <prerel>  A string as defined by PRERELEASE above.
+
+  <build>   A string as defined by BUILD above.
+
+Options:
+  -v, --version          Print the version of this tool.
+  -h, --help             Print this help message.
+
+Commands:
+  bump     Bump by one of major, minor, patch; zeroing or removing
+           subsequent parts. \"bump prerel\" sets the PRERELEASE part and
+           removes any BUILD part. \"bump build\" sets the BUILD part.
+           \"bump release\" removes any PRERELEASE or BUILD parts.
+           The bumped version is written to stdout.
+
+  compare  Compare <version> with <other_version>, output to stdout the
+           following values: -1 if <other_version> is newer, 0 if equal, 1 if
+           older. The BUILD part is not used in comparisons.
+
+  get      Extract given part of <version>, where part is one of major, minor,
+           patch, prerel, build, or release.
+
+See also:
+  https://semver.org -- Semantic Versioning 2.0.0"
+
+function error {
+  echo -e "$1" >&2
+  exit 1
+}
+
+function usage-help {
+  error "$USAGE"
+}
+
+function usage-version {
+  echo -e "${PROG}: $PROG_VERSION"
+  exit 0
+}
+
+function validate-version {
+  local version=$1
+  if [[ "$version" =~ $SEMVER_REGEX ]]; then
+    # if a second argument is passed, store the result in var named by $2
+    if [ "$#" -eq "2" ]; then
+      local major=${BASH_REMATCH[1]}
+      local minor=${BASH_REMATCH[2]}
+      local patch=${BASH_REMATCH[3]}
+      local prere=${BASH_REMATCH[4]}
+      local build=${BASH_REMATCH[8]}
+      eval "$2=(\"$major\" \"$minor\" \"$patch\" \"$prere\" \"$build\")"
+    else
+      echo "$version"
+    fi
+  else
+    error "version $version does not match the semver scheme 'X.Y.Z(-PRERELEASE)(+BUILD)'. See help for more information."
+  fi
+}
+
+function is-nat {
+    [[ "$1" =~ ^($NAT)$ ]]
+}
+
+function is-null {
+    [ -z "$1" ]
+}
+
+function order-nat {
+    [ "$1" -lt "$2" ] && { echo -1 ; return ; }
+    [ "$1" -gt "$2" ] && { echo 1 ; return ; }
+    echo 0
+}
+
+function order-string {
+    [[ $1 < $2 ]] && { echo -1 ; return ; }
+    [[ $1 > $2 ]] && { echo 1 ; return ; }
+    echo 0
+}
+
+# given two (named) arrays containing NAT and/or ALPHANUM fields, compare them
+# one by one according to semver 2.0.0 spec. Return -1, 0, 1 if left array ($1)
+# is less-than, equal, or greater-than the right array ($2).  The longer array
+# is considered greater-than the shorter if the shorter is a prefix of the longer.
+#
+function compare-fields {
+    local l="$1[@]"
+    local r="$2[@]"
+    local leftfield=( "${!l}" )
+    local rightfield=( "${!r}" )
+    local left
+    local right
+
+    local i=$(( -1 ))
+    local order=$(( 0 ))
+
+    while true
+    do
+        [ $order -ne 0 ] && { echo $order ; return ; }
+
+        : $(( i++ ))
+        left="${leftfield[$i]}"
+        right="${rightfield[$i]}"
+
+        is-null "$left" && is-null "$right" && { echo 0  ; return ; }
+        is-null "$left"                     && { echo -1 ; return ; }
+                           is-null "$right" && { echo 1  ; return ; }
+
+        is-nat "$left" &&  is-nat "$right" && { order=$(order-nat "$left" "$right") ; continue ; }
+        is-nat "$left"                     && { echo -1 ; return ; }
+                           is-nat "$right" && { echo 1  ; return ; }
+                                              { order=$(order-string "$left" "$right") ; continue ; }
+    done
+}
+
+# shellcheck disable=SC2206     # checked by "validate"; ok to expand prerel id's into array
+function compare-version {
+  local order
+  validate-version "$1" V
+  validate-version "$2" V_
+
+  # compare major, minor, patch
+
+  local left=( "${V[0]}" "${V[1]}" "${V[2]}" )
+  local right=( "${V_[0]}" "${V_[1]}" "${V_[2]}" )
+
+  order=$(compare-fields left right)
+  [ "$order" -ne 0 ] && { echo "$order" ; return ; }
+
+  # compare pre-release ids when M.m.p are equal
+
+  local prerel="${V[3]:1}"
+  local prerel_="${V_[3]:1}"
+  local left=( ${prerel//./ } )
+  local right=( ${prerel_//./ } )
+
+  # if left and right have no pre-release part, then left equals right
+  # if only one of left/right has pre-release part, that one is less than simple M.m.p
+
+  [ -z "$prerel" ] && [ -z "$prerel_" ] && { echo 0  ; return ; }
+  [ -z "$prerel" ]                      && { echo 1  ; return ; }
+                      [ -z "$prerel_" ] && { echo -1 ; return ; }
+
+  # otherwise, compare the pre-release id's
+
+  compare-fields left right
+}
+
+function command-bump {
+  local new; local version; local sub_version; local command;
+
+  case $# in
+    2) case $1 in
+        major|minor|patch|release) command=$1; version=$2;;
+        *) usage-help;;
+       esac ;;
+    3) case $1 in
+        prerel|build) command=$1; sub_version=$2 version=$3 ;;
+        *) usage-help;;
+       esac ;;
+    *) usage-help;;
+  esac
+
+  validate-version "$version" parts
+  # shellcheck disable=SC2154
+  local major="${parts[0]}"
+  local minor="${parts[1]}"
+  local patch="${parts[2]}"
+  local prere="${parts[3]}"
+  local build="${parts[4]}"
+
+  case "$command" in
+    major) new="$((major + 1)).0.0";;
+    minor) new="${major}.$((minor + 1)).0";;
+    patch) new="${major}.${minor}.$((patch + 1))";;
+    release) new="${major}.${minor}.${patch}";;
+    prerel) new=$(validate-version "${major}.${minor}.${patch}-${sub_version}");;
+    build) new=$(validate-version "${major}.${minor}.${patch}${prere}+${sub_version}");;
+    *) usage-help ;;
+  esac
+
+  echo "$new"
+  exit 0
+}
+
+function command-compare {
+  local v; local v_;
+
+  case $# in
+    2) v=$(validate-version "$1"); v_=$(validate-version "$2") ;;
+    *) usage-help ;;
+  esac
+
+  set +u                        # need unset array element to evaluate to null
+  compare-version "$v" "$v_"
+  exit 0
+}
+
+
+# shellcheck disable=SC2034
+function command-get {
+    local part version
+
+    if [[ "$#" -ne "2" ]] || [[ -z "$1" ]] || [[ -z "$2" ]]; then
+        usage-help
+        exit 0
+    fi
+
+    part="$1"
+    version="$2"
+
+    validate-version "$version" parts
+    local major="${parts[0]}"
+    local minor="${parts[1]}"
+    local patch="${parts[2]}"
+    local prerel="${parts[3]:1}"
+    local build="${parts[4]:1}"
+    local release="${major}.${minor}.${patch}"
+
+    case "$part" in
+        major|minor|patch|release|prerel|build) echo "${!part}" ;;
+        *) usage-help ;;
+    esac
+
+    exit 0
+}
+
+case $# in
+  0) echo "Unknown command: $*"; usage-help;;
+esac
+
+case $1 in
+  --help|-h) echo -e "$USAGE"; exit 0;;
+  --version|-v) usage-version ;;
+  bump) shift; command-bump "$@";;
+  get) shift; command-get "$@";;
+  compare) shift; command-compare "$@";;
+  *) echo "Unknown arguments: $*"; usage-help;;
+esac


### PR DESCRIPTION
Tooling built whilst releasing 1.2.0.

```bash
$ contrib/release.sh --help
Usage: release.sh [options]

Options:
  --major            Major version bump
  --minor            Minor version bump
  --patch            Patch version bump

  -v, --version      Print version
  --debug            Enable debug mode
  -h, --help         Display this message
```
---

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
