### PR TITLE
feat: Add lava support

### DIFF
--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -85,6 +85,14 @@ bats_test_begin() {
   setup
 }
 
+bats_test_end() {
+  BATS_TEST_DESCRIPTION="$1"
+
+  if [[ -n "$BATS_EXTENDED_SYNTAX" ]]; then
+    printf 'end %d %s\n' "$BATS_TEST_NUMBER" "$BATS_TEST_DESCRIPTION" >&3
+  fi
+}
+
 bats_test_function() {
   local test_name="$1"
   BATS_TEST_NAMES+=("$test_name")

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -30,7 +30,7 @@ HELP_TEXT_HEADER
   -c, --count               Count test cases without running any tests
   -f, --filter <regex>      Only run tests that match the regular expression
   -F, --formatter <type>    Switch between formatters: pretty (default),
-                              tap (default w/o term), junit
+                              tap (default w/o term), junit, lava
   -h, --help                Display this help message
   -j, --jobs <jobs>         Number of parallel jobs (requires GNU parallel)
   --parallel-preserve-environment
@@ -42,6 +42,9 @@ HELP_TEXT_HEADER
   -r, --recursive           Include tests in subdirectories
   -t, --tap                 Shorthand for "--formatter tap"
   -T, --timing              Add timing information to tests
+                              (cannot be used with lava formatter)
+  -M, --measurements        Add lava measurement results to tests
+                              (default for lava formatter)
   -v, --version             Display the version number
 
   For more information, see https://github.com/bats-core/bats-core
@@ -155,10 +158,10 @@ while [[ "$#" -ne 0 ]]; do
     ;;
   -F | --formatter)
     shift
-    if [[ $1 =~ ^(pretty|junit|tap)$ ]]; then
+    if [[ $1 =~ ^(pretty|junit|tap|lava)$ ]]; then
       formatter="$1"
     else
-      printf "Unknown formatter '%s', valid options are pretty, junit, tap\n" "$1"
+      printf "Unknown formatter '%s', valid options are pretty, junit, tap, lava\n" "$1"
       exit 1
     fi
     ;;
@@ -182,6 +185,10 @@ while [[ "$#" -ne 0 ]]; do
   -T | --timing)
     flags+=('-T')
     formatter_flags+=('-T')
+    ;;
+  -M | --measurements)
+    flags+=('-M')
+    formatter_flags+=('-M')
     ;;
   --parallel-preserve-environment)
     flags+=("--parallel-preserve-environment")
@@ -219,6 +226,16 @@ fi
 if [[ "$formatter" == "junit" ]]; then
   flags+=('-T')
   formatter_flags+=('-T')
+fi
+
+if [[ "$formatter" == "lava" ]]; then
+  for flag in "${flags[@]}"; do
+    if [[ "$flag" == "-T" ]]; then
+      abort "-T cannot be used with lava formatter"
+    fi
+  done
+  # enable lava measurements
+  flags+=('-M')
 fi
 
 if [[ "${#arguments[@]}" -eq 0 ]]; then

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -22,6 +22,9 @@ while [[ "$#" -ne 0 ]]; do
   -T)
     flags+=('-T')
     ;;
+  -M)
+    flags+=('-M')
+    ;;
   -x)
     flags+=('-x')
     extended_syntax=1

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -31,6 +31,9 @@ while [[ "$#" -ne 0 ]]; do
   -T)
     flags+=('-T')
     ;;
+  -M)
+    flags+=('-M')
+    ;;
   -x)
     flags+=('-x')
     ;;

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -6,6 +6,7 @@ BATS_COUNT_ONLY=''
 BATS_TEST_FILTER=''
 BATS_ENABLE_TIMING=''
 BATS_EXTENDED_SYNTAX=''
+BATS_ENABLE_LAVA_MEASUREMENTS=''
 
 while [[ "$#" -ne 0 ]]; do
   case "$1" in
@@ -21,6 +22,9 @@ while [[ "$#" -ne 0 ]]; do
   -T)
     BATS_ENABLE_TIMING='-T'
     BATS_PERFORM_TEST_CMD+=('-T')
+    ;;
+  -M)
+    BATS_ENABLE_LAVA_MEASUREMENTS='-M'
     ;;
   -x)
     # shellcheck disable=SC2034
@@ -85,6 +89,13 @@ bats_exit_trap() {
     BATS_TEST_TIME=" in "$((SECONDS - BATS_TEST_START_TIME))"sec"
   fi
 
+  BATS_LAVA_MEASUREMENTS=""
+  if [[ -z "${skipped}" && -n "$BATS_ENABLE_LAVA_MEASUREMENTS" ]]; then
+    BATS_LAVA_MEASUREMENTS=" measurement:$lava_measurement units:$lava_units"
+  fi
+
+  bats_test_end "$BATS_TEST_DESCRIPTION" >>"$BATS_OUT" 2>&1
+
   if [[ -z "$BATS_TEST_COMPLETED" || -z "$BATS_TEARDOWN_COMPLETED" ]]; then
     if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
       # For some versions of bash, `$?` may not be set properly for some error
@@ -99,7 +110,7 @@ bats_exit_trap() {
       BATS_STACK_TRACE=("${BATS_CURRENT_STACK_TRACE[@]}")
       BATS_ERROR_STATUS=1
     fi
-    printf 'not ok %d %s\n' "$BATS_TEST_NUMBER" "${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}" >&3
+    printf 'not ok %d %s\n' "$BATS_TEST_NUMBER" "${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}${BATS_LAVA_MEASUREMENTS}" >&3
     bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
     bats_print_failed_command >&3
 
@@ -111,7 +122,7 @@ bats_exit_trap() {
     fi
     status=1
   else
-    printf 'ok %d %s%s\n' "$BATS_TEST_NUMBER" "${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}" \
+    printf 'ok %d %s%s\n' "$BATS_TEST_NUMBER" "${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}${BATS_LAVA_MEASUREMENTS}" \
       "$skipped" >&3
     status=0
   fi

--- a/libexec/bats-core/bats-format-lava
+++ b/libexec/bats-core/bats-format-lava
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -e
+
+header_pattern='[0-9]+\.\.[0-9]+'
+read -r header
+
+if [[ "$header" =~ $header_pattern ]]; then
+  index=0
+  name=
+else
+  # If the first line isn't a TAP plan, print it and pass the rest through
+  printf '%s is not a valid TAP input, exitting\n' "$header"
+  exit 1
+fi
+
+begin() {
+    buffer '<LAVA_SIGNAL_STARTTC %s>' "$name"
+    advance
+}
+
+end() {
+    buffer '<LAVA_SIGNAL_ENDTC %s>' "$name"
+    advance
+}
+
+pass() {
+  local measurement=${1#measurement:}
+  local units=${2#units:}
+
+  # It is valid to have a measurement without units, but not units without a measuremnt
+  if [[ "$measurement" != "" ]] && [[ "$units" != "" ]]; then
+    buffer '<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s MEASUREMENT=%s UNITS=%s>' "$name" "$measurement" "$units"
+  elif [[ "$measurement" != "" ]]; then
+    buffer '<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s MEASUREMENT=%s>' "$name" "$measurement"
+  else
+    buffer '<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s result=pass>' "$name"
+  fi
+
+  advance
+}
+
+skip() {
+  buffer '<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s result=skip>' "$name"
+  true
+}
+
+fail() {
+  buffer '<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s result=fail>' "$name"
+  advance
+}
+
+log() {
+  buffer '   %s\n' "$1"
+}
+
+advance() {
+  buffer '\n'
+}
+
+_buffer=
+
+buffer() {
+  local content
+  # shellcheck disable=SC2059
+  printf -v content -- "$@"
+  _buffer+="$content"
+}
+
+flush() {
+  printf '%s' "$_buffer"
+  [[ -n "$BATS_REPORT_OUTPUT_PATH" ]] && printf '%s' "$_buffer" | tee "$BATS_REPORT_OUTPUT_PATH/report.tap" >/dev/null
+  _buffer=
+}
+
+finish() {
+  flush
+  printf '\n'
+}
+
+trap finish EXIT
+
+measurement_expr='measurement:([[:print:]]*)[[:space:]]units:([[:print:]]*)'
+
+while IFS= read -r line; do
+  case "$line" in
+  'begin'*)
+    ((++index))
+    name="${line#* $index }"
+    begin
+    flush
+    ;;
+  'ok '*)
+    skip_expr="ok $index (.*) # skip ?(([[:print:]]*))?"
+    if [[ "$line" =~ $skip_expr ]]; then
+      skip "${BASH_REMATCH[2]}"
+    else
+      if [[ "$line" =~ $measurement_expr ]]; then
+        pass "measurement:${BASH_REMATCH[1]}" "units:${BASH_REMATCH[2]}"
+      else
+        echo "Could not match output line to measurement regex: $line" >&2
+        exit 1
+      fi
+    fi
+    ;;
+  'not ok '*)
+    fail
+    ;;
+  'end'*)
+    end
+    flush
+    ;;
+  '# '*)
+    log "${line:2}"
+    ;;
+  'suite '*) ;;
+
+  esac
+done

--- a/man/bats.1
+++ b/man/bats.1
@@ -1,94 +1,140 @@
-.\" generated with Ronn-NG/v0.9.0
-.\" http://github.com/apjanke/ronn-ng/tree/0.9.0
-.TH "BATS" "1" "April 2020" "bats-core" "Bash Automated Testing System"
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "BATS" "1" "May 2020" "bats-core" "Bash Automated Testing System"
+.
 .SH "NAME"
 \fBbats\fR \- Bash Automated Testing System
+.
 .SH "SYNOPSIS"
 Usage: bats [OPTIONS] \fItests\fR bats [\-h | \-v]
+.
 .P
 \fItests\fR is the path to a Bats test file, or the path to a directory containing Bats test files (ending with "\.bats")
+.
 .SH "DESCRIPTION"
 Bats is a TAP\-compliant testing framework for Bash\. It provides a simple way to verify that the UNIX programs you write behave as expected\.
+.
 .P
 A Bats test file is a Bash script with special syntax for defining test cases\. Under the hood, each test case is just a function with a description\.
+.
 .P
 Test cases consist of standard shell commands\. Bats makes use of Bash\'s \fBerrexit\fR (\fBset \-e\fR) option when running test cases\. If every command in the test case exits with a \fB0\fR status code (success), the test passes\. In this way, each line is an assertion of truth\.
+.
 .P
 See \fBbats\fR(7) for more information on writing Bats tests\.
+.
 .SH "RUNNING TESTS"
 To run your tests, invoke the \fBbats\fR interpreter with a path to a test file\. The file\'s test cases are run sequentially and in isolation\. If all the test cases pass, \fBbats\fR exits with a \fB0\fR status code\. If there are any failures, \fBbats\fR exits with a \fB1\fR status code\.
+.
 .P
 You can invoke the \fBbats\fR interpreter with multiple test file arguments, or with a path to a directory containing multiple \fB\.bats\fR files\. Bats will run each test file individually and aggregate the results\. If any test case fails, \fBbats\fR exits with a \fB1\fR status code\.
+.
 .SH "OPTIONS"
+.
 .TP
 \fB\-c\fR, \fB\-\-count\fR
 Count the number of test cases without running any tests
+.
 .TP
 \fB\-f\fR, \fB\-\-filter <regex>\fR
 Filter test cases by names matching the regular expression
+.
 .TP
 \fB\-F\fR, \fB\-\-formatter <type>\fR
-Switch between formatters: pretty (default), tap (default w/o term), junit
+Switch between formatters: pretty (default), tap (default w/o term), junit, lava
+.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Display this help message
+.
 .TP
 \fB\-j\fR, \fB\-\-jobs <jobs>\fR
-Display this help message
+Number of parallel jobs (requires GNU parallel)
+.
 .TP
 \fB\-\-parallel\-preserve\-environment\fR
 Preserve the current environment for "\-\-jobs" (run \fBparallel \-\-record\-env\fR before)
+.
 .TP
 \fB\-\-no\-tempdir\-cleanup\fR
 Preserve test output temporary directory
+.
 .TP
 \fB\-o\fR, \fB\-\-output <dir>\fR
 Directory to write report files
+.
 .TP
 \fB\-p\fR, \fB\-\-pretty\fR
 Shorthand for "\-\-formatter pretty"
+.
 .TP
 \fB\-r\fR, \fB\-\-recursive\fR
 Include tests in subdirectories
+.
 .TP
 \fB\-t\fR, \fB\-\-tap\fR
 Shorthand for "\-\-formatter tap"
+.
 .TP
 \fB\-T\fR, \fB\-\-timing\fR
 Add timing information to tests
+.
+.TP
+\fB\-M\fR, \fB\-\-measurements\fR
+Add lava measurement results to tests
+.
 .TP
 \fB\-v\fR, \fB\-\-version\fR
 Display the version number
+.
 .SH "OUTPUT"
 When you run Bats from a terminal, you\'ll see output as each test is performed, with a check\-mark next to the test\'s name if it passes or an "X" if it fails\.
+.
 .IP "" 4
+.
 .nf
+
 $ bats addition\.bats
  ✓ addition using bc
  ✓ addition using dc
 
 2 tests, 0 failures
+.
 .fi
+.
 .IP "" 0
+.
 .P
 If Bats is not connected to a terminal\-\-in other words, if you run it from a continuous integration system or redirect its output to a file\-\-the results are displayed in human\-readable, machine\-parsable TAP format\. You can force TAP output from a terminal by invoking Bats with the \fB\-\-tap\fR option\.
+.
 .IP "" 4
+.
 .nf
+
 $ bats \-\-tap addition\.bats
 1\.\.2
 ok 1 addition using bc
 ok 2 addition using dc
+.
 .fi
+.
 .IP "" 0
+.
 .SH "EXIT STATUS"
 The \fBbats\fR interpreter exits with a value of \fB0\fR if all test cases pass, or \fB1\fR if one or more test cases fail\.
+.
 .SH "SEE ALSO"
 Bats wiki: \fIhttps://github\.com/bats\-core/bats\-core/wiki/\fR
+.
 .P
 \fBbash\fR(1), \fBbats\fR(7)
+.
 .SH "COPYRIGHT"
 (c) 2017\-2018 bats\-core organization
+.
 .br
 (c) 2011\-2016 Sam Stephenson
+.
 .P
 Bats is released under the terms of an MIT\-style license\.

--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -52,7 +52,7 @@ OPTIONS
   * `-f`, `--filter <regex>`:
     Filter test cases by names matching the regular expression
   * `-F`, `--formatter <type>`:
-    Switch between formatters: pretty (default), tap (default w/o term), junit
+    Switch between formatters: pretty (default), tap (default w/o term), junit, lava
   * `-h`, `--help`:
     Display this help message
   * `-j`, `--jobs <jobs>`:
@@ -71,6 +71,8 @@ OPTIONS
     Shorthand for "--formatter tap"
   * `-T`, `--timing`:
     Add timing information to tests
+  * `-M`, `--measurements`:
+    Add lava measurement results to tests
   * `-v`, `--version`:
     Display the version number
 


### PR DESCRIPTION
Support lava formatter.

This requires including test end marker in extended syntax output, because lava expects such markers (signals, in lava parlance). This change could perhaps be factored out to a separate commit, consisting of a definition of bats_test_end and its invocation in bats_exit_trap().

Lava assumes that "measurements" can be passed to the output signals (markers), so a -M option is added to support that e.g. in tap output, if the user wants to see the measurements but prefers tap output for human reading when working on the tests. That same option is implied if the user selects
the lava formatter.

The formatter itself is pretty straightforward: it translates begin, end, ok (including skipped) and not ok to lava signals.

The measurements are passed from an individual test to the framework like in the example below, with lava_measurement and lava_unit variables.

Invocation: bats -F lava file.bats

or

bats -M -F tap file.bats

An example file.bats:

#!/usr/bin/env bats

setup()
{
	true
}

@test "Passing testcase" {
	true
}

@test "Passing testcase with measuerement" {
	lava_measurement="abc"
	true
}

@test "Passing testcase with measuerement and units" {
	lava_measurement="123"
	lava_units="kg"
	true
}

@test "Failing testcase" {
	false
}

@test "Skip me" {
	skip
}

Signed-off-by: Andrzej Pietrasiewicz <andrzej.p@collabora.com>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
