### PR TITLE
Reintroduce readlink greadlink usage

### DIFF
--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -49,6 +49,7 @@ HELP_TEXT_BODY
 }
 
 expand_link() {
+  readlink="$(command -v greadlink readlink | head -1)"
   IFS='/' read -ra parts <<<"$1"
 
   # Starting point.
@@ -61,7 +62,7 @@ expand_link() {
     [ -e "$path/$part" ] || return 1
 
     # If it's a link, we need to resolve it first.
-    [ -L "$path/$part" ] && part="$(readlink "$path/$part")"
+    [ -L "$path/$part" ] && part="$("$readlink" "$path/$part")"
 
     # If the component starts with "/" we stomp the existing $path.
     [[ "$part" =~ ^/ ]] && path=""


### PR DESCRIPTION
In gh #217 the helper to pick readlink or greadlink was removed and soley relies
on readlink. This will break on systems such as MacOS. Reintroducing the helper
and using the result of whatever came out of it.

Signed-off-by: Wesley Schwengle <wesley@opndev.io>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
