### PR TITLE
Allow for output format to differ between stdout and report file

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Usage: bats [OPTIONS] <tests>
   --no-parallelize-within-files
                             Serialize test execution within files instead of
                             running them in parallel (requires --jobs >1)
+  --report-formatter <type> Switch between reporters (same options as --formatter)
   -o, --output <dir>        Directory to write report files
   -p, --pretty              Shorthand for "--formatter pretty"
   -r, --recursive           Include tests in subdirectories

--- a/lib/bats-core/formatter.bash
+++ b/lib/bats-core/formatter.bash
@@ -23,7 +23,7 @@ function bats_parse_internal_extended_tap() {
     fi
 
     ok_line_regexpr="ok ([0-9]+) (.*)"
-    skip_line_regexpr="ok ([0-9]+) (.*) # skip ?(.*)?$"
+    skip_line_regexpr="ok ([0-9]+) (.*) # skip( (.*))?$"
     not_ok_line_regexpr="not ok ([0-9]+) (.*)"
 
     timing_expr="in ([0-9]+)ms$"
@@ -44,7 +44,7 @@ function bats_parse_internal_extended_tap() {
                 test_name="${BASH_REMATCH[2]}"
                 if [[ "$line" =~ $skip_line_regexpr ]]; then
                     test_name="${BASH_REMATCH[2]}" # cut off name before "# skip"
-                    local skip_reason="${BASH_REMATCH[3]}"
+                    local skip_reason="${BASH_REMATCH[4]}"
                     bats_tap_stream_skipped "$ok_index" "$test_name" "$skip_reason"
                 else
                     if [[ "$line" =~ $timing_expr ]]; then

--- a/lib/bats-core/formatter.bash
+++ b/lib/bats-core/formatter.bash
@@ -23,7 +23,7 @@ function bats_parse_internal_extended_tap() {
     fi
 
     ok_line_regexpr="ok ([0-9]+) (.*)"
-    skip_line_regexpr="ok ([0-9]+) (.*) # skip ?([[:print:]]*)?$"
+    skip_line_regexpr="ok ([0-9]+) (.*) # skip ?(.*)?$"
     not_ok_line_regexpr="not ok ([0-9]+) (.*)"
 
     timing_expr="in ([0-9]+)ms$"

--- a/lib/bats-core/formatter.bash
+++ b/lib/bats-core/formatter.bash
@@ -48,7 +48,7 @@ function bats_parse_internal_extended_tap() {
                     bats_tap_stream_skipped "$ok_index" "$test_name" "$skip_reason"
                 else
                     if [[ "$line" =~ $timing_expr ]]; then
-                        bats_tap_stream_ok --duration "${BASH_REMATCH[2]}" "$ok_index" "$test_name"
+                        bats_tap_stream_ok --duration "${BASH_REMATCH[1]}" "$ok_index" "$test_name"
                     else
                         bats_tap_stream_ok "$ok_index" "$test_name"
                     fi
@@ -64,7 +64,7 @@ function bats_parse_internal_extended_tap() {
                 not_ok_index="${BASH_REMATCH[1]}"
                 test_name="${BASH_REMATCH[2]}"
                 if [[ "$line" =~ $timing_expr ]]; then
-                    bats_tap_stream_not_ok --duration "${BASH_REMATCH[2]}" "$not_ok_index" "$test_name"
+                    bats_tap_stream_not_ok --duration "${BASH_REMATCH[1]}" "$not_ok_index" "$test_name"
                 else
                     bats_tap_stream_not_ok "$not_ok_index" "$test_name"
                 fi

--- a/lib/bats-core/formatter.bash
+++ b/lib/bats-core/formatter.bash
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# reads (extended) bats tap streams from stdin and calls callback functions for each line
+# bats_tap_stream_plan <number of tests>                                      -> when the test plan is encountered
+# bats_tap_stream_begin <test index> <test name>                              -> when a new test is begun WARNING: extended only
+# bats_tap_stream_ok [--duration <milliseconds] <test index> <test name>      -> when a test was successful
+# bats_tap_stream_not_ok [--duration <milliseconds>] <test index> <test name> -> when a test has failed
+# bats_tap_stream_skipped <test index> <test name> <skip reason>              -> when a test was skipped
+# bats_tap_stream_comment <comment text without leading '# '>                 -> when a comment line was encountered
+# bats_tap_stream_suite <file name>                                           -> when a new file is begun WARNING: extended only
+# bats_tap_stream_unknown <full line>                                         -> when a line is encountered that does not match the previous entries
+# forwards all input as is, when there is no TAP test plan header
+function bats_parse_internal_extended_tap() {
+    local header_pattern='[0-9]+\.\.[0-9]+'
+    IFS= read -r header
+
+    if [[ "$header" =~ $header_pattern ]]; then
+        bats_tap_stream_plan "${header:3}"
+    else
+        # If the first line isn't a TAP plan, print it and pass the rest through
+        printf '%s\n' "$header"
+        exec cat
+    fi
+
+    ok_line_regexpr="ok ([0-9]+) (.*)"
+    skip_line_regexpr="ok ([0-9]+) (.*) # skip ?([[:print:]]*)?$"
+    not_ok_line_regexpr="not ok ([0-9]+) (.*)"
+
+    timing_expr="in ([0-9]+)ms$"
+    local test_name begin_index ok_index not_ok_index index
+    begin_index=0
+    index=0
+    while IFS= read -r line; do
+        case "$line" in
+        'begin '*) # this might only be called in extended tap output
+            ((++begin_index))
+            test_name="${line#* $begin_index }"
+            bats_tap_stream_begin "$begin_index" "$test_name"
+            ;;
+        'ok '*)
+            ((++index))
+            if [[ "$line" =~ $ok_line_regexpr ]]; then
+                ok_index="${BASH_REMATCH[1]}"
+                test_name="${BASH_REMATCH[2]}"
+                if [[ "$line" =~ $skip_line_regexpr ]]; then
+                    test_name="${BASH_REMATCH[2]}" # cut off name before "# skip"
+                    local skip_reason="${BASH_REMATCH[3]}"
+                    bats_tap_stream_skipped "$ok_index" "$test_name" "$skip_reason"
+                else
+                    if [[ "$line" =~ $timing_expr ]]; then
+                        bats_tap_stream_ok --duration "${BASH_REMATCH[2]}" "$ok_index" "$test_name"
+                    else
+                        bats_tap_stream_ok "$ok_index" "$test_name"
+                    fi
+                fi
+            else
+                printf "ERROR: could not match ok line: %s" "$line" >&2
+                exit 1
+            fi
+            ;;
+        'not ok '*)
+            ((++index))
+            if [[ "$line" =~ $not_ok_line_regexpr ]]; then
+                not_ok_index="${BASH_REMATCH[1]}"
+                test_name="${BASH_REMATCH[2]}"
+                if [[ "$line" =~ $timing_expr ]]; then
+                    bats_tap_stream_not_ok --duration "${BASH_REMATCH[2]}" "$not_ok_index" "$test_name"
+                else
+                    bats_tap_stream_not_ok "$not_ok_index" "$test_name"
+                fi
+            else
+                printf "ERROR: could not match not ok line: %s" "$line" >&2
+                exit 1
+            fi
+            ;;
+        '# '*)
+            bats_tap_stream_comment "${line:2}"
+            ;;
+        'suite '*) 
+            # pass on the
+            bats_tap_stream_suite "${line:6}"
+        ;;
+        *)
+            bats_tap_stream_unknown "$line"
+        ;;
+        esac
+    done
+}

--- a/lib/bats-core/formatter.bash
+++ b/lib/bats-core/formatter.bash
@@ -86,3 +86,19 @@ function bats_parse_internal_extended_tap() {
         esac
     done
 }
+
+# given a prefix and a path, remove the prefix if the path starts with it
+# e.g. 
+# remove_prefix /usr/bin /usr/bin/bash -> bash
+# remove_prefix /usr /usr/lib/bash -> lib/bash
+# remove_prefix /usr/bin /usr/local/bin/bash -> /usr/local/bin/bash
+remove_prefix() {
+  base_path="$1"
+  path="$2"
+  if [[ "$path" == "$base_path"* ]]; then
+    # cut off the common prefix
+    printf "%s" "${path:${#base_path}}"
+  else
+    printf "%s" "$path"
+  fi
+}

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -206,7 +206,11 @@ if [[ "$formatter" != "tap" ]]; then
 fi
 if [[ "$formatter" == "junit" ]]; then
   flags+=('-T')
-  formatter_flags+=('-T')
+  formatter_flags+=('--base-path' "${arguments[0]}")
+fi
+if [[ "$report_formatter" == "junit" ]]; then
+  flags+=('-T')
+  report_formatter_flags+=('--base-path' "${arguments[0]}")
 fi
 
 if [[ "${#arguments[@]}" -eq 0 ]]; then
@@ -265,7 +269,7 @@ source "$BATS_ROOT/lib/bats-core/validator.bash"
 set -o pipefail execfail
 
 if [[ -n "$report_formatter" ]]; then
-  exec bats-exec-suite "${flags[@]}" "${filenames[@]}" | tee >("bats-format-${report_formatter}" >"${BATS_REPORT_OUTPUT_PATH}/${BATS_REPORT_FILE_NAME}") | bats_test_count_validator | "bats-format-${formatter}" "${formatter_flags[@]}"
+  exec bats-exec-suite "${flags[@]}" "${filenames[@]}" | tee >("bats-format-${report_formatter}" "${report_formatter_flags[@]}" >"${BATS_REPORT_OUTPUT_PATH}/${BATS_REPORT_FILE_NAME}") | bats_test_count_validator | "bats-format-${formatter}" "${formatter_flags[@]}"
 else
   exec bats-exec-suite "${flags[@]}" "${filenames[@]}" | bats_test_count_validator | "bats-format-${formatter}" "${formatter_flags[@]}"
 fi

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -104,6 +104,7 @@ unset flags recursive formatter_flags
 flags=()
 formatter_flags=()
 formatter='tap'
+report_formatter=''
 recursive=
 tempdir_cleanup=1
 output=
@@ -135,6 +136,15 @@ while [[ "$#" -ne 0 ]]; do
       formatter="$1"
     else
       printf "Unknown formatter '%s', valid options are pretty, junit, tap\n" "$1"
+      exit 1
+    fi
+    ;;
+  --report)
+    shift
+    if [[ $1 =~ ^(pretty|junit|tap)$ ]]; then
+      report_formatter="$1"
+    else
+      printf "Unknown reporter '%s', valid options are pretty, junit, tap\n" "$1"
       exit 1
     fi
     ;;
@@ -203,6 +213,23 @@ if [[ "${#arguments[@]}" -eq 0 ]]; then
   abort 'Must specify at least one <test>'
 fi
 
+if [[ -n "$report_formatter" ]]; then
+  # default to the current directory for output
+  if [[ -z "$output" ]]; then
+    output=.
+  fi
+  case "$report_formatter" in
+    tap)
+      BATS_REPORT_FILE_NAME="report.tap"
+      ;;
+    junit)
+      BATS_REPORT_FILE_NAME="report.xml"
+      ;;
+    pretty)
+      BATS_REPORT_FILE_NAME="report.log"
+      ;;
+  esac
+fi
 
 if [[ -n "$output" ]]; then
   if [[ ! -w "${output}" ]]; then
@@ -236,4 +263,9 @@ done
 source "$BATS_ROOT/lib/bats-core/validator.bash"
 
 set -o pipefail execfail
-exec bats-exec-suite "${flags[@]}" "${filenames[@]}" | bats_test_count_validator | "bats-format-${formatter}" "${formatter_flags[@]}"
+
+if [[ -n "$report_formatter" ]]; then
+  exec bats-exec-suite "${flags[@]}" "${filenames[@]}" | tee >("bats-format-${report_formatter}" >"${BATS_REPORT_OUTPUT_PATH}/${BATS_REPORT_FILE_NAME}") | bats_test_count_validator | "bats-format-${formatter}" "${formatter_flags[@]}"
+else
+  exec bats-exec-suite "${flags[@]}" "${filenames[@]}" | bats_test_count_validator | "bats-format-${formatter}" "${formatter_flags[@]}"
+fi

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -134,7 +134,8 @@ while [[ "$#" -ne 0 ]]; do
     ;;
   -F | --formatter)
     shift
-    if [[ $1 =~ ^(pretty|junit|tap|tap13)$ ]]; then
+    # allow cat formatter to see extended output but don't advertise to users
+    if [[ $1 =~ ^(pretty|junit|tap|tap13|cat)$ ]]; then
       formatter="$1"
     else
       printf "Unknown formatter '%s', valid options are %s\n" "$1" "${VALID_FORMATTERS}"

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -41,7 +41,7 @@ HELP_TEXT_HEADER
   --no-parallelize-within-files
                             Serialize test execution within files instead of
                             running them in parallel (requires --jobs >1)
-  --report <type>           Switch between reporters (options as --formatter)
+  --report-formatter <type> Switch between reporters (same options as --formatter)
   -o, --output <dir>        Directory to write report files
   -p, --pretty              Shorthand for "--formatter pretty"
   -r, --recursive           Include tests in subdirectories
@@ -141,12 +141,12 @@ while [[ "$#" -ne 0 ]]; do
       exit 1
     fi
     ;;
-  --report)
+  --report-formatter)
     shift
     if [[ $1 =~ ^(pretty|junit|tap|tap13)$ ]]; then
       report_formatter="$1"
     else
-      printf "Unknown reporter '%s', valid options are %s\n" "$1" "${VALID_FORMATTERS}"
+      printf "Unknown report formatter '%s', valid options are %s\n" "$1" "${VALID_FORMATTERS}"
       exit 1
     fi
     ;;
@@ -204,6 +204,14 @@ if [[ -n "$tempdir_cleanup" ]]; then
 fi
 
 if [[ "$formatter" != "tap" ]]; then
+  flags+=('-x')
+fi
+
+if [[ -n "$report_formatter" && "$report_formatter" != "tap" ]]; then
+  if [[ "$formatter" == "tap" ]]; then
+    abort 'You cannot use the tap formatter with a report formatter (!=tap)'
+  fi
+  # specifying extended syntrax  while using tap would print out the extended syntax
   flags+=('-x')
 fi
 if [[ "$formatter" == "junit" ]]; then

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -2,6 +2,7 @@
 set -e
 
 export BATS_VERSION='1.2.1'
+VALID_FORMATTERS="pretty, junit, tap, tap13"
 
 version() {
   printf 'Bats %s\n' "$BATS_VERSION"
@@ -40,6 +41,7 @@ HELP_TEXT_HEADER
   --no-parallelize-within-files
                             Serialize test execution within files instead of
                             running them in parallel (requires --jobs >1)
+  --report <type>           Switch between reporters (options as --formatter)
   -o, --output <dir>        Directory to write report files
   -p, --pretty              Shorthand for "--formatter pretty"
   -r, --recursive           Include tests in subdirectories
@@ -135,16 +137,16 @@ while [[ "$#" -ne 0 ]]; do
     if [[ $1 =~ ^(pretty|junit|tap|tap13)$ ]]; then
       formatter="$1"
     else
-      printf "Unknown formatter '%s', valid options are pretty, junit, tap\n" "$1"
+      printf "Unknown formatter '%s', valid options are %s\n" "$1" "${VALID_FORMATTERS}"
       exit 1
     fi
     ;;
   --report)
     shift
-    if [[ $1 =~ ^(pretty|junit|tap)$ ]]; then
+    if [[ $1 =~ ^(pretty|junit|tap|tap13)$ ]]; then
       report_formatter="$1"
     else
-      printf "Unknown reporter '%s', valid options are pretty, junit, tap\n" "$1"
+      printf "Unknown reporter '%s', valid options are %s\n" "$1" "${VALID_FORMATTERS}"
       exit 1
     fi
     ;;
@@ -223,7 +225,7 @@ if [[ -n "$report_formatter" ]]; then
     output=.
   fi
   case "$report_formatter" in
-    tap)
+    tap|tap13)
       BATS_REPORT_FILE_NAME="report.tap"
       ;;
     junit)

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -208,12 +208,9 @@ if [[ "$formatter" != "tap" ]]; then
 fi
 
 if [[ -n "$report_formatter" && "$report_formatter" != "tap" ]]; then
-  if [[ "$formatter" == "tap" ]]; then
-    abort 'You cannot use the tap formatter with a report formatter (!=tap)'
-  fi
-  # specifying extended syntrax  while using tap would print out the extended syntax
   flags+=('-x')
 fi
+
 if [[ "$formatter" == "junit" ]]; then
   flags+=('-T')
   formatter_flags+=('--base-path' "${arguments[0]}")
@@ -221,6 +218,11 @@ fi
 if [[ "$report_formatter" == "junit" ]]; then
   flags+=('-T')
   report_formatter_flags+=('--base-path' "${arguments[0]}")
+fi
+
+# if we don't need to filter extended syntax, use the faster formatter
+if [[ "$formatter" == tap && -z "$report_formatter" ]]; then
+  formatter="cat"
 fi
 
 if [[ "${#arguments[@]}" -eq 0 ]]; then

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -250,7 +250,7 @@ bats_run_tests() {
 }
 
 if [[ -n "$extended_syntax" ]]; then
-  printf "suite %s\n" "$(basename "$filename")"
+  printf "suite %s\n" "$filename"
 fi
 
 bats_preprocess_source "$filename"

--- a/libexec/bats-core/bats-format-cat
+++ b/libexec/bats-core/bats-format-cat
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+cat

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -52,6 +52,12 @@ fail() {
   printf "\n    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
         <failure type=\"failure\"><![CDATA[" "${class}" "${name}" "${test_exec_time}"
 
+  # escape ]]> in outputs
+  output="${1//]]>/]]]]><![CDATA[>}"
+  # escape control character in outputs
+  local CONTROL_CHAR=$'\033'
+  output="${output//$CONTROL_CHAR/&#27;}"
+
   echo -n "${1}"
 
   printf "]]></failure>

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -185,7 +185,6 @@ remove_prefix() {
     printf "%s" "${path:${#base_path}}"
   else
     printf "%s" "$path"
-    return 1
   fi
 }
 

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -215,8 +215,7 @@ while IFS= read -r line; do
       test_exec_time=0
       buffer skip "${BASH_REMATCH[1]}"
     elif [[ "$line" =~ $expr_ok ]]; then
-      # TODO: remove "1000 *" once we measure in ms
-      test_exec_time="$(( 1000 * BASH_REMATCH[1] ))"
+      test_exec_time="${BASH_REMATCH[1]}"
       file_exec_time="$((file_exec_time + test_exec_time))"
       suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
       buffer pass
@@ -230,8 +229,7 @@ while IFS= read -r line; do
     ((file_failures += 1))
     expr_notok="not ok $index .* in ([0-9]+)ms"
     if [[ "$line" =~ $expr_notok ]]; then
-    # TODO: remove "1000 *" once we measure in ms
-      test_exec_time="$(( 1000 * BASH_REMATCH[1] ))"
+      test_exec_time="${BASH_REMATCH[1]}"
       suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
     else
       log "Wrong output format: ${line}"

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -46,8 +46,14 @@ host() {
 
 # convert $1 (time in milliseconds) to seconds
 milliseconds_to_seconds() {
-  # use printf to convert bc's .03 into 0.03
-  printf "%f" "$(bc <<< "scale=3; $1/1000")"
+  # we cannot rely on having bc for this calculation
+  full_seconds=$(($1 / 1000))
+  remaining_milliseconds=$(($1 % 1000))
+  if [[ $remaining_milliseconds -eq 0 ]]; then
+    printf "%d" "$full_seconds"
+  else
+    printf "%d.%03d" "$full_seconds" "$remaining_milliseconds"
+  fi
 }
 
 suite_header() {

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -27,6 +27,8 @@ index=0
 
 init_suite() {
   suite_test_exec_time=0
+  # since we have to print the suite header before its contents but we don't know the contents before the header, 
+  # we have to buffer the contents
   _suite_buffer=""
 }
 
@@ -97,12 +99,8 @@ xml_escape() {
 
 fail() {
   printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
-        <failure type=\"failure\">" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
-
-  xml_escape "$1"
-
-  printf "</failure>
-    </testcase>\n"
+      <failure type=\"failure\">%s</failure>
+    </testcase>\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")" "$(xml_escape "$1")"
 }
 
 skip() {
@@ -148,7 +146,7 @@ flush_log() {
 
 finish_file() {
   file_header
-  flush
+  printf "%s\n" "${_buffer}"
   file_footer
 }
 

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -12,7 +12,11 @@ while [[ "$#" -ne 0 ]]; do
       BASE_PATH="$1"
       # use the containing directory when --base-path is a file
       if [[ ! -d "$BASE_PATH" ]]; then
-        BASE_PATH=$(dirname "$BASE_PATH")
+        BASE_PATH="$(dirname "$BASE_PATH")"
+      fi
+      # ensure the path ends with / to strip that later on
+      if [[ "${BASE_PATH}" != *"/" ]]; then
+        BASE_PATH="$BASE_PATH/"
       fi
     ;;
   esac
@@ -166,6 +170,23 @@ if [[ ! "$header" =~ $header_pattern ]]; then
   exit 1
 fi
 
+# given a prefix and a path, remove the prefix if the path starts with it
+# e.g. 
+# remove_prefix /usr/bin /usr/bin/bash -> bash
+# remove_prefix /usr /usr/lib/bash -> lib/bash
+# remove_prefix /usr/bin /usr/local/bin/bash -> /usr/local/bin/bash
+remove_prefix() {
+  base_path="$1"
+  path="$2"
+  if [[ "$path" == "$base_path"* ]]; then
+    # cut off the common prefix
+    printf "%s" "${path:${#base_path}}"
+  else
+    printf "%s" "$path"
+    return 1
+  fi
+}
+
 while IFS= read -r line; do
   case "$line" in
   "suite "*)
@@ -179,7 +200,7 @@ while IFS= read -r line; do
     init_file
     suite_expr="suite (.*)"
     if [[ "$line" =~ $suite_expr ]]; then
-      class="$(realpath --relative-to "$BASE_PATH" "${BASH_REMATCH[1]}")"
+      class="$(remove_prefix "$BASE_PATH" "${BASH_REMATCH[1]}")"
     fi
     ;;
   "begin "*)

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -145,9 +145,11 @@ flush_log() {
 }
 
 finish_file() {
-  file_header
-  printf "%s\n" "${_buffer}"
-  file_footer
+  if [[ "${class-JUNIT_FORMATTER_NO_FILE_ENCOUNTERED}" != JUNIT_FORMATTER_NO_FILE_ENCOUNTERED ]]; then
+    file_header
+    printf "%s\n" "${_buffer}"
+    file_footer
+  fi
 }
 
 finish_suite() {
@@ -192,12 +194,7 @@ while IFS= read -r line; do
   case "$line" in
   "suite "*)
     flush_log
-    # finish the previous file if this is not the first one
-    if [[ ${not_first_file-UNSET} != UNSET ]]; then
-      suite_buffer finish_file
-    else
-      not_first_file=1
-    fi
+    suite_buffer finish_file
     init_file
     suite_expr="suite (.*)"
     if [[ "$line" =~ $suite_expr ]]; then

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -30,6 +30,7 @@ init_suite() {
   # since we have to print the suite header before its contents but we don't know the contents before the header, 
   # we have to buffer the contents
   _suite_buffer=""
+  test_result_state="" # declare for the first flush, when no test has been encountered
 }
 
 _buffer_log=
@@ -41,6 +42,8 @@ init_file() {
   test_exec_time=0
   _buffer=""
   _buffer_log=""
+  _system_out_log=""
+  test_result_state="" # mark that no test has run in this file so far
 }
 
 host() {
@@ -83,13 +86,22 @@ suite_footer() {
   printf "</testsuites>\n"
 }
 
-pass() {
-  if [[ -n "${_buffer_log}" ]]; then
-    printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
-      <system-out>%s</system-out>
-    </testcase>\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")" "$(xml_escape "${_buffer_log}")"
+print_test_case() {
+  if [[ "$test_result_state" == ok && -z "$_system_out_log" && -z "$_buffer_log" ]]; then
+    # pass and no output can be shortened
+    printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\" />\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
   else
-    printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\"/>\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
+    printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
+    if [[ -n "$_system_out_log" ]]; then
+      printf "        <system-out>%s</system-out>\n" "$(xml_escape "${_system_out_log}")"
+    fi
+    if [[ -n "$_buffer_log" || "$test_result_state" == not_ok ]]; then
+      printf "        <failure type=\"failure\">%s</failure>\n" "$(xml_escape "${_buffer_log}")"
+    fi
+    if [[ "$test_result_state" == skipped ]]; then
+      printf "        <skipped>%s</skipped>\n" "$(xml_escape "$test_skip_message")"
+    fi
+    printf "    </testcase>\n"
   fi
 }
 
@@ -102,19 +114,6 @@ xml_escape() {
   local CONTROL_CHAR=$'\033'
   output="${output//$CONTROL_CHAR/&#27;}"
   printf "%s" "$output"
-}
-
-fail() {
-  printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
-      <failure type=\"failure\">%s</failure>
-    </testcase>\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")" "$(xml_escape "$1")"
-}
-
-skip() {
-  # shellcheck disable=SC2183
-  printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
-        <skipped>%s</skipped>
-    </testcase>\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")" "$(xml_escape "$1")"
 }
 
 suite_buffer() {
@@ -149,9 +148,19 @@ $1"
 }
 
 flush_log() {
-  if [[ -n "${_buffer_log}" ]]; then
-    buffer fail "${_buffer_log}"
-    _buffer_log=""
+  if [[ -n "$test_result_state" ]]; then
+    buffer print_test_case
+  fi
+  _buffer_log=""
+  _system_out_log=""
+}
+
+log_system_out() {
+  if [[ -n "$_system_out_log" ]]; then
+    _system_out_log="${_system_out_log}
+$1"
+  else
+    _system_out_log="$1"
   fi
 }
 
@@ -194,19 +203,17 @@ bats_tap_stream_ok() { # [--duration <milliseconds] <test index> <test name>
     test_exec_time=0
   fi
   ((file_count += 1))
+  test_result_state='ok'
   file_exec_time="$((file_exec_time + test_exec_time))"
   suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
-  buffer pass
-  # reset log for printouts from FD3 or we will see this again as failure (see #360)
-  # we cannot move this into pass because it is run inside buffer in an extra shell
-  _buffer_log=""
 }
 
 bats_tap_stream_skipped() { # <test index> <test name> <skip reason>
   ((file_count += 1))
   ((file_skipped += 1))
+  test_result_state='skipped'
   test_exec_time=0
-  buffer skip "$3"
+  test_skip_message="$3"
 }
 
 bats_tap_stream_not_ok() { # [--duration <milliseconds>] <test index> <test name>
@@ -217,12 +224,19 @@ bats_tap_stream_not_ok() { # [--duration <milliseconds>] <test index> <test name
   else
     test_exec_time=0
   fi
+  test_result_state=not_ok
   file_exec_time="$((file_exec_time + test_exec_time))"
   suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
 }
 
-bats_tap_stream_comment() { # <comment text without leading '# '>
-  log "$1"
+bats_tap_stream_comment() { # <comment text without leading '# '> <scope>
+  if [[ "$2" == begin ]]; then
+    # everything that happens between begin and [not] ok is FD3 output from the test
+    log_system_out "$1"
+  else
+    # everything else is considered error output
+    log "$1"
+  fi
 }
 
 bats_tap_stream_suite() { # <file name>

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -62,14 +62,13 @@ milliseconds_to_seconds() {
 }
 
 suite_header() {
-  printf "\
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+  printf "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <testsuites time=\"%s\">\n" "$(milliseconds_to_seconds "${suite_test_exec_time}")"
 }
 
 file_header() {
   timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S")
-  printf "<testsuite name=\"%s\" tests=\"%s\" failures=\"%s\" errors=\"0\" skipped=\"%s\" time=\"%s\" timestamp=\"%s\" hostname=\"%s\">" \
+  printf "<testsuite name=\"%s\" tests=\"%s\" failures=\"%s\" errors=\"0\" skipped=\"%s\" time=\"%s\" timestamp=\"%s\" hostname=\"%s\">\n" \
                      "$(xml_escape "${class}")" "${file_count}" "${file_failures}" "${file_skipped}" "$(milliseconds_to_seconds "${file_exec_time}")" "${timestamp}" "$(host)"
 }
 
@@ -82,7 +81,7 @@ suite_footer() {
 }
 
 pass() {
-  printf "\n    <testcase classname=\"%s\" name=\"%s\" time=\"%s\"/>" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
+  printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\"/>\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
 }
 
 xml_escape() {
@@ -97,7 +96,7 @@ xml_escape() {
 }
 
 fail() {
-  printf "\n    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
+  printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
         <failure type=\"failure\">" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
 
   xml_escape "$1"
@@ -108,26 +107,30 @@ fail() {
 
 skip() {
   # shellcheck disable=SC2183
-  printf "\n    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
+  printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
         <skipped>%s</skipped>
     </testcase>\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")" "$(xml_escape "$1")"
 }
 
 suite_buffer() {
-  _suite_buffer="${_suite_buffer}$("$@")"
+  local output
+  output="$("$@"; printf "x")" # use x marker to avoid losing trailing newlines
+  _suite_buffer="${_suite_buffer}${output%x}"
 }
 
 suite_flush() {
-  echo "${_suite_buffer}"
+  echo -n "${_suite_buffer}"
   _suite_buffer=""
 }
 
 buffer() {
-  _buffer="${_buffer}$("$@")"
+  local output
+  output="$("$@"; printf "x")" # use x marker to avoid losing trailing newlines
+  _buffer="${_buffer}${output%x}"
 }
 
 flush() {
-  echo "${_buffer}"
+  echo -n "${_buffer}"
   _buffer=""
 }
 

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -158,9 +158,6 @@ finish_suite() {
   suite_footer
 }
 
-init_suite
-trap finish_suite EXIT
-
 header_pattern='[0-9]+\.\.[0-9]+'
 IFS= read -r header
 
@@ -187,6 +184,9 @@ remove_prefix() {
     printf "%s" "$path"
   fi
 }
+
+init_suite
+trap finish_suite EXIT
 
 while IFS= read -r line; do
   case "$line" in

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -4,16 +4,18 @@ set -euo pipefail
 index=0
 
 init_suite() {
-  count=0
-  failures=0
-  skipped=0
-  suitetest_exec_time=0
-  name=""
+  suite_test_exec_time=0
+  _suite_buffer=""
+}
+
+init_file() {
+  file_count=0
+  file_failures=0
+  file_skipped=0
+  file_exec_time=0
   _buffer=""
   _buffer_log=""
 }
-
-init_suite
 
 host() {
   local hostname="${HOST:-}"
@@ -24,43 +26,54 @@ host() {
   echo "$hostname"
 }
 
-header() {
-  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S")
-  printf "\
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<testsuite name=\"%s\" tests=\"%s\" failures=\"%s\" errors=\"0\" skipped=\"%s\" time=\"%s\" timestamp=\"%s\" hostname=\"%s\">
-  <properties>" "${class}" "${count}" "${failures}" "${skipped}" "${suitetest_exec_time}" "${timestamp}" "$(host)"
-  while IFS= read -r line; do
-    name="$(echo "$line" | cut -d'=' -f1)"
-    value="$(echo "$line" | cut -d'=' -f2-)"
-    printf "\n    <property name=\"%s\" value=\"%s\"/>" "${name}" "${value}"
-  done < <(env | grep "^BATS_")
-  printf "\n  </properties>"
+# convert $1 (time in milliseconds) to seconds
+milliseconds_to_seconds() {
+  # use printf to convert bc's .03 into 0.03
+  printf "%f" "$(bc <<< "scale=3; $1/1000")"
 }
 
-footer() {
-  printf "  <system-out></system-out>\n"
-  printf "  <system-err></system-err>\n"
+suite_header() {
+  printf "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<testsuites time=\"%s\">\n" "$(milliseconds_to_seconds "${suite_test_exec_time}")"
+}
+
+file_header() {
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%S")
+  printf "<testsuite name=\"%s\" tests=\"%s\" failures=\"%s\" errors=\"0\" skipped=\"%s\" time=\"%s\" timestamp=\"%s\" hostname=\"%s\">" \
+                     "$(xml_escape "${class}")" "${file_count}" "${file_failures}" "${file_skipped}" "$(milliseconds_to_seconds "${file_exec_time}")" "${timestamp}" "$(host)"
+}
+
+file_footer() {
   printf "</testsuite>\n"
 }
 
+suite_footer() {
+  printf "</testsuites>\n"
+}
+
 pass() {
-  printf "\n    <testcase classname=\"%s\" name=\"%s\" time=\"%s\"/>" "${class}" "${name}" "${test_exec_time}"
+  printf "\n    <testcase classname=\"%s\" name=\"%s\" time=\"%s\"/>" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
+}
+
+xml_escape() {
+  output=${1//&/&amp;}
+  output=${output//</&lt;}
+  output=${output//>/&gt;}
+  output=${output//'"'/&quot;}
+  output=${output//\'/&#39;}
+  local CONTROL_CHAR=$'\033'
+  output="${output//$CONTROL_CHAR/&#27;}"
+  printf "%s" "$output"
 }
 
 fail() {
   printf "\n    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
-        <failure type=\"failure\"><![CDATA[" "${class}" "${name}" "${test_exec_time}"
+        <failure type=\"failure\">" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
 
-  # escape ]]> in outputs
-  output="${1//]]>/]]]]><![CDATA[>}"
-  # escape control character in outputs
-  local CONTROL_CHAR=$'\033'
-  output="${output//$CONTROL_CHAR/&#27;}"
+  xml_escape "$1"
 
-  echo -n "${1}"
-
-  printf "]]></failure>
+  printf "</failure>
     </testcase>\n"
 }
 
@@ -68,7 +81,16 @@ skip() {
   # shellcheck disable=SC2183
   printf "\n    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
         <skipped>%s</skipped>
-    </testcase>\n" "${class}" "${name}" "${test_exec_time}" "$1"
+    </testcase>\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")" "$(xml_escape "$1")"
+}
+
+suite_buffer() {
+  _suite_buffer="${_suite_buffer}$("$@")"
+}
+
+suite_flush() {
+  echo "${_suite_buffer}"
+  _suite_buffer=""
 }
 
 buffer() {
@@ -86,39 +108,51 @@ $1"
 }
 
 flush_log() {
-  if [[ -n "${_buffer_log}" ]]; then
+  if [[ -v _buffer_log ]] && [[ -n "${_buffer_log}" ]]; then
     buffer fail "${_buffer_log}"
     _buffer_log=""
   fi
 }
 
+finish_file() {
+  file_header
+  flush
+  file_footer
+}
+
 finish_suite() {
-  [[ ${count} -gt 0 ]] && {
-    (
-      flush_log
-      header
-      flush
-      footer
-    ) >"$(output_path)"
-  }
-  init_suite
+  flush_log
+  suite_header
+  suite_flush
+  finish_file # must come after suite flush to not print the last file before the others
+  suite_footer
 }
 
-output_path() {
-  path="TestReport-${class}.xml"
-  if [[ -n "${BATS_REPORT_OUTPUT_PATH:-}" ]]; then
-    path="${BATS_REPORT_OUTPUT_PATH%/}/${path}"
-  fi
-  echo "$path"
-}
-
+init_suite
 trap finish_suite EXIT
+
+header_pattern='[0-9]+\.\.[0-9]+'
+IFS= read -r header
+
+if [[ ! "$header" =~ $header_pattern ]]; then
+  # If the first line isn't a TAP plan, print it and pass the rest through
+  printf "junit formatter: This is not the expected TAP format!" >&2
+  printf '%s\n' "$header"
+  exec cat
+  exit 1
+fi
 
 while IFS= read -r line; do
   case "$line" in
   "suite "*)
     flush_log
-    finish_suite
+    # finish the previous file if this is not the first one
+    if [[ -v not_first_file ]]; then
+      suite_buffer finish_file
+    else
+      not_first_file=1
+    fi
+    init_file
     suite_expr="suite (.*)"
     if [[ "$line" =~ $suite_expr ]]; then
       class="${BASH_REMATCH[1]}"
@@ -130,31 +164,34 @@ while IFS= read -r line; do
     name="${line#* $index }"
     ;;
   "ok "*)
-    echo "$line"
-    ((count += 1))
+    ((file_count += 1))
     expr_ok="ok $index .* in ([0-9]+)ms"
     expr_skip="ok $index .* # skip[ ]?(.*)"
     if [[ "$line" =~ $expr_skip ]]; then
-      ((skipped += 1))
+      ((file_skipped += 1))
       test_exec_time=0
       buffer skip "${BASH_REMATCH[1]}"
     elif [[ "$line" =~ $expr_ok ]]; then
-      test_exec_time="${BASH_REMATCH[1]}"
-      suitetest_exec_time=$((suitetest_exec_time + test_exec_time))
+      # TODO: remove "1000 *" once we measure in ms
+      test_exec_time="$(( 1000 * BASH_REMATCH[1] ))"
+      file_exec_time="$((file_exec_time + test_exec_time))"
+      suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
       buffer pass
     else
       log "Wrong output format: ${line}"
-      ((failures += 1))
+      ((file_failures += 1))
     fi
     ;;
   "not ok "*)
-    echo "$line"
-    ((count += 1))
-    ((failures += 1))
+    ((file_count += 1))
+    ((file_failures += 1))
     expr_notok="not ok $index .* in ([0-9]+)ms"
     if [[ "$line" =~ $expr_notok ]]; then
-      test_exec_time="${BASH_REMATCH[1]}"
-      suitetest_exec_time=$((suitetest_exec_time + test_exec_time))
+    # TODO: remove "1000 *" once we measure in ms
+      test_exec_time="$(( 1000 * BASH_REMATCH[1] ))"
+      suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
+    else
+      log "Wrong output format: ${line}"
     fi
     ;;
   "# "*)

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -14,6 +14,8 @@ while [[ "$#" -ne 0 ]]; do
       if [[ ! -d "$BASE_PATH" ]]; then
         BASE_PATH="$(dirname "$BASE_PATH")"
       fi
+      # get the absolute path
+      BASE_PATH="$(cd "$BASE_PATH"; pwd)"
       # ensure the path ends with / to strip that later on
       if [[ "${BASE_PATH}" != *"/" ]]; then
         BASE_PATH="$BASE_PATH/"

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -30,6 +30,7 @@ init_suite() {
   _suite_buffer=""
 }
 
+_buffer_log=
 init_file() {
   file_count=0
   file_failures=0
@@ -136,7 +137,7 @@ $1"
 }
 
 flush_log() {
-  if [[ -v _buffer_log ]] && [[ -n "${_buffer_log}" ]]; then
+  if [[ -n "${_buffer_log}" ]]; then
     buffer fail "${_buffer_log}"
     _buffer_log=""
   fi
@@ -192,7 +193,7 @@ while IFS= read -r line; do
   "suite "*)
     flush_log
     # finish the previous file if this is not the first one
-    if [[ -v not_first_file ]]; then
+    if [[ ${not_first_file-UNSET} != UNSET ]]; then
       suite_buffer finish_file
     else
       not_first_file=1

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -25,8 +25,6 @@ while [[ "$#" -ne 0 ]]; do
   shift
 done
 
-index=0
-
 init_suite() {
   suite_test_exec_time=0
   # since we have to print the suite header before its contents but we don't know the contents before the header, 
@@ -40,6 +38,7 @@ init_file() {
   file_failures=0
   file_skipped=0
   file_exec_time=0
+  test_exec_time=0
   _buffer=""
   _buffer_log=""
 }
@@ -85,7 +84,13 @@ suite_footer() {
 }
 
 pass() {
-  printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\"/>\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
+  if [[ -n "${_buffer_log}" ]]; then
+    printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\">
+      <system-out>%s</system-out>
+    </testcase>\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")" "$(xml_escape "${_buffer_log}")"
+  else
+    printf "    <testcase classname=\"%s\" name=\"%s\" time=\"%s\"/>\n" "$(xml_escape "${class}")" "$(xml_escape "${name}")" "$(milliseconds_to_seconds "${test_exec_time}")"
+  fi
 }
 
 xml_escape() {
@@ -135,8 +140,12 @@ flush() {
 }
 
 log() {
-  _buffer_log="${_buffer_log}
+  if [[ -n "$_buffer_log" ]]; then
+    _buffer_log="${_buffer_log}
 $1"
+  else
+    _buffer_log="$1"
+  fi
 }
 
 flush_log() {
@@ -162,86 +171,69 @@ finish_suite() {
   suite_footer
 }
 
-header_pattern='[0-9]+\.\.[0-9]+'
-IFS= read -r header
+# shellcheck source=lib/bats-core/formatter.bash
+source "$BATS_ROOT/lib/bats-core/formatter.bash"
 
-if [[ ! "$header" =~ $header_pattern ]]; then
-  # If the first line isn't a TAP plan, print it and pass the rest through
-  printf "junit formatter: This is not the expected TAP format!" >&2
-  printf '%s\n' "$header"
-  exec cat
-  exit 1
-fi
-
-# given a prefix and a path, remove the prefix if the path starts with it
-# e.g. 
-# remove_prefix /usr/bin /usr/bin/bash -> bash
-# remove_prefix /usr /usr/lib/bash -> lib/bash
-# remove_prefix /usr/bin /usr/local/bin/bash -> /usr/local/bin/bash
-remove_prefix() {
-  base_path="$1"
-  path="$2"
-  if [[ "$path" == "$base_path"* ]]; then
-    # cut off the common prefix
-    printf "%s" "${path:${#base_path}}"
-  else
-    printf "%s" "$path"
-  fi
+bats_tap_stream_plan() { #  <number of tests>
+  :
 }
 
 init_suite
 trap finish_suite EXIT
 
-while IFS= read -r line; do
-  case "$line" in
-  "suite "*)
-    flush_log
-    suite_buffer finish_file
-    init_file
-    suite_expr="suite (.*)"
-    if [[ "$line" =~ $suite_expr ]]; then
-      class="$(remove_prefix "$BASE_PATH" "${BASH_REMATCH[1]}")"
-    fi
-    ;;
-  "begin "*)
-    flush_log
-    ((index += 1))
-    name="${line#* $index }"
-    ;;
-  "ok "*)
-    ((file_count += 1))
-    expr_ok="ok $index .* in ([0-9]+)ms"
-    expr_skip="ok $index .* # skip[ ]?(.*)"
-    if [[ "$line" =~ $expr_skip ]]; then
-      ((file_skipped += 1))
-      test_exec_time=0
-      buffer skip "${BASH_REMATCH[1]}"
-    elif [[ "$line" =~ $expr_ok ]]; then
-      test_exec_time="${BASH_REMATCH[1]}"
-      file_exec_time="$((file_exec_time + test_exec_time))"
-      suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
-      buffer pass
-    else
-      log "Wrong output format: ${line}"
-      ((file_failures += 1))
-    fi
-    ;;
-  "not ok "*)
-    ((file_count += 1))
-    ((file_failures += 1))
-    expr_notok="not ok $index .* in ([0-9]+)ms"
-    if [[ "$line" =~ $expr_notok ]]; then
-      test_exec_time="${BASH_REMATCH[1]}"
-      suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
-    else
-      log "Wrong output format: ${line}"
-    fi
-    ;;
-  "# "*)
-    log "${line:2}"
-    ;;
-  *)
-    echo "$line"
-    ;;
-  esac
-done
+bats_tap_stream_begin() { # <test index> <test name>
+  flush_log
+  # set after flushing to avoid overriding name of test
+  name="$2"
+}
+
+bats_tap_stream_ok() { # [--duration <milliseconds] <test index> <test name>
+  if [[ "$1" == "--duration" ]]; then
+    test_exec_time="${BASH_REMATCH[1]}"
+  else
+    test_exec_time=0
+  fi
+  ((file_count += 1))
+  file_exec_time="$((file_exec_time + test_exec_time))"
+  suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
+  buffer pass
+  # reset log for printouts from FD3 or we will see this again as failure (see #360)
+  # we cannot move this into pass because it is run inside buffer in an extra shell
+  _buffer_log=""
+}
+
+bats_tap_stream_skipped() { # <test index> <test name> <skip reason>
+  ((file_count += 1))
+  ((file_skipped += 1))
+  test_exec_time=0
+  buffer skip "$3"
+}
+
+bats_tap_stream_not_ok() { # [--duration <milliseconds>] <test index> <test name>
+  ((file_count += 1))
+  ((file_failures += 1))
+  if [[ "$1" == "--duration" ]]; then
+    test_exec_time="${BASH_REMATCH[1]}"
+  else
+    test_exec_time=0
+  fi
+  file_exec_time="$((file_exec_time + test_exec_time))"
+  suite_test_exec_time=$((suite_test_exec_time + test_exec_time))
+}
+
+bats_tap_stream_comment() { # <comment text without leading '# '>
+  log "$1"
+}
+
+bats_tap_stream_suite() { # <file name>
+  flush_log
+  suite_buffer finish_file
+  init_file
+  class="$(remove_prefix "$BASE_PATH" "$1")"
+}
+
+bats_tap_stream_unknown() { # <full line>
+  :
+}
+
+bats_parse_internal_extended_tap

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+BASE_PATH=.
+
+while [[ "$#" -ne 0 ]]; do
+  case "$1" in
+    --base-path)
+      shift
+      # the relative path root to use for reporting filenames
+      # this is mainly intended for suite mode, where this will be the suite root folder
+      BASE_PATH="$1"
+      # use the containing directory when --base-path is a file
+      if [[ ! -d "$BASE_PATH" ]]; then
+        BASE_PATH=$(dirname "$BASE_PATH")
+      fi
+    ;;
+  esac
+  shift
+done
+
 index=0
 
 init_suite() {
@@ -155,7 +173,7 @@ while IFS= read -r line; do
     init_file
     suite_expr="suite (.*)"
     if [[ "$line" =~ $suite_expr ]]; then
-      class="${BASH_REMATCH[1]}"
+      class="$(realpath --relative-to "$BASE_PATH" "${BASH_REMATCH[1]}")"
     fi
     ;;
   "begin "*)

--- a/libexec/bats-core/bats-format-pretty
+++ b/libexec/bats-core/bats-format-pretty
@@ -10,9 +10,6 @@ while [[ "$#" -ne 0 ]]; do
   shift
 done
 
-header_pattern='[0-9]+\.\.[0-9]+'
-IFS= read -r header
-
 update_count_column_width() {
   count_column_width=$((${#count} * 2 + 2))
   if [[ -n "$BATS_ENABLE_TIMING" ]]; then
@@ -32,20 +29,6 @@ update_screen_width() {
 update_count_column_left() {
   count_column_left=$((screen_width - count_column_width))
 }
-
-if [[ "$header" =~ $header_pattern ]]; then
-  count="${header:3}"
-  index=0
-  passed=0
-  failures=0
-  skipped=0
-  name=
-  update_count_column_width
-else
-  # If the first line isn't a TAP plan, print it and pass the rest through
-  printf '%s\n' "$header"
-  exec cat
-fi
 
 trap update_screen_width WINCH
 update_screen_width
@@ -193,54 +176,60 @@ finish() {
 
 trap finish EXIT
 
-timing_expr="in (([0-9]+ms))$"
+# shellcheck source=lib/bats-core/formatter.bash
+source "$BATS_ROOT/lib/bats-core/formatter.bash"
 
-while IFS= read -r line; do
-  case "$line" in
-  'begin '*)
-    ((++index))
-    name="${line#* $index }"
-    begin
-    flush
-    ;;
-  'ok '*)
-    skip_expr="ok $index (.*) # skip ?(([[:print:]]*))?"
-    if [[ "$line" =~ $skip_expr ]]; then
-      ((++skipped))
-      skip "${BASH_REMATCH[2]}"
-    else
-      ((++passed))
-      if [[ -n "$BATS_ENABLE_TIMING" ]]; then
-        if [[ "$line" =~ $timing_expr ]]; then
-          pass "${BASH_REMATCH[2]}"
-        else
-          echo "Could not match output line to timing regex: $line" >&2
-          exit 1
-        fi
-      else
-        pass
-      fi
-    fi
-    ;;
-  'not ok '*)
-    ((++failures))
-    if [[ -n "$BATS_ENABLE_TIMING" ]]; then
-      if [[ "$line" =~ $timing_expr ]]; then
-        fail "${BASH_REMATCH[2]}"
-      else
-        echo "Could not match failure line to timing regex: $line" >&2
-        exit 1
-      fi
-    else
-      fail
-    fi
-    ;;
-  '# '*)
-    log "${line:2}"
-    ;;
-  'suite '*) ;;
+bats_tap_stream_plan() {
+  count="$1"
+  index=0
+  passed=0
+  failures=0
+  skipped=0
+  name=
+  update_count_column_width
+}
 
-  esac
-done
+bats_tap_stream_begin() {
+  index="$1"
+  name="$2"
+  begin
+  flush
+}
+  
+bats_tap_stream_ok() {
+  index="$1"
+  ((++passed))
+  if [[ "$1" == "--duration" ]]; then
+    pass "$2"
+  else
+    pass
+  fi
+}
+
+bats_tap_stream_skipped() {
+  index="$1"
+  ((++skipped))
+  skip "$3"
+}
+
+bats_tap_stream_not_ok() {
+  index="$1"
+  ((++failures))
+  if [[ "$1" == "--duration" ]]; then
+    fail "$2"
+  else
+    fail
+  fi
+}
+
+bats_tap_stream_comment() {
+  log "$1"
+}
+
+bats_tap_stream_suite() {
+  : #test_file="$1"
+}
+
+bats_parse_internal_extended_tap
 
 summary

--- a/libexec/bats-core/bats-format-pretty
+++ b/libexec/bats-core/bats-format-pretty
@@ -183,7 +183,6 @@ buffer() {
 
 flush() {
   printf '%s' "$_buffer"
-  [[ -n "$BATS_REPORT_OUTPUT_PATH" ]] && printf '%s' "$_buffer" | tee "$BATS_REPORT_OUTPUT_PATH/report.tap" >/dev/null
   _buffer=
 }
 

--- a/libexec/bats-core/bats-format-tap
+++ b/libexec/bats-core/bats-format-tap
@@ -1,4 +1,51 @@
 #!/usr/bin/env bash
 set -e
 
-cat
+# shellcheck source=lib/bats-core/formatter.bash
+source "$BATS_ROOT/lib/bats-core/formatter.bash"
+
+bats_tap_stream_plan() {
+    printf "1..%d\n" "$1"
+}
+
+bats_tap_stream_begin() { #<test index> <test name>
+    :
+}
+
+bats_tap_stream_ok() { # [--duration <milliseconds] <test index> <test name>
+    if [[ "$1" == "--duration" ]]; then
+        printf "ok %d %s # in %d ms\n" "$3" "$4" "$2"
+    else
+        printf "ok %d %s\n" "$1" "$2"
+    fi
+}
+
+bats_tap_stream_not_ok() { # [--duration <milliseconds>] <test index> <test name>
+    if [[ "$1" == "--duration" ]]; then
+        printf "not ok %d %s # in %d ms\n" "$3" "$4" "$2"
+    else
+        printf "not ok %d %s\n" "$1" "$2"
+    fi
+}
+
+bats_tap_stream_skipped() { # <test index> <test name> <reason>
+    if [[ -n "$3" ]]; then
+        printf "ok %d %s # skip %s\n" "$1" "$2" "$3"
+    else
+        printf "ok %d %s # skip\n" "$1" "$2" 
+    fi
+}
+
+bats_tap_stream_comment() { # <comment text without leading '# '>
+    printf "# %s\n" "$1"
+}
+
+bats_tap_stream_suite() { # <file name>
+    :
+}
+
+bats_tap_stream_unknown() { # <full line>       
+    printf "%s\n" "$1"
+}
+
+bats_parse_internal_extended_tap

--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -63,6 +63,8 @@ OPTIONS
     Serialize test file execution instead of running them in parallel (requires --jobs >1)
   * `--no-parallelize-within-files`
     Serialize test execution within files instead of running them in parallel (requires --jobs >1)
+  * `--report-formatter <type>`:
+    Switch between reporters (same options as --formatter)
   * `-o`, `--output <dir>`:
     Directory to write report files
   * `-p`, `--pretty`:

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -680,29 +680,3 @@ END_OF_ERR_MSG
     #   ^ kill the process for good when SIGINT failed,
     #     to avoid waiting endlessly for stuck children to finish
 }
-
-@test "Permitted formatter reporter combinations" {
-  make_bats_test_suite_tmpdir "$BATS_TEST_NAME"
-  
-  # no other formatters must be combined with tap
-
-  bats   --formatter tap    --report-formatter tap  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  ! bats --formatter tap13  --report-formatter tap  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  ! bats --formatter junit  --report-formatter tap  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  ! bats --formatter pretty --report-formatter tap  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-
-  ! bats --formatter tap    --report-formatter tap13  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  bats   --formatter tap13  --report-formatter tap13  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  bats   --formatter junit  --report-formatter tap13  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  bats   --formatter pretty --report-formatter tap13  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  
-  ! bats --formatter tap    --report-formatter junit  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  bats   --formatter tap13  --report-formatter junit  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  bats   --formatter junit  --report-formatter junit  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  bats   --formatter pretty --report-formatter junit  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-
-  ! bats --formatter tap    --report-formatter pretty --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  bats   --formatter tap13  --report-formatter pretty --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  bats   --formatter junit  --report-formatter pretty --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-  bats   --formatter pretty --report-formatter pretty --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
-}

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -327,7 +327,7 @@ teardown() {
   run bats-exec-suite -x "$FIXTURE_ROOT/failing_and_passing.bats"
   echo "$output"
   [ $status -eq 1 ]
-  [ "${lines[1]}" = 'suite failing_and_passing.bats' ]
+  [ "${lines[1]}" = "suite $FIXTURE_ROOT/failing_and_passing.bats" ]
   [ "${lines[2]}" = 'begin 1 a failing test' ]
   [ "${lines[3]}" = 'not ok 1 a failing test' ]
   [ "${lines[6]}" = 'begin 2 a passing test' ]

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -680,3 +680,29 @@ END_OF_ERR_MSG
     #   ^ kill the process for good when SIGINT failed,
     #     to avoid waiting endlessly for stuck children to finish
 }
+
+@test "Permitted formatter reporter combinations" {
+  make_bats_test_suite_tmpdir "$BATS_TEST_NAME"
+  
+  # no other formatters must be combined with tap
+
+  bats   --formatter tap    --report-formatter tap  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  ! bats --formatter tap13  --report-formatter tap  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  ! bats --formatter junit  --report-formatter tap  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  ! bats --formatter pretty --report-formatter tap  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+
+  ! bats --formatter tap    --report-formatter tap13  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  bats   --formatter tap13  --report-formatter tap13  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  bats   --formatter junit  --report-formatter tap13  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  bats   --formatter pretty --report-formatter tap13  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  
+  ! bats --formatter tap    --report-formatter junit  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  bats   --formatter tap13  --report-formatter junit  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  bats   --formatter junit  --report-formatter junit  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  bats   --formatter pretty --report-formatter junit  --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+
+  ! bats --formatter tap    --report-formatter pretty --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  bats   --formatter tap13  --report-formatter pretty --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  bats   --formatter junit  --report-formatter pretty --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+  bats   --formatter pretty --report-formatter pretty --output "$BATS_TEST_SUITE_TMPDIR" "$FIXTURE_ROOT/empty.bats"
+}

--- a/test/fixtures/junit-formatter/duplicate/first/file1.bats
+++ b/test/fixtures/junit-formatter/duplicate/first/file1.bats
@@ -1,0 +1,3 @@
+@test "test in duplicate file" {
+    true
+}

--- a/test/fixtures/junit-formatter/duplicate/second/file1.bats
+++ b/test/fixtures/junit-formatter/duplicate/second/file1.bats
@@ -1,0 +1,3 @@
+@test "test in duplicate file" {
+    true
+}

--- a/test/fixtures/junit-formatter/issue_360.bats
+++ b/test/fixtures/junit-formatter/issue_360.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+setup() {
+    echo "# setup stdout"
+    echo "# setup FD3" >&3
+}
+
+teardown() {
+    echo "# teardown stdout" 
+    echo "# teardown FD3" >&3
+}
+
+@test "say hello to Biblo" {
+    echo "# hello stdout"
+    echo "# hello Bilbo" >&3
+}
+
+@test "fail to say hello to Biblo" {
+    echo "# hello stdout"
+    echo "# hello Bilbo" >&3
+    false
+}

--- a/test/fixtures/junit-formatter/skipped.bats
+++ b/test/fixtures/junit-formatter/skipped.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "a skipped test" {
+  skip
+}
+
+@test "a skipped test with a reason" {
+  skip "a reason"
+}

--- a/test/fixtures/junit-formatter/suite/file1.bats
+++ b/test/fixtures/junit-formatter/suite/file1.bats
@@ -1,0 +1,3 @@
+@test "one test" {
+    true
+}

--- a/test/fixtures/junit-formatter/suite/file2.bats
+++ b/test/fixtures/junit-formatter/suite/file2.bats
@@ -1,0 +1,3 @@
+@test "another test" {
+    true
+}

--- a/test/fixtures/junit-formatter/xml-escape.bats
+++ b/test/fixtures/junit-formatter/xml-escape.bats
@@ -1,0 +1,11 @@
+@test "Successful test with escape characters: \"'<>&(0x1b)" {
+  true
+}
+
+@test "Failed test with escape characters: \"'<>&(0x1b)" {
+  echo "<>'&" && false
+}
+
+@test "Skipped test with escape characters: \"'<>&(0x1b)" {
+  skip "\"'<>&"
+}

--- a/test/fixtures/junit-formatter/xml-escape.bats
+++ b/test/fixtures/junit-formatter/xml-escape.bats
@@ -1,11 +1,11 @@
-@test "Successful test with escape characters: \"'<>&(0x1b)" {
+@test "Successful test with escape characters: \"'<>&[0m (0x1b)" {
   true
 }
 
-@test "Failed test with escape characters: \"'<>&(0x1b)" {
-  echo "<>'&" && false
+@test "Failed test with escape characters: \"'<>&[0m (0x1b)" {
+  echo "<>'&[0m" && false
 }
 
-@test "Skipped test with escape characters: \"'<>&(0x1b)" {
-  skip "\"'<>&"
+@test "Skipped test with escape characters: \"'<>&[0m (0x1b)" {
+  skip "\"'<>&[0m"
 }

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -83,3 +83,11 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
   [[ "${lines[7]}" == *"</testsuite>"* ]]
   [[ "${lines[8]}" == *"</testsuites>"* ]]
 }
+
+@test "junit formatter: files with the same name are distinguishable" {
+  run bats --formatter junit -r "$FIXTURE_ROOT/duplicate/"
+  echo "$output"
+
+  [[ "${lines[2]}" == *"<testsuite name=\"first/file1.bats\""* ]]
+  [[ "${lines[5]}" == *"<testsuite name=\"second/file1.bats\""* ]]
+}

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -43,7 +43,6 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
       ESCAPED_TEST_FILE_NAME="xml-escape-&quot;&lt;&gt;&#39;&amp;.bats"
       TEST_FILE_PATH="$BATS_TEST_SUITE_TMPDIR/$TEST_FILE_NAME"
       cp "$FIXTURE_ROOT/xml-escape.bats" "$TEST_FILE_PATH"
-      NEED_CLEANUP=1
     ;;
     *)
       # use the filename without special chars
@@ -53,20 +52,15 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
     ;;
   esac
   run bats --formatter junit "$TEST_FILE_PATH"
-  [[ ${NEED_CLEANUP-0} == 0 ]] || rm "$TEST_FILE_PATH" # clean up to avoid leaving local file
 
   echo "$output"
-  TESTSUITE_REGEX="<testsuite name=\"$ESCAPED_TEST_FILE_NAME\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"$FLOAT_REGEX\" timestamp=\"$TIMESTAMP_REGEX\" hostname=\".*\">"
-  [[ "${lines[2]}" =~ $TESTSUITE_REGEX ]]
-  TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Successful test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;[0m \(0x1b\)\" time=\"$FLOAT_REGEX\"/>"
-  [[ "${lines[3]}" =~ $TESTCASE_REGEX ]]
-  [[ "${lines[4]}" == *"<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Failed test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;[0m (0x1b)\" "* ]]
-  [[ "${lines[5]}" == *'<failure type="failure">(in test file '*"$ESCAPED_TEST_FILE_NAME, line 6)" ]]
-  [[ "${lines[6]}" == *'`echo &quot;&lt;&gt;&#39;&amp;&#27;[0m&quot; &amp;&amp; false&#39; failed'* ]]
-
-  TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Skipped test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;\[0m \(0x1b\)\" time=\"$FLOAT_REGEX\">"
-  [[ "${lines[9]}" =~ $TESTCASE_REGEX ]]
-  [[ "${lines[10]}" == *"<skipped>&quot;&#39;&lt;&gt;&amp;&#27;[0m</skipped>"* ]]
+  [[ "${lines[2]}" == "<testsuite name=\"$ESCAPED_TEST_FILE_NAME\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\""*"\" timestamp=\""*"\" hostname=\""*"\">" ]]
+  [[ "${lines[3]}" == "    <testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Successful test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;[0m (0x1b)\" time=\""*"\" />" ]]
+  [[ "${lines[4]}" == "    <testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Failed test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;[0m (0x1b)\" "* ]]
+  [[ "${lines[5]}" == '        <failure type="failure">(in test file '*"$ESCAPED_TEST_FILE_NAME, line 6)" ]]
+  [[ "${lines[6]}" == '  `echo &quot;&lt;&gt;&#39;&amp;&#27;[0m&quot; &amp;&amp; false&#39; failed'* ]]
+  [[ "${lines[9]}" == "    <testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Skipped test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;[0m (0x1b)\" time=\""*"\">" ]]
+  [[ "${lines[10]}" == "        <skipped>&quot;&#39;&lt;&gt;&amp;&#27;[0m</skipped>" ]]
 }
 
 @test "junit formatter: test suites" {
@@ -125,24 +119,24 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 
   echo "$output"
 
-  [[ "${lines[2]}" == *'<testsuite name="issue_360.bats" '*'>'* ]]
-  [[ "${lines[3]}" == *'<testcase classname="issue_360.bats" '*'>' ]]
+  [[ "${lines[2]}" == '<testsuite name="issue_360.bats" '*'>' ]]
+  [[ "${lines[3]}" == '    <testcase classname="issue_360.bats" '*'>' ]]
   # only the outputs on FD3 should be visible on a successful test
-  [[ "${lines[4]}" == *'<system-out>setup FD3' ]]
+  [[ "${lines[4]}" == '        <system-out>setup FD3' ]]
   [[ "${lines[5]}" == 'hello Bilbo' ]]
-  [[ "${lines[6]}" == 'teardown FD3</system-out>'* ]]
-  [[ "${lines[7]}" == *'</testcase>' ]]
-  [[ "${lines[8]}" == *'<testcase classname="issue_360.bats" name="fail to say hello to Biblo"'* ]]
+  [[ "${lines[6]}" == 'teardown FD3</system-out>' ]]
+  [[ "${lines[7]}" == '    </testcase>' ]]
+  [[ "${lines[8]}" == '    <testcase classname="issue_360.bats" name="fail to say hello to Biblo" time="'*'">' ]]
   # a failed test should show FD3 output first ...
-  [[ "${lines[9]}" == *'<failure type="failure">setup FD3' ]]
+  [[ "${lines[9]}" == '        <system-out>setup FD3' ]]
   [[ "${lines[10]}" == 'hello Bilbo' ]]
-  [[ "${lines[11]}" == 'teardown FD3' ]]
-  [[ "${lines[12]}" == '(in test file '*'test/fixtures/junit-formatter/issue_360.bats, line 21)' ]]
+  [[ "${lines[11]}" == 'teardown FD3</system-out>' ]]
+  [[ "${lines[12]}" == '        <failure type="failure">(in test file '*'test/fixtures/junit-formatter/issue_360.bats, line 21)' ]]
   [[ "${lines[13]}" == '  `false&#39; failed' ]]
   # ... and then the stdout output
   [[ "${lines[14]}" == '# setup stdout' ]]
   [[ "${lines[15]}" == '# hello stdout' ]]
-  [[ "${lines[16]}" == '# teardown stdout</failure>'* ]]
-  [[ "${lines[17]}" == *'</testcase>'* ]]
-  [[ "${lines[18]}" == *'</testsuite>'* ]]
+  [[ "${lines[16]}" == '# teardown stdout</failure>' ]]
+  [[ "${lines[17]}" == '    </testcase>' ]]
+  [[ "${lines[18]}" == '</testsuite>' ]]
 }

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -107,3 +107,15 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
   [[ "${lines[2]}" == *"<testsuite name=\"first/file1.bats\""* ]]
   [[ "${lines[5]}" == *"<testsuite name=\"second/file1.bats\""* ]]
 }
+
+@test "junit formatter as report formatter creates report.xml" {
+  make_bats_test_suite_tmpdir
+  cd "$BATS_TEST_SUITE_TMPDIR" # don't litter sources with output files
+  run bats --report-formatter junit "$FIXTURE_ROOT/suite/"
+  echo "$output"
+  [[ -e "report.xml" ]]
+  run cat "report.xml"
+  echo "$output"
+  [[ "${lines[2]}" == *"<testsuite name=\"file1.bats\" tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\""* ]]
+  [[ "${lines[5]}" == *"<testsuite name=\"file2.bats\" tests=\"1\" failures=\"0\" errors=\"0\" skipped=\"0\""* ]]
+}

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -1,19 +1,79 @@
 #!/usr/bin/env bats
 
-TEST_REPORT_FILE="TestReport-skipped.bats.xml"
+load test_helper
+fixtures junit-formatter
 
-teardown() {
-  rm "${TEST_REPORT_FILE}"
-}
+FLOAT_REGEX='[0-9]+(\.[0-9]+){0,1}'
+TIMESTAMP_REGEX='[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}'
+TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 
 @test "junit formatter with skipped test does not fail" {
-  bats --formatter junit "$BATS_ROOT/test/fixtures/bats/skipped.bats"
+  run bats --formatter junit "$FIXTURE_ROOT/skipped.bats"
+  echo "$output"
+  [[ $status -eq 0 ]]
+  [[ "${lines[0]}" == '<?xml version="1.0" encoding="UTF-8"?>' ]]
+  
+  [[ "${lines[1]}" =~ $TESTSUITES_REGEX ]]
 
-  run grep -A 1 'name="a skipped test"' "${TEST_REPORT_FILE}"
-  echo "Skipped test without reason: '${lines[1]}'"
-  [[ ${lines[1]} == *"<skipped></skipped>"* ]]
+  TESTSUITE_REGEX="<testsuite name=\"skipped.bats\" tests=\"2\" failures=\"0\" errors=\"0\" skipped=\"2\" time=\"$FLOAT_REGEX\" timestamp=\"$TIMESTAMP_REGEX\" hostname=\".*?\">"
+  [[ "${lines[2]}" =~ $TESTSUITE_REGEX ]]
 
-  run grep -A 1 'name="a skipped test with a reason"' "${TEST_REPORT_FILE}"
-  echo "Skipped test with reason: ${lines[1]}"
-  [[ ${lines[1]} == *"<skipped>a reason</skipped>"* ]]
+  TESTCASE_REGEX="<testcase classname=\"skipped.bats\" name=\"a skipped test\" time=\"$FLOAT_REGEX\">"
+  [[ "${lines[3]}" =~ $TESTCASE_REGEX ]]
+
+  [[ "${lines[4]}" == *"<skipped></skipped>"* ]]
+  [[ "${lines[5]}" == *"</testcase>"* ]]
+
+  TESTCASE_REGEX="<testcase classname=\"skipped.bats\" name=\"a skipped test with a reason\" time=\"$FLOAT_REGEX\">"
+  [[ "${lines[6]}" =~ $TESTCASE_REGEX ]]
+  [[ "${lines[7]}" == *"<skipped>a reason</skipped>"* ]]
+  [[ "${lines[8]}" == *"</testcase>"* ]]
+  
+  [[ "${lines[9]}" == *"</testsuite>"* ]]
+  [[ "${lines[10]}" == *"</testsuites>"* ]]
+}
+
+@test "junit formatter: escapes xml special chars" {
+  case $OSTYPE in
+    linux*|darwin)
+      # their CI can handle special chars on filename
+      TEST_FILE_NAME="xml-escape-\"<>'&.bats"
+      ESCAPED_TEST_FILE_NAME="xml-escape-&quot;&lt;&gt;&#39;&amp;.bats"
+      cp "$FIXTURE_ROOT/xml-escape.bats" "$FIXTURE_ROOT/$TEST_FILE_NAME"
+    ;;
+    *)
+      # use the filename without special chars
+      TEST_FILE_NAME="xml-escape.bats"
+      ESCAPED_TEST_FILE_NAME="$TEST_FILE_NAME"
+    ;;
+  esac
+  run bats --formatter junit "$FIXTURE_ROOT/$TEST_FILE_NAME"
+
+  echo "$output"
+  TESTSUITE_REGEX="<testsuite name=\"$ESCAPED_TEST_FILE_NAME\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"$FLOAT_REGEX\" timestamp=\"$TIMESTAMP_REGEX\" hostname=\".*?\">"
+  [[ "${lines[2]}" =~ $TESTSUITE_REGEX ]]
+  TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Successful test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;\(0x1b\)\" time=\"$FLOAT_REGEX\"/>"
+  [[ "${lines[3]}" =~ $TESTCASE_REGEX ]]
+  [[ "${lines[7]}" == *'`echo &quot;&lt;&gt;&#39;&amp;&#27;&quot; &amp;&amp; false&#39; failed'* ]]
+
+  TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Skipped test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;\(0x1b\)\" time=\"$FLOAT_REGEX\">"
+  [[ "${lines[10]}" =~ $TESTCASE_REGEX ]]
+
+  TESTCASE_REGEX="<skipped>&quot;&#39;&lt;&gt;&amp;&#27;</skipped>"
+  [[ "${lines[11]}" =~ $TESTCASE_REGEX ]]
+}
+
+@test "junit formatter: test suites" {
+  run bats --formatter junit "$FIXTURE_ROOT/suite/"
+  echo "$output"
+
+  [[ "${lines[0]}" == '<?xml version="1.0" encoding="UTF-8"?>' ]]
+  [[ "${lines[1]}" == *"<testsuites "* ]]
+  [[ "${lines[2]}" == *"<testsuite name=\"file1.bats\""* ]]
+  [[ "${lines[3]}" == *"<testcase "* ]]
+  [[ "${lines[4]}" == *"</testsuite>"* ]]
+  [[ "${lines[5]}" == *"<testsuite name=\"file2.bats\""* ]]
+  [[ "${lines[6]}" == *"<testcase"* ]]
+  [[ "${lines[7]}" == *"</testsuite>"* ]]
+  [[ "${lines[8]}" == *"</testsuites>"* ]]
 }

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -58,14 +58,14 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
   echo "$output"
   TESTSUITE_REGEX="<testsuite name=\"$ESCAPED_TEST_FILE_NAME\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"$FLOAT_REGEX\" timestamp=\"$TIMESTAMP_REGEX\" hostname=\".*\">"
   [[ "${lines[2]}" =~ $TESTSUITE_REGEX ]]
-  TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Successful test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;\(0x1b\)\" time=\"$FLOAT_REGEX\"/>"
+  TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Successful test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;[0m \(0x1b\)\" time=\"$FLOAT_REGEX\"/>"
   [[ "${lines[3]}" =~ $TESTCASE_REGEX ]]
-  [[ "${lines[7]}" == *'`echo &quot;&lt;&gt;&#39;&amp;&#27;&quot; &amp;&amp; false&#39; failed'* ]]
+  [[ "${lines[7]}" == *'`echo &quot;&lt;&gt;&#39;&amp;&#27;[0m&quot; &amp;&amp; false&#39; failed'* ]]
 
-  TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Skipped test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;\(0x1b\)\" time=\"$FLOAT_REGEX\">"
+  TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Skipped test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;[0m \(0x1b\)\" time=\"$FLOAT_REGEX\">"
   [[ "${lines[10]}" =~ $TESTCASE_REGEX ]]
 
-  TESTCASE_REGEX="<skipped>&quot;&#39;&lt;&gt;&amp;&#27;</skipped>"
+  TESTCASE_REGEX="<skipped>&quot;&#39;&lt;&gt;&amp;&#27;[0m</skipped>"
   [[ "${lines[11]}" =~ $TESTCASE_REGEX ]]
 }
 

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -35,21 +35,25 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 }
 
 @test "junit formatter: escapes xml special chars" {
+  make_bats_test_suite_tmpdir
   case $OSTYPE in
     linux*|darwin)
       # their CI can handle special chars on filename
       TEST_FILE_NAME="xml-escape-\"<>'&.bats"
       ESCAPED_TEST_FILE_NAME="xml-escape-&quot;&lt;&gt;&#39;&amp;.bats"
-      cp "$FIXTURE_ROOT/xml-escape.bats" "$FIXTURE_ROOT/$TEST_FILE_NAME"
+      TEST_FILE_PATH="$BATS_TEST_SUITE_TMPDIR/$TEST_FILE_NAME"
+      cp "$FIXTURE_ROOT/xml-escape.bats" "$TEST_FILE_PATH"
+      NEED_CLEANUP=1
     ;;
     *)
       # use the filename without special chars
       TEST_FILE_NAME="xml-escape.bats"
       ESCAPED_TEST_FILE_NAME="$TEST_FILE_NAME"
+      TEST_FILE_PATH="$FIXTURE_ROOT/$TEST_FILE_NAME"
     ;;
   esac
-  run bats --formatter junit "$FIXTURE_ROOT/$TEST_FILE_NAME"
-  rm "$FIXTURE_ROOT/$TEST_FILE_NAME" # clean up to avoid leaving local file
+  run bats --formatter junit "$TEST_FILE_PATH"
+  [[ ${NEED_CLEANUP-0} == 0 ]] || rm "$TEST_FILE_PATH" # clean up to avoid leaving local file
 
   echo "$output"
   TESTSUITE_REGEX="<testsuite name=\"$ESCAPED_TEST_FILE_NAME\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"$FLOAT_REGEX\" timestamp=\"$TIMESTAMP_REGEX\" hostname=\".*\">"

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -4,7 +4,7 @@ load test_helper
 fixtures junit-formatter
 
 FLOAT_REGEX='[0-9]+(\.[0-9]+){0,1}'
-TIMESTAMP_REGEX='[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}'
+TIMESTAMP_REGEX='[0-9]+-[0-1][0-9]-[0-3][0-9]T[0-2][0-9]:[0-5][0-9]:[0-5][0-9]'
 TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 
 @test "junit formatter with skipped test does not fail" {
@@ -15,7 +15,8 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
   
   [[ "${lines[1]}" =~ $TESTSUITES_REGEX ]]
 
-  TESTSUITE_REGEX="<testsuite name=\"skipped.bats\" tests=\"2\" failures=\"0\" errors=\"0\" skipped=\"2\" time=\"$FLOAT_REGEX\" timestamp=\"$TIMESTAMP_REGEX\" hostname=\".*?\">"
+  TESTSUITE_REGEX="<testsuite name=\"skipped.bats\" tests=\"2\" failures=\"0\" errors=\"0\" skipped=\"2\" time=\"$FLOAT_REGEX\" timestamp=\"$TIMESTAMP_REGEX\" hostname=\".*\">"
+  echo "TESTSUITE_REGEX='$TESTSUITE_REGEX'"
   [[ "${lines[2]}" =~ $TESTSUITE_REGEX ]]
 
   TESTCASE_REGEX="<testcase classname=\"skipped.bats\" name=\"a skipped test\" time=\"$FLOAT_REGEX\">"
@@ -51,7 +52,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
   rm "$FIXTURE_ROOT/$TEST_FILE_NAME" # clean up to avoid leaving local file
 
   echo "$output"
-  TESTSUITE_REGEX="<testsuite name=\"$ESCAPED_TEST_FILE_NAME\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"$FLOAT_REGEX\" timestamp=\"$TIMESTAMP_REGEX\" hostname=\".*?\">"
+  TESTSUITE_REGEX="<testsuite name=\"$ESCAPED_TEST_FILE_NAME\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"$FLOAT_REGEX\" timestamp=\"$TIMESTAMP_REGEX\" hostname=\".*\">"
   [[ "${lines[2]}" =~ $TESTSUITE_REGEX ]]
   TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Successful test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;\(0x1b\)\" time=\"$FLOAT_REGEX\"/>"
   [[ "${lines[3]}" =~ $TESTCASE_REGEX ]]

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -48,6 +48,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
     ;;
   esac
   run bats --formatter junit "$FIXTURE_ROOT/$TEST_FILE_NAME"
+  rm "$FIXTURE_ROOT/$TEST_FILE_NAME" # clean up to avoid leaving local file
 
   echo "$output"
   TESTSUITE_REGEX="<testsuite name=\"$ESCAPED_TEST_FILE_NAME\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\"$FLOAT_REGEX\" timestamp=\"$TIMESTAMP_REGEX\" hostname=\".*?\">"

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -3,7 +3,7 @@
 load test_helper
 fixtures junit-formatter
 
-FLOAT_REGEX='[0-9]+(\.[0-9]+){0,1}'
+FLOAT_REGEX='[0-9]+(\.[0-9]+)?'
 TIMESTAMP_REGEX='[0-9]+-[0-1][0-9]-[0-3][0-9]T[0-2][0-9]:[0-5][0-9]:[0-5][0-9]'
 TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 
@@ -66,7 +66,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
   [[ "${lines[5]}" == *'<failure type="failure">(in test file '"$ESCAPED_TEST_FILE_PATH, line 6)" ]]
   [[ "${lines[6]}" == *'`echo &quot;&lt;&gt;&#39;&amp;&#27;[0m&quot; &amp;&amp; false&#39; failed'* ]]
 
-  TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Skipped test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;[0m \(0x1b\)\" time=\"$FLOAT_REGEX\">"
+  TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Skipped test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;\[0m \(0x1b\)\" time=\"$FLOAT_REGEX\">"
   [[ "${lines[9]}" =~ $TESTCASE_REGEX ]]
   [[ "${lines[10]}" == *"<skipped>&quot;&#39;&lt;&gt;&amp;&#27;[0m</skipped>"* ]]
 }

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -84,6 +84,22 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
   [[ "${lines[8]}" == *"</testsuites>"* ]]
 }
 
+@test "junit formatter: test suites relative path" {
+  cd "$FIXTURE_ROOT"
+  run bats --formatter junit "suite/"
+  echo "$output"
+
+  [[ "${lines[0]}" == '<?xml version="1.0" encoding="UTF-8"?>' ]]
+  [[ "${lines[1]}" == *"<testsuites "* ]]
+  [[ "${lines[2]}" == *"<testsuite name=\"file1.bats\""* ]]
+  [[ "${lines[3]}" == *"<testcase "* ]]
+  [[ "${lines[4]}" == *"</testsuite>"* ]]
+  [[ "${lines[5]}" == *"<testsuite name=\"file2.bats\""* ]]
+  [[ "${lines[6]}" == *"<testcase"* ]]
+  [[ "${lines[7]}" == *"</testsuite>"* ]]
+  [[ "${lines[8]}" == *"</testsuites>"* ]]
+}
+
 @test "junit formatter: files with the same name are distinguishable" {
   run bats --formatter junit -r "$FIXTURE_ROOT/duplicate/"
   echo "$output"

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -41,7 +41,6 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
       # their CI can handle special chars on filename
       TEST_FILE_NAME="xml-escape-\"<>'&.bats"
       ESCAPED_TEST_FILE_NAME="xml-escape-&quot;&lt;&gt;&#39;&amp;.bats"
-      ESCAPED_TEST_FILE_PATH="$BATS_TEST_SUITE_TMPDIR$ESCAPED_TEST_FILE_NAME"
       TEST_FILE_PATH="$BATS_TEST_SUITE_TMPDIR/$TEST_FILE_NAME"
       cp "$FIXTURE_ROOT/xml-escape.bats" "$TEST_FILE_PATH"
       NEED_CLEANUP=1
@@ -51,7 +50,6 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
       TEST_FILE_NAME="xml-escape.bats"
       ESCAPED_TEST_FILE_NAME="$TEST_FILE_NAME"
       TEST_FILE_PATH="$FIXTURE_ROOT/$TEST_FILE_NAME"
-      ESCAPED_TEST_FILE_PATH="$TEST_FILE_PATH"
     ;;
   esac
   run bats --formatter junit "$TEST_FILE_PATH"
@@ -63,7 +61,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
   TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Successful test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;[0m \(0x1b\)\" time=\"$FLOAT_REGEX\"/>"
   [[ "${lines[3]}" =~ $TESTCASE_REGEX ]]
   [[ "${lines[4]}" == *"<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Failed test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;[0m (0x1b)\" "* ]]
-  [[ "${lines[5]}" == *'<failure type="failure">(in test file '"$ESCAPED_TEST_FILE_PATH, line 6)" ]]
+  [[ "${lines[5]}" == *'<failure type="failure">(in test file '*"$ESCAPED_TEST_FILE_NAME, line 6)" ]]
   [[ "${lines[6]}" == *'`echo &quot;&lt;&gt;&#39;&amp;&#27;[0m&quot; &amp;&amp; false&#39; failed'* ]]
 
   TESTCASE_REGEX="<testcase classname=\"$ESCAPED_TEST_FILE_NAME\" name=\"Skipped test with escape characters: &quot;&#39;&lt;&gt;&amp;&#27;\[0m \(0x1b\)\" time=\"$FLOAT_REGEX\">"
@@ -139,7 +137,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
   [[ "${lines[9]}" == *'<failure type="failure">setup FD3' ]]
   [[ "${lines[10]}" == 'hello Bilbo' ]]
   [[ "${lines[11]}" == 'teardown FD3' ]]
-  [[ "${lines[12]}" == '(in test file test/fixtures/junit-formatter/issue_360.bats, line 21)' ]]
+  [[ "${lines[12]}" == '(in test file '*'test/fixtures/junit-formatter/issue_360.bats, line 21)' ]]
   [[ "${lines[13]}" == '  `false&#39; failed' ]]
   # ... and then the stdout output
   [[ "${lines[14]}" == '# setup stdout' ]]

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -57,10 +57,10 @@ fixtures suite
   echo "output: $output"
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..3" ]
-  [ "${lines[1]}" = "suite a.bats" ]
+  [ "${lines[1]}" = "suite $FIXTURE_ROOT/multiple/a.bats" ]
   [ "${lines[2]}" = "begin 1 truth" ]
   [ "${lines[3]}" = "ok 1 truth" ]
-  [ "${lines[4]}" = "suite b.bats" ]
+  [ "${lines[4]}" = "suite $FIXTURE_ROOT/multiple/b.bats" ]
   [ "${lines[5]}" = "begin 2 more truth" ]
   [ "${lines[6]}" = "ok 2 more truth" ]
   [ "${lines[7]}" = "begin 3 quasi-truth" ]
@@ -87,11 +87,11 @@ fixtures suite
   echo "$output"
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..3" ]
-  [ "${lines[1]}" = "suite a.bats" ]
+  [ "${lines[1]}" = "suite $FIXTURE_ROOT/multiple/a.bats" ]
   [ "${lines[2]}" = "begin 1 truth" ]
   regex="ok 1 truth in [0-9]+ms"
   [[ "${lines[3]}" =~ $regex ]]
-  [ "${lines[4]}" = "suite b.bats" ]
+  [ "${lines[4]}" = "suite $FIXTURE_ROOT/multiple/b.bats" ]
   [ "${lines[5]}" = "begin 2 more truth" ]
   regex="ok 2 more truth in [0-9]+ms"
   [[ "${lines[6]}" =~ $regex ]]


### PR DESCRIPTION
This mainly deals with #342 but might incorporate #341  as well.

- [x] document --report option
- [x] update to #337's timing information, as soon as it lands

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
