### PR TITLE
parallel: preserve environment by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,6 @@ Usage: bats [OPTIONS] <tests>
                               tap (default w/o term), junit
   -h, --help                Display this help message
   -j, --jobs <jobs>         Number of parallel jobs (requires GNU parallel)
-  --parallel-preserve-environment
-                            Preserve the current environment for "--jobs"
-                              (run `parallel --record-env` before)
   --no-tempdir-cleanup      Preserve test output temporary directory
   --no-parallelize-across-files
                             Serialize test file execution instead of running
@@ -292,12 +289,6 @@ Ordering of parallised tests is not guaranteed, so this mode may break suites
 with dependencies between tests (or tests that write to shared locations). When
 enabling `--jobs` for the first time be sure to re-run bats multiple times to
 identify any inter-test dependencies or non-deterministic test behaviour.
-
-If your code relies on variables from the environment, or from `setup_file()`,
-you need to specify `--parallel-preserve-environment` as well. Note that this
-requires running `parallel --record-env` first as a setup step as GNU Parallel
-will refuse to run without. Only environment variables that were **not** set
-during this setup step will be preserved!
 
 When parallelizing, the results of a file only become visible after it has been finished.
 You can use `--no-parallelize-across-files` to get immediate output at the cost of reduced

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -33,9 +33,6 @@ HELP_TEXT_HEADER
                               tap (default w/o term), junit
   -h, --help                Display this help message
   -j, --jobs <jobs>         Number of parallel jobs (requires GNU parallel)
-  --parallel-preserve-environment
-                            Preserve the current environment for "--jobs"
-                              (run `parallel --record-env` before)
   --no-tempdir-cleanup      Preserve test output temporary directory
   --no-parallelize-across-files
                             Serialize test file execution instead of running
@@ -162,12 +159,8 @@ while [[ "$#" -ne 0 ]]; do
     flags+=('-T')
     formatter_flags+=('-T')
     ;;
+  # this flag is now a no-op, as it is the parallel default
   --parallel-preserve-environment)
-    flags+=("--parallel-preserve-environment")
-    # check if parallel's env setup was run before
-    # will print on stderr and return 255 on failure
-    # suppress stdout (on success)
-    parallel --env _ echo ::: 1 >/dev/null || exit 1
     ;;
   --no-parallelize-across-files)
     flags+=("--no-parallelize-across-files")

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -152,7 +152,7 @@ bats_is_next_parallel_test_finished() {
   # get the pid of the next potentially finished test
   PID=$(cat "$output_folder/$(( test_number_in_suite_of_last_finished_test + 1 ))/pid")
   # try to send a signal to this process
-  # if it fails, the process exited, 
+  # if it fails, the process exited,
   # if it succeeds, the process is still running
   if kill -0 "$PID" 2>/dev/null; then
     return 1
@@ -234,7 +234,7 @@ bats_run_tests() {
       if [[ $test_name ]]; then
         ((++test_number_in_suite))
         ((++test_number_in_file))
-        # deal with emtpty flags to avoid spurious "unbound variable" errors on Bash 4.3 and lower
+        # deal with empty flags to avoid spurious "unbound variable" errors on Bash 4.3 and lower
         if [[ "${#flags[@]}" -gt 0 ]]; then
           bats-exec-test "${flags[@]}" "$filename" "$test_name" "$test_number_in_suite" "$test_number_in_file" || status=1
         else

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -36,9 +36,6 @@ while [[ "$#" -ne 0 ]]; do
   -x)
     flags+=('-x')
     ;;
-  --parallel-preserve-environment)
-    bats_parallel_args=("--env" "_")
-    ;;
   --no-parallelize-across-files)
     bats_no_parallelize_across_files=1
     ;;
@@ -128,14 +125,14 @@ IFS=$'\n' read -d '' -r -a  BATS_UNIQUE_TEST_FILENAMES < <(printf "%s\n" "$@"| n
 
 if [[ "$num_jobs" -gt 1 ]] && [[ -z "$bats_no_parallelize_across_files" ]]; then
   # run files in parallel to get the maximum pool of parallel tasks
-  if [[ ${#flags[@]} -eq 0 ]]; then 
+  if [[ ${#flags[@]} -eq 0 ]]; then
     # if there are no flags, our quoting below would keep an empty arg, which is wrong
     parallel "${bats_parallel_args[@]}" --keep-order --jobs "$num_jobs" bats-exec-file "{}" "$TESTS_LIST_FILE"  ::: "${BATS_UNIQUE_TEST_FILENAMES[@]}" 2>&1 || status=1
   else
     # shellcheck disable=SC2086,SC2068
-    # we need to handle the quoting of ${flags[@]} ourselves, 
+    # we need to handle the quoting of ${flags[@]} ourselves,
     # because parallel can only quote it as one
-    parallel "${bats_parallel_args[@]}" --keep-order --jobs "$num_jobs" bats-exec-file "$(printf "%q " "${flags[@]}")" "{}" "$TESTS_LIST_FILE"  ::: "${BATS_UNIQUE_TEST_FILENAMES[@]}" 2>&1 || status=1
+    parallel --keep-order --jobs "$num_jobs" bats-exec-file "$(printf "%q " "${flags[@]}")" "{}" "$TESTS_LIST_FILE"  ::: "${BATS_UNIQUE_TEST_FILENAMES[@]}" 2>&1 || status=1
   fi
 else
   for filename in "${BATS_UNIQUE_TEST_FILENAMES[@]}"; do

--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -57,8 +57,6 @@ OPTIONS
     Display this help message
   * `-j`, `--jobs <jobs>`:
     Number of parallel jobs (requires GNU parallel)
-  * `--parallel-preserve-environment`:
-    Preserve the current environment for "--jobs" (run `parallel --record-env` before)
   * `--no-tempdir-cleanup`:
     Preserve test output temporary directory
   * `--no-parallelize-across-files`

--- a/test/parallel.bats
+++ b/test/parallel.bats
@@ -22,15 +22,8 @@ setup() {
 }
 
 @test "parallel can preserve environment variables" {
-  if [[ ! -e ~/.parallel/ignored_vars ]]; then
-    parallel --record-env
-    PARALLEL_WAS_SETUP=1
-  fi
   export TEST_ENV_VARIABLE='test-value'
-  run bats --jobs 2 --parallel-preserve-environment "$FIXTURE_ROOT/parallel-preserve-environment.bats"
-  if [[ $PARALLEL_WAS_SETUP ]]; then
-    rm ~/.parallel/ignored_vars
-  fi
+  run bats --jobs 2 "$FIXTURE_ROOT/parallel-preserve-environment.bats"
   echo "$output"
   [[ "$status" -eq 0 ]]
 }

--- a/test/parallell.bats
+++ b/test/parallell.bats
@@ -27,7 +27,7 @@ setup() {
     PARALLEL_WAS_SETUP=1
   fi
   export TEST_ENV_VARIABLE='test-value'
-  run bats --jobs 1 --parallel-preserve-environment "$FIXTURE_ROOT/parallel-preserve-environment.bats"
+  run bats --jobs 2 --parallel-preserve-environment "$FIXTURE_ROOT/parallel-preserve-environment.bats"
   if [[ $PARALLEL_WAS_SETUP ]]; then
     rm ~/.parallel/ignored_vars
   fi


### PR DESCRIPTION
Along with parallel's --env _ feature, there's an --env env_parallel
feature, which just propagates whatever is in the current environment.

Let's do this by default to not violate the principle of least surprise,
but retain the old functionality for people who want to use ignored_vars.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
