### PR TITLE
Fix parallel invocation for debian

### DIFF
--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -167,7 +167,7 @@ bats_run_tests() {
         # use --results to gather output in separate files
         # use --fg mode to retrieve exit codes (all non zero exit codes seem to mapped to 1), but which requires us to suppress its output
         # shellcheck disable=SC2154 #bats_parallel_args is inherited from exec-suite
-        parallel --semaphore -j "$num_jobs" "${bats_parallel_args[@]}" --fg --results "$test_output_dir/{}/" -- bats-exec-test "${flags[@]}" "$filename" "$test_name" "$test_number" >>"$parallel_log_file" 2>&1 &
+        parallel --semaphore -j "$num_jobs" "${bats_parallel_args[@]}" --fg -- bats-exec-test "${flags[@]}" "$filename" "$test_name" "$test_number" >"$test_output_dir/stdout" 2>"$test_output_dir/stderr" &
         pid=$!
         test_pids_and_numbers+=("$pid,$test_number")
       fi

--- a/test/parallell.bats
+++ b/test/parallell.bats
@@ -37,7 +37,8 @@ setup() {
 
 @test "parallel suite execution with --jobs" {
   SECONDS=0
-  run bats --jobs 40 "$FIXTURE_ROOT/suite/"
+  run bash -c "bats --jobs 40 \"${FIXTURE_ROOT}/suite/\" 2> >(grep -v '^parallel: Warning: ')"
+
   duration="$SECONDS"
   echo "$output"
   echo "Duration: $duration"
@@ -52,8 +53,8 @@ setup() {
     done
   done
   # In theory it should take 3s, but let's give it bit of extra time for load tolerance.
-  # (Since there is no limit to load, we cannot totally avoid erronous failures by limited tolerance.)
-  # Also check that parallelization happens accross all files instead of
+  # (Since there is no limit to load, we cannot totally avoid erroneous failures by limited tolerance.)
+  # Also check that parallelization happens across all files instead of
   # linearizing between files, which requires at least 12s
   [[ "$duration" -lt 12 ]] || (echo "If this fails on Travis, make sure the failure is repeatable and not due to heavy load."; false)
 }


### PR DESCRIPTION
parallel's --semaphore mode does not seem to mesh well with --results.
We emulate its behavior by creating the output ourselves.

This is intended to replace #298 

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
