### PR TITLE
Add beginner documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,9 +10,13 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 * added checks and improved documentation for `$BATS_TMPDIR` (#410)
+
+#### Documentation
+
+* added tutorial for new users (#397)
 
 ### Fixed
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -151,8 +151,11 @@ How can I lint/shell-format my bats tests?
 ------------------------------------------
 
 Due to their custom syntax (`@test`), `.bats` files are not standard bash. This prevents most tools from working with bats.
-However, shellcheck supports `.bats` files since version 0.7 and there is an alternative syntax `function_name { # @test` to declare tests in a bash compliant manner.
-There is currently no known formatter that supports formatting custom `.bats` syntax files directly.
+However, there is an alternative syntax `function_name { # @test` to declare tests in a bash compliant manner.
+
+- shellcheck support since version 0.7
+- shfmt support since version 3.2.0 (using `-ln bats`)
+
 
 How can I check if a test failed/succeeded during teardown?
 -----------------------------------------------------------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,0 +1,166 @@
+FAQ
+===
+
+How do I set the working directory?
+-----------------------------------
+
+The working directory is simply the directory where you started when executing bats.
+If you want to enforce a specific directory, you can use `cd` in the `setup_file`/`setup` functions.
+However, be aware that code outside any function will run before any of these setup functions and my interfere with bats' internals.
+
+
+How do I see the output of the command under `run` when a test fails?
+---------------------------------------------------------------------
+
+`run` captures stdout and stderr of its command and stores it in the `$output` and `${lines[@]}` variables.
+If you want to see this output, you need to print it yourself, or use functions like `assert_output` that will reproduce it on failure.
+
+Can I use `--filter` to exclude files/tests?
+--------------------------------------------
+
+No, not directly. `--filter` uses a regex to match against test names. So you could try to invert the regex.
+The filename won't be part of the strings that are tested, so you cannot filter against files.
+
+How can I exclude a single test from a test run?
+------------------------------------------------
+
+If you wan't to exclude only few tests from a run, you can either `skip` them:
+
+.. code-block:: bash
+
+    @test "Testname" {
+        # yadayada
+    }
+
+becomes 
+
+.. code-block:: bash
+
+    @test "Testname" {
+        skip 'Optional skip message'
+        # yadayada
+    }
+
+or comment them out, e.g.:
+
+.. code-block:: bash
+
+    @test "Testname" {
+
+becomes 
+
+.. code-block:: bash
+
+    disabled() { # @test "Testname" {
+
+For multiple tests or all tests of a file, this becomes tedious, so read on.
+
+How can I exclude all tests of a file from a test run?
+--------------------------------------------------------
+
+If you run your test suite by naming individual files like:
+
+.. code-block:: bash
+
+    $ bats test/a.bats test/b.bats ...
+
+you can simply omit your file. When running a folder like
+
+
+.. code-block:: bash
+
+    $ bats test/
+
+you can prevent test files from being picked up by changing their extension to something other than `.bats`.
+
+It is also possible to `skip` in `setup_file`/`setup` which will skip all tests in the file.
+
+How can I include my own `.sh` files for testing?
+-------------------------------------------------
+
+You can simply `source <your>.sh`files. However, be aware that `source`ing files with errors outside of any function (or inside `setup_file`) will trip up bats
+and lead to hard to diagnose errors.
+Therefore, it is safest to only `source` inside `setup` or the test functions themselves.
+
+How can I debug a failing test?
+-------------------------------
+
+Short of using a bash debugger you should make sure to use appropriate asserts for your task instead of raw bash comparisons, e.g.:
+
+.. code-block:: bash
+
+    @test test {
+        run echo test failed
+        assert_output "test"
+        # instead of 
+        [ "$output" = "test" ]
+    }
+
+Because the former will print the output when the test fails while the latter won't.
+Similarly, you should use `assert_success`/`assert_failure` instead of `[ "$status" -eq 0]` for return code checks.
+
+Is there a mechanism to add file/test specific functionality to a common setup function?
+----------------------------------------------------------------------------------------
+
+Often the setup consists of parts that are common between different files of a test suite and parts that are specific to each file.
+There is no suite wide setup functionality yet, so you should extract these common setup steps into their own file (e.g. `common-test-setup.sh`) and function (e.g. `commonSetup() {}`),
+which can be `source`d or `load`ed and call it in `setup_file` or `setup`.
+
+How can I use helper libraries like bats-assert?
+------------------------------------------------
+
+This is a short reproduction of https://github.com/ztombol/bats-docs.
+
+At first, you should make sure the library is installed. This is usually done in the `test_helper/` folders alongside the `.bats` files, giving you a filesystem layout like this:
+
+.. code-block::
+
+    test/
+        test.bats
+        test_helper/
+            bats-support/
+            bats-assert/
+
+Next, you should load those helper libraries:
+
+.. code-block:: bash
+
+    setup() {
+        load 'test_helper/bats-support/load' # this is required by bats-assert!
+        load 'test_helper/bats-assert/load'
+    }    
+
+Now, you should be able to use the functions from these helpers inside your tests, e.g.:
+
+.. code-block:: bash
+
+    @test "test" {
+        run echo test
+        assert_output "test"
+    }
+
+Note that you obviously need to load the library before using it.
+If you need the library inside `setup_file` or `teardown_file` you need to load it in `setup_file`.
+
+How to set a test timeout in bats?
+----------------------------------
+
+Unfortunately, this is not possible yet. Please contribute to issue `#396 <https://github.com/bats-core/bats-core/issues/396>`_ for further progress.
+
+How can I lint/shell-format my bats tests?
+------------------------------------------
+
+Due to their custom syntax (`@test`), `.bats` files are not standard bash. This prevents most tools from working with bats.
+However, shellcheck supports `.bats` files since version 0.7 and there is an alternative syntax `function_name { # @test` to declare tests in a bash compliant manner.
+There is currently no known formatter that supports formatting custom `.bats` syntax files directly.
+
+How can I check if a test failed/succeeded during teardown?
+-----------------------------------------------------------
+
+You can check `BATS_TEST_COMPLETED` which will be set to 1 if the test was successful or empty if it was not.
+There is also `BATS_TEST_SKIPPED` which will be non-empty (contains the skip message or -1) when `skip` was called.
+
+How can I setup/cleanup before/after all tests?
+-----------------------------------------------
+
+Currently, this is not supported. Please contribute your usecase to issue `#39 <https://github.com/bats-core/bats-core/issues/39>`_.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -24,7 +24,7 @@ The filename won't be part of the strings that are tested, so you cannot filter 
 How can I exclude a single test from a test run?
 ------------------------------------------------
 
-If you wan't to exclude only few tests from a run, you can either `skip` them:
+If you want to exclude only few tests from a run, you can either `skip` them:
 
 .. code-block:: bash
 
@@ -78,7 +78,7 @@ It is also possible to `skip` in `setup_file`/`setup` which will skip all tests 
 How can I include my own `.sh` files for testing?
 -------------------------------------------------
 
-You can simply `source <your>.sh`files. However, be aware that `source`ing files with errors outside of any function (or inside `setup_file`) will trip up bats
+You can simply `source <your>.sh` files. However, be aware that `source`ing files with errors outside of any function (or inside `setup_file`) will trip up bats
 and lead to hard to diagnose errors.
 Therefore, it is safest to only `source` inside `setup` or the test functions themselves.
 
@@ -97,7 +97,7 @@ Short of using a bash debugger you should make sure to use appropriate asserts f
     }
 
 Because the former will print the output when the test fails while the latter won't.
-Similarly, you should use `assert_success`/`assert_failure` instead of `[ "$status" -eq 0]` for return code checks.
+Similarly, you should use `assert_success`/`assert_failure` instead of `[ "$status" -eq 0 ]` for return code checks.
 
 Is there a mechanism to add file/test specific functionality to a common setup function?
 ----------------------------------------------------------------------------------------

--- a/docs/source/gotchas.rst
+++ b/docs/source/gotchas.rst
@@ -1,0 +1,103 @@
+Gotchas
+=======
+
+My test fails although I return true?
+-------------------------------------
+
+Using `return 1` to signify `true` for a success as is done often in other languages does not mesh well with Bash's 
+convention of using return code 0 to signify success and everything non-zero to indicate a failure.
+
+Please adhere to this idiom while using bats, or you will constantly work against your environment.
+
+I cannot register a test multiple times via for loop.
+-----------------------------------------------------
+
+The usual bats tests (`@test`) are preprocessed into functions.
+Wrapping them into a for loop only redeclares this function.
+
+If you are interested in registering multiple calls to the same function, contribute your wishes to issue `#306 <https://github.com/bats-core/bats-core/issues/306>`_.
+
+I cannot pass parameters to test or .bats files.
+------------------------------------------------
+
+Especially while using bats via shebang:
+
+.. code-block:: bash
+
+    #!/usr/bin/env bats
+
+    @test "test" {
+        # ...
+    }
+
+You could be tempted to pass parameters to the test invocation like `./test.bats param1 param2`.
+However, bats does not support passing parameters to files or tests.
+If you need such a feature, please let us know about your usecase.
+
+As a workaround you can use environment variables to pass parameters.
+
+Testing functions that return their results via a variable.
+-----------------------------------------------------------
+
+The `run` function executes its command in a subshell which means the changes to variables won't be available in the calling shell.
+
+If you want to test these functions, you should call them without `run`.
+
+`run` doesn't fail, although the same command without `run` does.
+-----------------------------------------------------------------
+
+`run` is a wrapper that always succeeds. The wrapped command's exit code is stored in `$status` and the stdout/stderr in `$output`.
+If you want to fail the test, you should explicitly check `$status` or omit `run`. See also `when not to use run <writing-tests.html#when-not-to-use-run>`_.
+
+`load` won't load my `.sh` files.
+---------------------------------
+
+`load` is intended as an internal helper function that always loads `.bash` files (by appending this suffix).
+If you want to load an `.sh` file, you can simple `source` it.
+
+I can't lint/shell-format my bats tests.
+----------------------------------------
+
+Bats uses a custom syntax for annotating tests (`@test`) that is not bash compliant.
+Therefore, standard bash tooling won't be able to interact directly with `.bats` files.
+Shellcheck supports bats' native syntax as of version 0.7.
+
+Additionally, there is bash compatible syntax for tests: 
+
+.. code-block:: bash 
+
+    function bash_compliant_function_name_as_test_name { # @test
+        # your code
+    }
+
+
+The output (stdout/err) from commands under `run` is not visible in failed tests.
+---------------------------------------------------------------------------------
+
+By default, `run` only stores stdout/stderr in `$output` (and `${lines[@]}`).
+If you want to see this output, you either should use bat-assert's assertions or have to print `$output` before the check that fails.
+
+My piped command does not work under run.
+-----------------------------------------
+
+Be careful with using pipes and with `run`. While your mind model of `run` might wrap the whole command behind it, bash's parser won't
+
+.. code-block:: bash
+
+    run echo foo | grep bar
+
+Won't `run (echo foo | grep bar)` but will `(run echo foo) | grep bar`. If you need to incorporate pipes, you either should do
+
+.. code-block:: bash
+
+    run bash -c 'echo foo | grep bar'
+
+or use a function to wrap the pipe in:
+
+.. code-block:: bash
+
+    fun_with_pipes() {
+        echo foo | grep bar
+    }
+
+    run fun_with_pipes

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,8 +7,11 @@ Versions before v1.2.1 are documented over `there <https://github.com/bats-core/
    :maxdepth: 2
    :caption: Contents:
 
+   tutorial
    installation
    usage
    docker-usage
    writing-tests
+   gotchas
+   faq
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -85,7 +85,7 @@ A new test run gives us
 
     1 test, 1 failure
 
-Oh, we still use the wrong path. No problem, we just need to use the correct path to `project.sh`.
+Oh, we still used the wrong path. No problem, we just need to use the correct path to `project.sh`.
 Since we're still in the same directory as when we started `bats`, we can simply do:
 
 .. code-block:: bash
@@ -125,7 +125,9 @@ Our new `test/test.bats` now looks like this:
     }
 
     @test "can run our script" {
-        project.sh # notice the missing ./
+        # notice the missing ./ 
+        # As we added src/ to $PATH, we can omit the relative path to `src/project.sh`.
+        project.sh
     }
 
 still giving us:
@@ -137,7 +139,7 @@ still giving us:
 
     1 test, 0 failures
 
-What happened? The newly added `setup` function put the absolute path to `src/` onto `$PATH`.
+It still works as expected. This is because the newly added `setup` function put the absolute path to `src/` onto `$PATH`.
 This setup function is automatically called before each test.
 Therefore, our test could execute `project.sh` directly, without using a (relative) path.
 
@@ -175,7 +177,7 @@ And gives is this test output:
 
     1 test, 1 failure
 
-Okay, our test failed again, because we now exit with 1 instead of 0.
+Okay, our test failed, because we now exit with 1 instead of 0.
 Additionally, we see the stdout and stderr of the failing program.
 
 Our goal now is to retarget our test and check that we get the welcome message.
@@ -224,11 +226,11 @@ which gives us the following test output:
     1 test, 1 failure
 
 The first change in this output is the failure description. We now fail on assert_output instead of the call itself.
-We prefixed our call to `project.sh` with `run`, which is an internal bats function that executes the command it gets passed as parameters.
+We prefixed our call to `project.sh` with `run`, which is a function provided by bats that executes the command it gets passed as parameters.
 Then, `run` sucks up the stdout and stderr of the command it ran and stores it in `$output`, stores the exit code in `$status` and returns 0.
 This means `run` never fails the test and won't generate any context/output in the log of a failed test on its own.
 
-Failing the test is and printing context information is up to the consumers of `$status` and `$output`. 
+Marking the test as failed and printing context information is up to the consumers of `$status` and `$output`. 
 `assert_output` is such a consumer, it compares `$output` to the the parameter it got and tells us quite succinctly that it did not match in this case.
 
 For our current test we don't care about any other output or the error message, so we want it gone.
@@ -268,7 +270,7 @@ Unfortunately, the latter is no valid bash syntax, so we have to work around it,
         assert_output 'Welcome to our project!'
     }
 
-Now our test passes again but having to write a function each time we want only a partial match does not accomodate our lazyness.
+Now our test passes again but having to write a function each time we want only a partial match does not accommodate our laziness.
 Isn't there an app for that? Maybe we should look at the documentation?
 
     Partial matching can be enabled with the --partial option (-p for short). When used, the assertion fails if the expected substring is not found in $output.
@@ -393,7 +395,7 @@ It is worth noting that we could do this `rm` in the test code itself but it wou
 
 .. important::
 
-    A test ends at its first failure. Non of the following commands in this test will be executed.
+    A test ends at its first failure. None of the subsequent commands in this test will be executed.
     The `teardown` function runs after each individual test in a file, regardless of test success or failure.
     Similarly to `setup`, each `.bats` file can have its own `teardown` function which will be the same for all tests in the file.
 
@@ -469,7 +471,7 @@ This allows for testing it separately in a new file `test/helper.bats`:
 .. code-block:: bash
 
     setup() {
-        load 'test_helper/common-setup`
+        load 'test_helper/common-setup'
         _common_setup
 
         source "$PROJECT_ROOT/src/helper.sh"

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1,0 +1,296 @@
+Tutorial
+========
+
+This tutorial is intended for beginners with bats and possibly bash.
+Make sure to also read the list of gotchas and the faq.
+
+For this tutorial we are assuming you already have a project in a git repository and want to add tests.
+Ultimately they should run in the CI environment but will also be started locally during development.
+
+..
+    
+    TODO: link to example repository?
+
+Quick installation
+------------------
+
+Since we already have an existing git repository, it is very easy to include bats and its libraries as submodules.
+We are aiming for following filesystem structure:
+
+.. code-block:: 
+
+    src/
+        project.sh
+        ...
+    test/
+        bats/               <- submodule
+        test_helper/
+            bats-support/   <- submodule
+            bats-assert/    <- submodule
+        test.bats
+        ...
+
+So we start from the project root:
+
+.. code-block:: console
+    
+    git submodule add https://github.com/bats-core/bats-core.git test/bats
+    git submodule add https://github.com/bats-core/bats-support.git test/test_helper/bats-support
+    git submodule add https://github.com/bats-core/bats-assert.git test/test_helper/bats-assert
+
+Your first test
+---------------
+
+Now we want to add our first test.
+
+In the tutorial repository, we want to build up our project in a TDD fashion.
+Thus, we start with an empty project and our first test is to just run our (non existing) shell script.
+
+We start by creating a new test file `test/test.bats`
+
+.. code-block:: bash
+
+    @test "can run our script" {
+        ./project.sh
+    }
+
+and run it by
+
+.. code-block:: console
+
+    $ ./test/bats/bin/bats test/test.bats
+     ✗ can run our script
+       (in test file test/test.bats, line 2)
+         `./project.sh' failed with status 127
+       /tmp/bats-run-19605/bats.19627.src: line 2: ./project.sh: No such file or directory
+
+    1 test, 1 failure
+
+Okay, our test is red. Obviously, the project.sh doesn't exist.
+Let us fix both problems. First, we create the file `src/project.sh`:
+
+.. code-block:: console
+
+    mkdir src/
+    echo '#!/usr/bin/env bash' > src/project.sh
+    chmod a+x src/project.sh
+
+A new test run gives us
+
+.. code-block:: console
+
+    $ ./test/bats/bin/bats test/test.bats
+     ✗ can run our script
+       (in test file test/test.bats, line 2)
+         `./project.sh' failed with status 127
+       /tmp/bats-run-19605/bats.19627.src: line 2: ./project.sh: No such file or directory
+
+    1 test, 1 failure
+
+Oh, we still use the wrong path. No problem, we just need to use the correct path to `project.sh`.
+Since we're still in the same directory as when we started `bats`, we can simply do:
+
+.. code-block:: bash
+
+    @test "can run our script" {
+        ./src/project.sh
+    }
+
+and get:
+
+.. code-block:: console
+
+    $ ./test/bats/bin/bats test/test.bats 
+     ✓ can run our script
+
+    1 test, 0 failures
+
+Yesss! But that victory feels shallow: What if somebody less competent than us starts bats from another directory?
+
+Let's do some setup
+-------------------
+
+The obvious solution to becoming independent of `$PWD` is using some fixed anchor point in the filesystem.
+We can use the path to the test file itself as an anchor and rely on the internal project structure.
+Since we are lazy people and want to treat our project's files as first class citizens in the executable world, we will also put them on the `$PATH`.
+Our new `test/test.bats` now looks like this:
+
+.. code-block:: bash
+
+    setup() {
+        # get the containing directory of this file
+        # use $BATS_TEST_FILENAME instead of ${BASH_SOURCE[0]} or $0,
+        # as those will point to the bats executable's location or the preprocessed file respectively
+        DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+        # make executables in src/ visible to PATH
+        PATH="$DIR/../src:$PATH"
+    }
+
+    @test "can run our script" {
+        project.sh # notice the missing ./
+    }
+
+still giving us:
+
+.. code-block:: console
+
+    $ ./test/bats/bin/bats test/test.bats 
+     ✓ can run our script
+
+    1 test, 0 failures
+
+What happened? The newly added `setup` function put the absolute path to `src/` onto `$PATH`.
+This setup function is automatically called before each test.
+Therefore, our test could execute `project.sh` directly, without using a (relative) path.
+
+Dealing with output
+-------------------
+
+Okay, we have a green test but our executable does not anything useful.
+To keep things simple, let us start with an error message. Our new `src/project.sh` now reads:
+
+.. code-block:: bash
+
+    #!/usr/bin/env bash
+
+    echo "Welcome to our project!"
+
+    echo "NOT IMPLEMENTED!" >&2
+    exit 1
+
+And gives is this test output:
+
+.. code-block:: console
+
+    $ ./test/bats/bin/bats test/test.bats 
+     ✗ can run our script
+       (in test file test/test.bats, line 11)
+         `project.sh' failed
+       Welcome to our project!
+       NOT IMPLEMENTED!
+
+    1 test, 1 failure
+
+Okay, our test failed again, because we now exit with 1 instead of 0.
+Additionally, we see the stdout and stderr of the failing program.
+
+Our goal now is to retarget our test and check that we get the welcome message.
+bats-assert gives us some help with this, so we should now load it (and its dependency bats-support),
+so we change `test/test.bats` to
+
+.. code-block:: bash
+
+    setup() {
+        load 'test_helper/bats-support/load'
+        load 'test_helper/bats-assert/load'
+        # ... the remaining setup is unchanged
+
+        # get the containing directory of this file
+        # use $BATS_TEST_FILENAME instead of ${BASH_SOURCE[0]} or $0,
+        # as those will point to the bats executable's location or the preprocessed file respectively
+        DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+        # make executables in src/ visible to PATH
+        PATH="$DIR/../src:$PATH"
+    }
+
+    @test "can run our script" {
+        run project.sh # notice `run`!
+        assert_output 'Welcome to our project!'
+    }
+
+which gives us the following test output:
+
+.. code-block:: console
+
+    $ LANG=C ./test/bats/bin/bats test/test.bats 
+     ✗ can run our script
+       (from function `assert_output' in file test/test_helper/bats-assert/src/assert_output.bash, line 194,
+        in test file test/test.bats, line 14)
+         `assert_output 'Welcome to our project!'' failed
+    
+       -- output differs --
+       expected (1 lines):
+         Welcome to our project!
+       actual (2 lines):
+         Welcome to our project!
+         NOT IMPLEMENTED!
+       --
+    
+
+    1 test, 1 failure
+
+The first change in this output is the failure description. We now fail on assert_output instead of the call itself.
+We prefixed our call to `project.sh` with `run`, which is an internal bats function that executes the command it gets passed as parameters.
+Then, `run` sucks up the stdout and stderr of the command it ran and stores it in `$output`, stores the exit code in `$status` and returns 0.
+This means `run` never fails the test and won't generate any context/output in the log of a failed test on its own.
+
+Failing the test is and printing context information is up to the consumers of `$status` and `$output`. 
+`assert_output` is such a consumer, it compares `$output` to the the parameter it got and tells us quite succinctly that it did not match in this case.
+
+For our current test we don't care about any other output or the error message, so we want it gone.
+`grep` is always at our fingertips, so we tape together this ramshackle construct
+
+.. code-block:: bash
+
+    run project.sh 2>&1 | grep Welcome
+
+which gives us the following test result:
+
+.. code-block:: console
+
+    $ LANG=C ./test/bats/bin/bats test/test.bats 
+     ✗ can run our script
+       (in test file test/test.bats, line 13)
+         `run project.sh | grep Welcome' failed
+
+    1 test, 1 failure
+
+Huh, what is going on? Why does it fail the `run` line again?
+
+This is a common mistake that can happen when our mind parses the file differently than the bash parser.
+`run` is just a function, so the pipe won't actually be forwarded into the function. Bash reads this as `(run project.sh) | grep Welcome`, 
+instead of our intended `run (project.sh | grep Welcome)`.
+
+Unfortunately, the latter is no valid bash syntax, so we have to work around it, e.g. by using a function:
+
+.. code-block:: bash
+
+    get_projectsh_welcome_message() {
+        project.sh  2>&1 | grep Welcome
+    }
+
+    @test "Check welcome message" {
+        run get_projectsh_welcome_message
+        assert_output 'Welcome to our project!'
+    }
+
+Now our test passes again but having to write a function each time we want only a partial match does not accomodate our lazyness.
+Isn't there an app for that? Maybe we should look at the documentation?
+
+    Partial matching can be enabled with the --partial option (-p for short). When used, the assertion fails if the expected substring is not found in $output.
+
+    -- the documentation for `assert_output <https://github.com/bats-core/bats-assert#partial-matching>`_
+
+Okay, so maybe we should try that:
+
+.. code-block:: bash
+
+    @test "Check welcome message" {
+        run project.sh
+        assert_output --partial 'Welcome to our project!'
+    }
+
+Aaannnd ... the test stays green. Yay!
+
+There are many other asserts and options but this is not the place for all of them.
+Skimming the documentation of `bats-assert <https://github.com/bats-core/bats-assert>`_ will give you a good idea what you can do.
+You should also have a look at the other helper libraries `here <https://github.com/bats-core>`_ like `bats-file <https://github.com/bats-core/bats-file>`_, 
+to avoid reinventing the wheel.
+
+..
+
+    TODO
+    - teardown
+    - setup_file/teardown_file
+    - sourcing your own .sh files
+    - testing functions that return via variables


### PR DESCRIPTION
Closes #358

The resulting output can be previewed [here](https://bats-core--397.org.readthedocs.build/en/397/tutorial.html#).
The companion repository for the example project can be found here: https://github.com/martin-schulze-vireso/bats-tutorial

- [x] fix all remaining todos in the text

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
