### PR TITLE
Include symlinks during --recursive operation

### DIFF
--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -264,7 +264,7 @@ for filename in "${arguments[@]}"; do
     if [[ "$recursive" -eq 1 ]]; then
       while IFS= read -r -d $'\0' file; do
         filenames+=("$file")
-      done < <(find "$filename" -type f -name '*.bats' -print0 | sort -z)
+      done < <(find -L "$filename" -type f -name '*.bats' -print0 | sort -z)
     else
       for suite_filename in "$filename"/*.bats; do
         filenames+=("$suite_filename")

--- a/test/fixtures/suite/recursive_with_symlinks/subsuite
+++ b/test/fixtures/suite/recursive_with_symlinks/subsuite
@@ -1,0 +1,1 @@
+../recursive/subsuite/

--- a/test/fixtures/suite/recursive_with_symlinks/test.bats
+++ b/test/fixtures/suite/recursive_with_symlinks/test.bats
@@ -1,0 +1,1 @@
+../recursive/test.bats

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -116,6 +116,18 @@ fixtures suite
   [ "${lines[2]}" = "ok 2 a passing test" ]
 }
 
+@test "recursive support with symlinks" {
+  if [[ ! -L "${FIXTURE_ROOT}/recursive_with_symlinks/test.bats" ]]; then
+    skip "symbolic links aren't functional on OSTYPE=$OSTYPE"
+  fi
+
+  run bats -r "${FIXTURE_ROOT}/recursive_with_symlinks"
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..2" ]
+  [ "${lines[1]}" = "ok 1 another passing test" ]
+  [ "${lines[2]}" = "ok 2 a passing test" ]
+}
+
 @test "run entire suite when --filter isn't set" {
   run bats "${FIXTURE_ROOT}/filter"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Previously, to implement recursive operation, `bats` used `find` without the `-L` switch. As a consequence, when the test cases were structured in subdirectories, where some of the folders were symlinks or the testcase itself was a symlink to a testcase, it would be ignored. The `-L` option of `find` follows symlinks and checks the test predicates on the target of the link.

Changes:
- added the `-L` option to the `find` call in the main program.
- added a new fixture in `suites/recursive_with_symlinks` that refers to the recursive test case via symlink.
- added a new test case in `suite.bats` that is skipped on OSes where symlinks are not functional.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
