### PR TITLE
fix: time is greater than 0ms for long test

### DIFF
--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -123,7 +123,7 @@ bats_exit_trap() {
 get_mills_since_epoch() {
   local ms_since_epoch
   ms_since_epoch=$(date +%s%N)
-  if [[ "$ms_since_epoch" == *N ]]; then
+  if [[ "$ms_since_epoch" == *N || "${#ms_since_epoch}" -lt 19 ]]; then
         ms_since_epoch=$(( $(date +%s) * 1000 ))
   else
         ms_since_epoch=$(( ms_since_epoch / 1000000 ))

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -357,6 +357,15 @@ teardown() {
   [[ "${lines[7]}" =~ $regex ]]
 }
 
+@test "time is greater than 0ms for long test" {
+  emulate_bats_env
+  run bats-exec-suite -x -T "$FIXTURE_ROOT/run_long_command.bats"
+  echo "$output"
+  [ $status -eq 0 ]
+  regex="ok 1 run long command in [1-9][0-9]*ms"
+  [[ "${lines[3]}" =~ $regex ]]
+}
+
 @test "pretty and tap formats" {
   run bats --formatter tap "$FIXTURE_ROOT/passing.bats"
   tap_output="$output"


### PR DESCRIPTION
- busybox doesn't support `date +%s%N` syntax
- returned time value judged to be in millis if more than 18 digits long

---

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
