### PR TITLE
Remove "See the Background section above" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ See `docs/CHANGELOG.md`.
 
 **Tuesday, September 19, 2017:** This was forked from [Bats][bats-orig] at
 commit [0360811][].  It was created via `git clone --bare` and `git push
---mirror`. See the [Background](#background) section above for more information.
+--mirror`.
 
 [bats-orig]: https://github.com/sstephenson/bats
 [0360811]: https://github.com/sstephenson/bats/commit/03608115df2071fff4eaaff1605768c275e5f81f


### PR DESCRIPTION
It points to the parent section just one header up, and doesn't offer any "more information". Appears to have been added [here](https://github.com/bats-core/bats-core/commit/3d7e49f642ab34b22c0068c43c8e671d0e03c84e#diff-04c6e90faac2675aa89e2176d2eec7d8R557).

---

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
