### PR TITLE
Improve BATS_RUN_TMPDIR documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,8 +594,10 @@ There are several global variables you can use to introspect on Bats tests:
   test file.
 * `$BATS_SUITE_TEST_NUMBER` is the (1-based) index of the current test case in
  the test suite (over all files).
-* `$BATS_TMPDIR` is the location to a directory that may be used to store
-  temporary files.
+* `$BATS_RUN_TMPDIR` is the path to a directory that will be deleted after the run
+  unless `--no-tmpdir-cleanup` is specified (defaults to `$BATS_TMPDIR/bats-run-<PID>`)
+* `$BATS_TMPDIR` is the path to a directory that may be used to store
+  temporary files. (defaults to `/tmp`)
 
 ### Libraries and Add-ons
 

--- a/lib/bats-core/preprocessing.bash
+++ b/lib/bats-core/preprocessing.bash
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-if [[ -z "$TMPDIR" ]]; then
-	export BATS_TMPDIR='/tmp'
-else
-	export BATS_TMPDIR="${TMPDIR%/}"
-fi
-
 BATS_TMPNAME="$BATS_RUN_TMPDIR/bats.$$"
 BATS_PARENT_TMPNAME="$BATS_RUN_TMPDIR/bats.$PPID"
 # shellcheck disable=SC2034

--- a/man/bats.1
+++ b/man/bats.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BATS" "1" "July 2020" "bats-core" "Bash Automated Testing System"
+.TH "BATS" "1" "October 2020" "bats-core" "Bash Automated Testing System"
 .
 .SH "NAME"
 \fBbats\fR \- Bash Automated Testing System
@@ -39,19 +39,25 @@ You can invoke the \fBbats\fR interpreter with multiple test file arguments, or 
 \fB\-f\fR, \fB\-\-filter <regex>\fR: Filter test cases by names matching the regular expression
 .
 .IP "\(bu" 4
-\fB\-F\fR, \fB\-\-formatter <type>\fR: Switch between formatters: pretty (default), tap (default w/o term), junit
+\fB\-F\fR, \fB\-\-formatter <type>\fR: Switch between formatters: pretty (default), tap (default w/o term), tap13, junit
 .
 .IP "\(bu" 4
 \fB\-h\fR, \fB\-\-help\fR: Display this help message
 .
 .IP "\(bu" 4
-\fB\-j\fR, \fB\-\-jobs <jobs>\fR: Number of parallel jobs
+\fB\-j\fR, \fB\-\-jobs <jobs>\fR: Number of parallel jobs (requires GNU parallel)
 .
 .IP "\(bu" 4
 \fB\-\-no\-tempdir\-cleanup\fR: Preserve test output temporary directory
 .
 .IP "\(bu" 4
-\fB\-\-no\-parallelize\-across\-files\fR Only parallelize tests within files\.
+\fB\-\-no\-parallelize\-across\-files\fR Serialize test file execution instead of running them in parallel (requires \-\-jobs >1)
+.
+.IP "\(bu" 4
+\fB\-\-no\-parallelize\-within\-files\fR Serialize test execution within files instead of running them in parallel (requires \-\-jobs >1)
+.
+.IP "\(bu" 4
+\fB\-\-report\-formatter <type>\fR: Switch between reporters (same options as \-\-formatter)
 .
 .IP "\(bu" 4
 \fB\-o\fR, \fB\-\-output <dir>\fR: Directory to write report files

--- a/man/bats.7
+++ b/man/bats.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BATS" "7" "July 2020" "bats-core" "Bash Automated Testing System"
+.TH "BATS" "7" "October 2020" "bats-core" "Bash Automated Testing System"
 .
 .SH "NAME"
 \fBbats\fR \- Bats test file format
@@ -173,7 +173,10 @@ There are several global variables you can use to introspect on Bats tests:
 \fB$BATS_SUITE_TEST_NUMBER\fR is the (1\-based) index of the current test case in the test suite (over all files)\.
 .
 .IP "\(bu" 4
-\fB$BATS_TMPDIR\fR is the location to a directory that may be used to store temporary files\.
+\fB$BATS_RUN_TMPDIR\fR is the path to a directory that will be deleted after the run unless \fB\-\-no\-tmpdir\-cleanup\fR is specified (defaults to \fB$BATS_TMPDIR/bats\-run\-<PID>\fR)
+.
+.IP "\(bu" 4
+\fB$BATS_TMPDIR\fR is the path to a directory that may be used to store temporary files\. (defaults to \fB/tmp\fR)
 .
 .IP "" 0
 .

--- a/man/bats.7.ronn
+++ b/man/bats.7.ronn
@@ -148,8 +148,11 @@ case.
 in the test file.
 * `$BATS_SUITE_TEST_NUMBER` is the (1-based) index of the current test 
   case in the test suite (over all files).
-* `$BATS_TMPDIR` is the location to a directory that may be used to
-store temporary files.
+* `$BATS_RUN_TMPDIR` is the path to a directory that will be deleted 
+  after the run unless `--no-tmpdir-cleanup` is specified (defaults to 
+  `$BATS_TMPDIR/bats-run-<PID>`)
+* `$BATS_TMPDIR` is the path to a directory that may be used to store
+  temporary files. (defaults to `/tmp`)
 
 
 SEE ALSO


### PR DESCRIPTION
Improve on the issues discussed in https://github.com/bats-core/bats-core/issues/283#issuecomment-629869040

I noticed that BATS_TMPDIR is unconditionally initialized from TMPDIR, so having set BATS_TMPDIR from outside will be overriden by TMPDIR. I think this might be confusing for new users. My proposal would be:

1. [ ] use BATS_TMPDIR as is, if it is set
2. [ ] use BATS_TMPDIR=$TMPDIR if BATS_TMPDIR is not set and TMPDIR is set
3. [ ] use BATS_TMPDIR=/tmp if neither BATS_TMPDIR nor TMPDIR are set
4. [ ] document this for new users

Hopefully, this does not break existing users as it only changes the case where an already set `BATS_TMPDIR` is (IMHO erroneously) overridden. WDYT @sublimino ?

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
