### PR TITLE
Add @include directive

### DIFF
--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -93,6 +93,7 @@ expand_path() {
 BATS_LIBEXEC="$(dirname "$(expand_link "${BASH_SOURCE[0]}")")"
 export BATS_CWD="$PWD"
 export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
+export BATS_TEST_INCLUDE="^[[:blank:]]*@include[[:blank:]]+(.*)\$"
 export BATS_TEST_FILTER=
 export PATH="$BATS_LIBEXEC:$PATH"
 export BATS_ROOT_PID=$$

--- a/libexec/bats-core/bats-preprocess
+++ b/libexec/bats-core/bats-preprocess
@@ -31,26 +31,46 @@ bats_encode_test_name() {
   printf -v "$2" '%s' "$result"
 }
 
-test_file="$1"
 tests=()
-{
-  while IFS= read -r line; do
-    line="${line//$'\r'/}"
-    if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
-      name="${BASH_REMATCH[1]#[\'\"]}"
-      name="${name%[\'\"]}"
-      body="${BASH_REMATCH[2]}"
-      bats_encode_test_name "$name" 'encoded_name'
-      printf '%s() { bats_test_begin "%s"; %s\n' "${encoded_name:?}" "$name" "$body" || :
 
-      if [[ -z "$BATS_TEST_FILTER" || "$name" =~ $BATS_TEST_FILTER ]]; then
-        tests+=("$encoded_name")
-      fi
-    else
-      printf '%s\n' "$line"
+read_file () {
+  while [ -n "$1" ]; do
+    test_file="$1"
+    if [[ ! -f "$test_file" ]] && ! type -P "$test_file" >/dev/null; then
+      printf 'bats: %s does not exist\n' "$test_file" >&2
+      exit 1
     fi
+    {
+      while IFS= read -r line; do
+        line="${line//$'\r'/}"
+        if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
+          name="${BASH_REMATCH[1]#[\'\"]}"
+          name="${name%[\'\"]}"
+          body="${BASH_REMATCH[2]}"
+          bats_encode_test_name "$name" 'encoded_name'
+          printf '%s() { bats_test_begin "%s"; %s\n' "${encoded_name:?}" "$name" "$body" || :
+
+          if [[ -z "$BATS_TEST_FILTER" || "$name" =~ $BATS_TEST_FILTER ]]; then
+            tests+=("$encoded_name")
+          fi
+        elif [[ "$line" =~ $BATS_TEST_INCLUDE ]]; then
+          name="${BASH_REMATCH[1]#[\'\"]}"
+          name="${name%[\'\"]}"
+          if [[ ${name:0:1} == "/" ]] ; then
+            read_file $name
+          else
+            read_file $( dirname "$test_file")/$name
+          fi
+        else
+          printf '%s\n' "$line"
+        fi
+      done
+    } <<<"$(<"$test_file")"$'\n'
+    shift
   done
-} <<<"$(<"$test_file")"$'\n'
+}
+
+read_file $1
 
 for test_name in "${tests[@]}"; do
   printf 'bats_test_function %s\n' "$test_name"


### PR DESCRIPTION
The files included aren't sourced, so it's possible to have tests in the included files.

Samples :
@test "addition using bc" {
result="$(echo 2+2 | bc)"
[ "$result" -eq 4 ]
}
@include "Tests/*.bats"

- [ ] I have reviewed the [Contributor Guidelines][contributor].
- [ ] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
