### PR TITLE
Add --shellcheck switch for checking *.bats files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM bash:${bashver}
 
 # Install parallel and accept the citation notice (we aren't using this in a
 # context where it make sense to cite GNU Parallel).
-RUN apk add --no-cache parallel ncurses && \
+RUN apk add --no-cache parallel ncurses shellcheck && \
     mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 
 RUN ln -s /opt/bats/bin/bats /usr/local/bin/bats

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ Usage: bats [OPTIONS] <tests>
   -o, --output <dir>        Directory to write report files
   -p, --pretty              Shorthand for "--formatter pretty"
   -r, --recursive           Include tests in subdirectories
+  --shellcheck              Run shellcheck on the *.bats files instead of 
+                            running the tests
   -t, --tap                 Shorthand for "--formatter tap"
   -T, --timing              Add timing information to tests
   -v, --version             Display the version number

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -301,11 +301,11 @@ if [[ -n $run_shellcheck ]]; then
       done
     }
 
-    BATS_SHELLCHECK_OPTIONS+=(--shell=bash) # override shellcheck's shell detection
+    BATS_SHELLCHECK_OPTIONS+=("--shell=bash") # override shellcheck's shell detection
     # since we pipe shellcheck's output through the function above, shellcheck 
     # can't detect if it should colorize or not -> let us decide
     if [[ -t 0 && -t 1 ]]; then
-      BATS_SHELLCHECK_OPTIONS+=(--color=always)
+      BATS_SHELLCHECK_OPTIONS+=("--color=always")
     fi
     (set -o pipefail; "${BATS_SHELLCHECK_EXE-shellcheck}" "${BATS_SHELLCHECK_OPTIONS[@]}" "${preprocessed_file}" | replace_preprocessed_filepath_by_original_filepath) || status=1
   done

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -45,6 +45,8 @@ HELP_TEXT_HEADER
   -o, --output <dir>        Directory to write report files
   -p, --pretty              Shorthand for "--formatter pretty"
   -r, --recursive           Include tests in subdirectories
+  --shellcheck              Run shellcheck on the *.bats files instead of 
+                            running the tests
   -t, --tap                 Shorthand for "--formatter tap"
   -T, --timing              Add timing information to tests
   -v, --version             Display the version number
@@ -110,6 +112,7 @@ report_formatter=''
 recursive=
 tempdir_cleanup=1
 output=
+run_shellcheck=
 if [[ -z "${CI:-}" && -t 0 && -t 1 ]] && command -v tput >/dev/null; then
   formatter='pretty'
 fi
@@ -183,6 +186,9 @@ while [[ "$#" -ne 0 ]]; do
     ;;
   --no-tempdir-cleanup)
     tempdir_cleanup=''
+    ;;
+  --shellcheck)
+    run_shellcheck=1
     ;;
   -*)
     abort "Bad command line option '$1'"
@@ -275,6 +281,36 @@ for filename in "${arguments[@]}"; do
     filenames+=("$filename")
   fi
 done
+
+if [[ -n $run_shellcheck ]]; then
+  index=0
+  status=0
+  for file in "${filenames[@]}"; do
+    (( ++index ))
+    preprocessed_file="${BATS_RUN_TMPDIR}/${index}_$(basename "$file")"
+    bats-preprocess "${file}" > "${preprocessed_file}"
+
+    if [[ ! -r "${file}" ]]; then
+      printf "Cannot read file '%s', does it exist?\n" "${file}"
+      exit 1
+    fi
+
+    replace_preprocessed_filepath_by_original_filepath() {
+      while read -r line; do 
+        printf "%s\n" "${line/${preprocessed_file}/${file#${PWD}/}}"; 
+      done
+    }
+
+    BATS_SHELLCHECK_OPTIONS+=(--shell=bash) # override shellcheck's shell detection
+    # since we pipe shellcheck's output through the function above, shellcheck 
+    # can't detect if it should colorize or not -> let us decide
+    if [[ -t 0 && -t 1 ]]; then
+      BATS_SHELLCHECK_OPTIONS+=(--color=always)
+    fi
+    (set -o pipefail; "${BATS_SHELLCHECK_EXE-shellcheck}" "${BATS_SHELLCHECK_OPTIONS[@]}" "${preprocessed_file}" | replace_preprocessed_filepath_by_original_filepath) || status=1
+  done
+  exit $status
+fi
 
 # shellcheck source=lib/bats-core/validator.bash
 source "$BATS_ROOT/lib/bats-core/validator.bash"

--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -71,6 +71,8 @@ OPTIONS
     Shorthand for "--formatter pretty"
   * `-r`, `--recursive`:
     Include tests in subdirectories
+  * `--shellcheck`:
+    Run shellcheck on the *.bats files instead of running the tests
   * `-t`, `--tap`:
     Shorthand for "--formatter tap"
   * `-T`, `--timing`:

--- a/test/fixtures/shellcheck/failure.bats
+++ b/test/fixtures/shellcheck/failure.bats
@@ -1,0 +1,3 @@
+@test test {
+    [[ $undefined_var == 0 ]]
+}

--- a/test/fixtures/shellcheck/valid.bats
+++ b/test/fixtures/shellcheck/valid.bats
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+@test "test" {
+    true
+}

--- a/test/shellcheck.bats
+++ b/test/shellcheck.bats
@@ -3,6 +3,12 @@
 load test_helper
 fixtures shellcheck
 
+setup() {
+    if ! command -v shellcheck; then
+        skip 'This test requires shellcheck to be installed'
+    fi
+}
+
 @test "shellcheck does not choke on custom syntax" {
     run bats --shellcheck "${FIXTURE_ROOT}/valid.bats"
     echo "$output"

--- a/test/shellcheck.bats
+++ b/test/shellcheck.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+load test_helper
+fixtures shellcheck
+
+@test "shellcheck does not choke on custom syntax" {
+    run bats --shellcheck "${FIXTURE_ROOT}/valid.bats"
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ -z "$output" ]]
+}
+
+@test "shellcheck errors are mapped to the correct file" {
+    run bats --shellcheck "${FIXTURE_ROOT}/failure.bats"
+    echo "$output"
+    [[ $status -ne 0 ]]
+    [[ "${lines[0]}" == "In ${RELATIVE_FIXTURE_ROOT}/failure.bats line 2:" ]]
+}


### PR DESCRIPTION
Bats files are not valid bash, so ~shellcheck~ some linters will choke on the special syntax, thus preventing us from checking our *.bats files.
This PR adds the `--shellcheck` flag which feeds the preprocessed bats files, that are valid bash, to shellcheck. Thus, bats acts as a wrapper around shellcheck to allow for checking test files.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
