### PR TITLE
Improve performance: Don't preprocess per test

### DIFF
--- a/lib/bats-core/preprocessing.bash
+++ b/lib/bats-core/preprocessing.bash
@@ -12,7 +12,9 @@ BATS_PARENT_TMPNAME="$BATS_RUN_TMPDIR/bats.$PPID"
 BATS_OUT="${BATS_TMPNAME}.out" # used in bats-exec-file
 
 bats_preprocess_source() {
-	BATS_TEST_SOURCE="${BATS_TMPNAME}.src"
+	# export to make it visible to bats_evaluate_preprocessed_source
+	# since the latter runs in bats-exec-test's bash while this runs in bats-exec-file's
+	export BATS_TEST_SOURCE="${BATS_TMPNAME}.src"
 	bats-preprocess "$BATS_TEST_FILENAME" >"$BATS_TEST_SOURCE"
 	trap 'bats_cleanup_preprocessed_source' ERR EXIT
 	trap 'bats_cleanup_preprocessed_source; exit 1' INT

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -117,7 +117,6 @@ bats_exit_trap() {
   fi
 
   rm -f "$BATS_OUT"
-  bats_cleanup_preprocessed_source
   exit "$status"
 }
 
@@ -162,6 +161,5 @@ source "$BATS_ROOT/lib/bats-core/preprocessing.bash"
 exec 3<&1
 
 # Run the given test.
-bats_preprocess_source
 bats_evaluate_preprocessed_source
 bats_perform_test "$@"


### PR DESCRIPTION
This should be done only once per file.

I noticed that each test will generate its own preprocessed file. This seems to have been broken a while back already since there is a comment that explicitly says we want to cache the result.

With this change the bats test suite ran 20% faster on my machine.

I'd like to have a regression test in place for this but so far I have no idea how to achieve this in a sensible manner.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
