### PR TITLE
Use absolute executable path to fix command-not-found error when PATH updated in tests.

### DIFF
--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -68,7 +68,8 @@ expand_path() {
   printf -v "$result" '%s/%s' "$dirname" "${path##*/}"
 }
 
-export BATS_LIBEXEC="$(dirname "$(bats_readlinkf "${BASH_SOURCE[0]}")")"
+BATS_LIBEXEC="$(dirname "$(bats_readlinkf "${BASH_SOURCE[0]}")")"
+export BATS_LIBEXEC
 export BATS_CWD="$PWD"
 export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
 export BATS_TEST_PATTERN_COMMENT="[[:blank:]]*([^[:blank:]()]+)[[:blank:]]*\(?\)?[[:blank:]]+\{[[:blank:]]+#[[:blank:]]*@test[[:blank:]]*\$"

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -68,7 +68,7 @@ expand_path() {
   printf -v "$result" '%s/%s' "$dirname" "${path##*/}"
 }
 
-BATS_LIBEXEC="$(dirname "$(bats_readlinkf "${BASH_SOURCE[0]}")")"
+export BATS_LIBEXEC="$(dirname "$(bats_readlinkf "${BASH_SOURCE[0]}")")"
 export BATS_CWD="$PWD"
 export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
 export BATS_TEST_PATTERN_COMMENT="[[:blank:]]*([^[:blank:]()]+)[[:blank:]]*\(?\)?[[:blank:]]+\{[[:blank:]]+#[[:blank:]]*@test[[:blank:]]*\$"

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -193,7 +193,7 @@ bats_run_tests_in_parallel() {
       ((++test_number_in_file))
       mkdir -p "$output_folder/$test_number_in_suite"
       bats_semaphore_run "$output_folder/$test_number_in_suite" \
-                          bats-exec-test "${flags[@]}" "$filename" "$test_name" "$test_number_in_suite" "$test_number_in_file" \
+                          "$BATS_LIBEXEC/bats-exec-test" "${flags[@]}" "$filename" "$test_name" "$test_number_in_suite" "$test_number_in_file" \
                           > "$output_folder/$test_number_in_suite/pid"
     fi
     # print results early to get interactive feedback
@@ -239,9 +239,9 @@ bats_run_tests() {
         ((++test_number_in_file))
         # deal with empty flags to avoid spurious "unbound variable" errors on Bash 4.3 and lower
         if [[ "${#flags[@]}" -gt 0 ]]; then
-          bats-exec-test "${flags[@]}" "$filename" "$test_name" "$test_number_in_suite" "$test_number_in_file" || status=1
+          "$BATS_LIBEXEC/bats-exec-test" "${flags[@]}" "$filename" "$test_name" "$test_number_in_suite" "$test_number_in_file" || status=1
         else
-          bats-exec-test "$filename" "$test_name" "$test_number_in_suite" "$test_number_in_file" || status=1
+          "$BATS_LIBEXEC/bats-exec-test" "$filename" "$test_name" "$test_number_in_suite" "$test_number_in_file" || status=1
         fi
       fi
     done

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -701,3 +701,9 @@ END_OF_ERR_MSG
   [ "${lines[5]}" = 'ok 5 should_be_found_with_function_and_parens' ]
   [ "${lines[6]}" = 'ok 6 should_be_found_with_function_parens_and_whitespace' ]
 }
+
+@test "test works even if PATH is reset" {
+  run bats "$FIXTURE_ROOT/update_path_env.bats"
+  [ "$status" -eq 1 ]
+  [ "${lines[4]}" = "# /usr/bin:/bin" ]
+}

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -705,5 +705,5 @@ END_OF_ERR_MSG
 @test "test works even if PATH is reset" {
   run bats "$FIXTURE_ROOT/update_path_env.bats"
   [ "$status" -eq 1 ]
-  [ "${lines[4]}" = "# /usr/bin:/bin" ]
+  [ "${lines[4]}" = "# /usr/local/bin:/usr/bin:/bin" ]
 }

--- a/test/fixtures/bats/update_path_env.bats
+++ b/test/fixtures/bats/update_path_env.bats
@@ -1,4 +1,4 @@
-PATH="/usr/bin:/bin"
+PATH="/usr/local/bin:/usr/bin:/bin"
 
 @test "PATH is reset" {
   echo "$PATH"

--- a/test/fixtures/bats/update_path_env.bats
+++ b/test/fixtures/bats/update_path_env.bats
@@ -1,0 +1,6 @@
+PATH="/usr/bin:/bin"
+
+@test "PATH is reset" {
+  echo "$PATH"
+  false
+}


### PR DESCRIPTION
Dear maintainers,

First, please look at below snippet:

https://github.com/bats-core/bats-core/blob/e81e2ef3a2b4d6a45d5f50deeb3d4f0e0aeca8b7/libexec/bats-core/bats-exec-file#L85

Because of the `source` command shown above, if `PATH` environment variable is reset or updated in user tests, which causes `$BATS_ROOT/libexec/bats-core` removed from `PATH`,  it will fail with below error:
```
/usr/local/libexec/bats-core/bats-exec-file: line 242: bats-exec-test: command not found
```

I met the above problem when I ran tests of [ruby-build](https://github.com/rbenv/ruby-build). In all its tests (e.g. [this test](https://github.com/rbenv/ruby-build/blob/763b14af70523064c9a81469c471b21423a47f8b/test/arguments.bats#L3)), they load a [test_helper](https://github.com/rbenv/ruby-build/blob/master/test/test_helper.bash#L8) script which resets `PATH` before running tests, which causes `command not found` error.

IMHO, no matter if the user is updating `PATH` purposely or unpurposely, we should make this library more robust to satisfy such need or tolerate such error. So I made this PR.

Please have a review. Thanks for your time!