### PR TITLE
Publish to npm/GHPR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release
+
+on: [push]
+
+jobs:
+  github-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          registry-url: "https://npm.pkg.github.com"
+      - run: npm publish --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
-on: [push]
+on:
+  release: { types: [published] }
+  workflow_dispatch:
 
 jobs:
   npmjs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           registry-url: "https://npm.pkg.github.com"
+      - name: scope package name as required by GHPR
+        run: npm init -y --scope ${{ github.repository_owner }}
       - run: npm publish --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,17 @@ name: Release
 on: [push]
 
 jobs:
+  npmjs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          registry-url: "https://registry.npmjs.org"
+      - run: npm publish --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   github-npm:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
-docker-compose.override.yml
-docs/build
+/docker-compose.override.yml
+/docs/build
+
+# npm
+/bats-*.tgz
+# we don't have any deps; un-ignore if that changes
+/package-lock.json


### PR DESCRIPTION
Adds workflow to publish as an npm package to the npmjs registry and github package registry.
The workflow has been tested and works (pre-release alphas have been published to both registries).
This also incorporates a host of administrative changes regarding orgs and permissions on npm.

Remaining todo: determine what the release workflow will actually be and change the trigger on this workflow accordingly. My assumption is that we'll want the creation of a Release on github to be manual (while we still manually create release notes, etc). That is to say, we probably _don't_ want the release process to be wholly automated off of, say, a git tag event. (yet)

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
