### PR TITLE
Minor doc fix: Fix broken link to "File Descriptor 3"

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,9 +451,9 @@ consumption, but if Bats is called with the `-t` flag, then the TAP stream is
 directly printed to the console.
 
 This has implications if you try to print custom text to the terminal. As
-mentioned in [File descriptor 3](#file-descriptor-3), bats provides a special
-file descriptor, `&3`, that you should use to print your custom text. Here are
-some detailed guidelines to refer to:
+mentioned in [File descriptor 3](#file-descriptor-3-read-this-if-bats-hangs),
+bats provides a special file descriptor, `&3`, that you should use to print
+your custom text. Here are some detailed guidelines to refer to:
 
 - Printing **from within a test function**:
   - To have text printed from within a test function you need to redirect the


### PR DESCRIPTION
Fix broken link to #file-descriptor-3-read-this-if-bats-hangs

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
