### PR TITLE
Fix unbound variables inside bats

### DIFF
--- a/lib/bats-core/preprocessing.bash
+++ b/lib/bats-core/preprocessing.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ -z "$TMPDIR" ]]; then
+if [[ -z "${TMPDIR:-}" ]]; then
 	export BATS_TMPDIR='/tmp'
 else
 	export BATS_TMPDIR="${TMPDIR%/}"
@@ -25,7 +25,7 @@ bats_cleanup_preprocessed_source() {
 }
 
 bats_evaluate_preprocessed_source() {
-	if [[ -z "$BATS_TEST_SOURCE" ]]; then
+	if [[ -z "${BATS_TEST_SOURCE:-}" ]]; then
 		BATS_TEST_SOURCE="${BATS_PARENT_TMPNAME}.src"
 	fi
 	# Dynamically loaded user files provided outside of Bats.

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -76,7 +76,7 @@ export BATS_TEST_PATTERN_COMMENT="[[:blank:]]*([^[:blank:]()]+)[[:blank:]]*\(?\)
 export BATS_TEST_FILTER=
 export PATH="$BATS_LIBEXEC:$PATH"
 export BATS_ROOT_PID=$$
-if [[ -z "$TMPDIR" ]]; then
+if [[ -z "${TMPDIR-}" ]]; then
   export BATS_TMPDIR="/tmp"
 else
   export BATS_TMPDIR="${TMPDIR%/}"

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -105,8 +105,8 @@ set -- "${arguments[@]}"
 arguments=()
 
 unset flags recursive formatter_flags
-flags=()
-formatter_flags=()
+flags=('--dummy-flag') # add a dummy flag to prevent unset varialeb errors on empty array expansion in old bash versions
+formatter_flags=('--dummy-flag') # add a dummy flag to prevent unset varialeb errors on empty array expansion in old bash versions
 formatter='tap'
 report_formatter=''
 recursive=

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -30,6 +30,8 @@ while [[ "$#" -ne 0 ]]; do
     # use singular to allow for users to override in file
     BATS_NO_PARALLELIZE_WITHIN_FILE=1
     ;;
+  --dummy-flag)
+    ;;
   *)
     break
     ;;

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -8,7 +8,7 @@ have_gnu_parallel=
 bats_parallel_args=()
 bats_no_parallelize_across_files=${BATS_NO_PARALLELIZE_ACROSS_FILES-}
 bats_no_parallelize_within_files=
-flags=()
+flags=('--dummy-flag') # add a dummy flag to prevent unset varialeb errors on empty array expansion in old bash versions
 
 abort() {
   printf 'Error: %s\n' "$1" >&2
@@ -42,6 +42,8 @@ while [[ "$#" -ne 0 ]]; do
   --no-parallelize-within-files)
     bats_no_parallelize_within_files=1
     flags+=("--no-parallelize-within-files")
+    ;;
+  --dummy-flag)
     ;;
   *)
     break
@@ -80,7 +82,8 @@ for filename in "$@"; do
     test_line=$(printf "%s\t%s" "$filename" "$line")
     all_tests+=("$test_line")
     printf "%s\n" "$test_line" >>"$TESTS_LIST_FILE"
-    if [[ " ${test_names[*]} " == *" $line "* ]]; then
+    # avoid unbound variable errors on empty array expansion with old bash versions
+    if [[ ${#test_names[@]} -gt 0 && " ${test_names[*]} " == *" $line "* ]]; then
       test_dupes+=("$line")
       continue
     fi

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -707,3 +707,13 @@ END_OF_ERR_MSG
   [ "$status" -eq 1 ]
   [ "${lines[4]}" = "# /usr/local/bin:/usr/bin:/bin" ]
 }
+
+@test "Test nounset does not trip up bats' internals (see #385)" {
+  # don't export nounset within this file or we might trip up the testsuite itself,
+  # getting bad diagnostics
+  run bash -c "set -o nounset; export SHELLOPTS; bats --tap '$FIXTURE_ROOT/passing.bats'"
+  echo "$output"
+  [ "${lines[0]}" = "1..1" ]
+  [ "${lines[1]}" = "ok 1 a passing test" ]
+  [ ${#lines[@]} = 2 ]
+}


### PR DESCRIPTION
This builds on top of #386, fixes #385 