### PR TITLE
Fix the implementation of the run helper function to properly parse lines of output

### DIFF
--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -30,17 +30,18 @@ load() {
 }
 
 run() {
-  local origFlags="$-"
-  set +eET
-  local origIFS="$IFS"
   # 'output', 'status', 'lines' are global variables available to tests.
-  # shellcheck disable=SC2034
+  local line origFlags="$-"
+  set +eET
   output="$("$@" 2>&1)"
-  # shellcheck disable=SC2034
   status="$?"
-  # shellcheck disable=SC2034,SC2206
-  IFS=$'\n' lines=($output)
-  IFS="$origIFS"
+  lines=()
+  while IFS= read -r line; do
+    lines+=("$line")
+  done <<<"$output"
+  if [[ -n "$line" ]]; then # if there's any content after the last newline
+    lines+=("$line")
+  fi
   set "-$origFlags"
 }
 

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -65,7 +65,7 @@ for filename in "$@"; do
 
   test_names=()
   test_dupes=()
-  while read -r line; do
+  while IFS= read -r line; do
     if [[ ! "$line" =~ ^bats_test_function\  ]]; then
       continue
     fi

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -51,13 +51,15 @@ fixtures bats
 @test "summary passing tests" {
   run filter_control_sequences bats -p "$FIXTURE_ROOT/passing.bats"
   [ $status -eq 0 ]
-  [ "${lines[1]}" = "1 test, 0 failures" ]
+  [ "${#lines[@]}" -eq 3 ]
+  [ "${lines[2]}" = "1 test, 0 failures" ]
 }
 
 @test "summary passing and skipping tests" {
   run filter_control_sequences bats -p "$FIXTURE_ROOT/passing_and_skipping.bats"
   [ $status -eq 0 ]
-  [ "${lines[3]}" = "3 tests, 0 failures, 2 skipped" ]
+  [ "${#lines[@]}" -eq 5 ]
+  [ "${lines[4]}" = "3 tests, 0 failures, 2 skipped" ]
 }
 
 @test "tap passing and skipping tests" {
@@ -72,13 +74,15 @@ fixtures bats
 @test "summary passing and failing tests" {
   run filter_control_sequences bats -p "$FIXTURE_ROOT/failing_and_passing.bats"
   [ $status -eq 0 ]
-  [ "${lines[4]}" = "2 tests, 1 failure" ]
+  [ "${#lines[@]}" -eq 6 ]
+  [ "${lines[5]}" = "2 tests, 1 failure" ]
 }
 
 @test "summary passing, failing and skipping tests" {
   run filter_control_sequences bats -p "$FIXTURE_ROOT/passing_failing_and_skipping.bats"
   [ $status -eq 0 ]
-  [ "${lines[5]}" = "3 tests, 1 failure, 1 skipped" ]
+  [ "${#lines[@]}" -eq 7 ]
+  [ "${lines[6]}" = "3 tests, 1 failure, 1 skipped" ]
 }
 
 @test "tap passing, failing and skipping tests" {
@@ -575,4 +579,28 @@ END_OF_ERR_MSG
 
   run bash -c "echo $'1..1\nok 1' | bats_test_count_validator"
   [[ $status -eq 0 ]]
+}
+
+@test "run properly captures output and status" {
+  printlines() {
+    local ret=$1; shift
+    printf '%s\n' "$@"
+    return "$ret"
+  }
+
+  run printlines 5 hello world
+  [ "$status" -eq 5 ]
+  [ "$output" == $'hello\nworld' ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" == 'hello' ]
+  [ "${lines[1]}" == 'world' ]
+
+  run printlines 0 ' whitespace ' '' $'\tand\tspecial\rchars' '*'
+  [ "$status" -eq 0 ]
+  [ "$output" == $' whitespace \n\n\tand\tspecial\rchars\n*' ]
+  [ "${#lines[@]}" -eq 4 ]
+  [ "${lines[0]}" == ' whitespace ' ]
+  [ "${lines[1]}" == '' ]
+  [ "${lines[2]}" == $'\tand\tspecial\rchars' ]
+  [ "${lines[3]}" == '*' ]
 }


### PR DESCRIPTION
The existing behavior is broken, as it relies on the shell to [word-split unquoted variables](https://github.com/koalaman/shellcheck/wiki/SC2206). This breaks down in several ways, notably that empty lines are silently dropped, but also because words-splitting also triggers globbing, so any line that happens to match a shell glob will be expanded in the resulting array.

**This is a breaking change**, but the existing behavior is fundamentally broken and does not work as documented.

Fixes #281 and #284 

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
