### PR TITLE
[docker] use tini as entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG bashver=latest
 FROM bash:${bashver}
 ARG TINI_VERSION=v0.19.0
 
-RUN wget https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static -O /tini && \
+RUN wget https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-amd64 -O /tini && \
     chmod +x /tini
 
 # Install parallel and accept the citation notice (we aren't using this in a

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 ARG bashver=latest
 
 FROM bash:${bashver}
+ARG TINI_VERSION=v0.19.0
+
+RUN wget https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static -O /tini && \
+    chmod +x /tini
 
 # Install parallel and accept the citation notice (we aren't using this in a
 # context where it make sense to cite GNU Parallel).
@@ -12,4 +16,4 @@ COPY . /opt/bats/
 
 WORKDIR /code/
 
-ENTRYPOINT ["bash", "bats"]
+ENTRYPOINT ["/tini", "--", "bash", "bats"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 ### Changed
 
 * added checks and improved documentation for `$BATS_TMPDIR` (#410)
-* the docker container now uses [tini](https://github.com/krallin/tini) to
+* the docker container now uses [tini](https://github.com/krallin/tini) as the container entrypoint to
   improve signal forwarding (#407)
 
 ### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 ### Changed
 
 * added checks and improved documentation for `$BATS_TMPDIR` (#410)
+* the docker container now uses [tini](https://github.com/krallin/tini) to
+  improve signal forwarding (#407)
 
 ### Fixed
 


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

Use [tini](https://github.com/krallin/tini) as entrypoint to handle signals correctly and by abble to press `Ctrl+C` to cancel tests.

More [infos](https://cloud.google.com/solutions/best-practices-for-building-containers#solution_3_use_a_specialized_init_system)

Regards,