### PR TITLE
Add warning about and link to version specific documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> # :warning: WARNING: documentation of unreleased features ahead
+>
+> This is the current development version. You can find the documentation for v1.2.0 [here](../v1.2.0/README.md).
+> Please refer to [this list](docs/versions.md) for older versions.
+
 # Bats-core: Bash Automated Testing System (2018)
 
 [![Latest release](https://img.shields.io/github/release/bats-core/bats-core.svg)](https://github.com/bats-core/bats-core/releases/latest)

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,0 +1,9 @@
+Here are the docs of following versions:
+
+* [v1.2.0](../../v1.2.0/README.md)
+* [v1.1.0](../../v1.1.0/README.md)
+* [v1.0.2](../../v1.0.2/README.md)
+* [v0.4.0](../../v0.4.0/README.md)
+* [v0.3.1](../../v0.3.1/README.md)
+* [v0.2.0](../../v0.2.0/README.md)
+* [v0.1.0](../../v0.1.0/README.md)


### PR DESCRIPTION
Quick fix to solve the confusion described in #318.
The links are relative to make them work on other repos before this has been merged. However, this has the drawback of broken links on branches that contain / in their name.


- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
