### PR TITLE
preprocessing: clean up incorrect unset variable handling

### DIFF
--- a/lib/bats-core/preprocessing.bash
+++ b/lib/bats-core/preprocessing.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ -z "$TMPDIR" ]]; then
+if [[ -z "${TMPDIR:-}" ]]; then
 	export BATS_TMPDIR='/tmp'
 else
 	export BATS_TMPDIR="${TMPDIR%/}"
@@ -25,7 +25,7 @@ bats_cleanup_preprocessed_source() {
 }
 
 bats_evaluate_preprocessed_source() {
-	if [[ -z "$BATS_TEST_SOURCE" ]]; then
+	if [[ -z "${BATS_TEST_SOURCE:-}" ]]; then
 		BATS_TEST_SOURCE="${BATS_PARENT_TMPNAME}.src"
 	fi
 	# Dynamically loaded user files provided outside of Bats.


### PR DESCRIPTION
Without this patch, a script that has "set -u" set will end up with one
of the following errors:

  preprocessing.bash: line 3: TMPDIR: unbound variable
  preprocessing.bash: line 28: BATS_TEST_SOURCE: unbound variable

Fixes: #385
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
