### PR TITLE
Fix abort usage

### DIFF
--- a/bin/bats
+++ b/bin/bats
@@ -10,7 +10,7 @@ elif command -v 'readlink' >/dev/null; then
   BATS_READLINK='readlink'
 fi
 
-if ! "${BATS_READLINK}" -m $0 &>/dev/null; then
+if ! "${BATS_READLINK}" -m "$0" &>/dev/null; then
   BATS_REALPATH='realpath'
 fi
 
@@ -20,7 +20,7 @@ resolve_path() {
 
   if [[ -L "${path_to_bats}" ]]; then
     # Busybox has no readlink from coreutils
-    if [[ ! -z "$BATS_REALPATH" ]]; then
+    if [[ -n "$BATS_REALPATH" ]]; then
       target_path="$("$BATS_REALPATH" "$path_to_bats")"
       # we need to traverse the paths
       target_path="$(dirname "$target_path")" # strip bats
@@ -30,14 +30,14 @@ resolve_path() {
     fi
   elif [[ -f "${path_to_bats}" ]]; then
     target_path=$(dirname "$path_to_bats")
-    if [[ ! -z "$BATS_REALPATH" ]]; then
+    if [[ -n "$BATS_REALPATH" ]]; then
       target_path="$("$BATS_REALPATH" "$target_path")"
     else
       target_path="$("$BATS_READLINK" -m "$target_path")"
     fi
     target_path="$(dirname "$target_path")" # strip bin
   elif [[ -d "${path_to_bats}" ]]; then
-    if [[ ! -z "$BATS_REALPATH" ]]; then
+    if [[ -n "$BATS_REALPATH" ]]; then
       target_path="$("$BATS_REALPATH" "$path_to_bats")"
       target_path="$(dirname "$target_path")"
     else

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,21 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 [kac]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/
 
+## [Unreleased]
+
+### Added
+* JUnit output and extensible formatter rewrite (#246) 
+* `load` function now reads from absolute and relative paths, and $PATH (#282)
+* Beginner-friendly examples in /docs/examples (#243)
+
+### Changed
+* Duplicate test names now error (previous behaviour was to issue a warning) (#286)
+* Changed default formatter in Docker to pretty by adding `ncurses` to Dockerfile, override with `--tap` (#239)
+* Replace "readlink -f" dependency with Bash solution (#217)
+
 ## [1.2.0] - 2020-04-25
+
+Support parallel suite execution and filtering by test name.
 
 ### Added
 * docs/CHANGELOG.md and docs/releasing.md (#122)

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -10,7 +10,6 @@ flags=()
 
 abort() {
   printf 'Error: %s\n' "$1" >&2
-  usage >&2
   exit 1
 }
 

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -424,7 +424,7 @@ END_OF_ERR_MSG
 }
 
 @test "duplicate tests error and generate a warning on stderr" {
-  run bats "$FIXTURE_ROOT/duplicate-tests.bats"
+  run bats --tap "$FIXTURE_ROOT/duplicate-tests.bats"
   [ $status -eq 1 ]
 
   local expected='Error: Duplicate test name(s) in file '
@@ -435,7 +435,7 @@ END_OF_ERR_MSG
   [ "${lines[0]}" = "$expected" ]
 
   printf 'num lines: %d\n' "${#lines[*]}" >&2
-  [ "${#lines[*]}" = "2" ]
+  [ "${#lines[*]}" = "1" ]
 }
 
 @test "sourcing a nonexistent file in setup produces error output" {


### PR DESCRIPTION
Corrects a mistake I introduced in 3f97f64d871fa80cfda9747ef6867b99fe9271fd where `abort` tries to call `usage`, which isn't defined in that file. Removes `usage` as it obscures the error message anyway.

Updates changelog for good measure.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
