### PR TITLE
Update the link to the Wiki from the Examples page

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -3,4 +3,4 @@
 This directory contains example .bats files.
 See the [bats-core wiki][examples] for more details.
 
-[examples]: (/bats-core/bats-core/wiki/Examples)
+[examples]: https://github.com/bats-core/bats-core/wiki/Examples


### PR DESCRIPTION
The current link brings you to this invalid page that will 404:
https://github.com/bats-core/bats-core/blob/master/docs/examples/(/bats-core/bats-core/wiki/Examples)

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
