### PR TITLE
Use mktemp

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * fix `bats_tap_stream_unknown: command not found` with pretty formatter, when
   writing non compliant extended output (#412)
+* avoid collisions on `$BATS_RUN_TMPDIR` with `--no-tempdir-cleanup` and docker
+  by using `mktemp` additionally to PID (#409)
 
 ## [1.3.0] - 2021-03-08
 

--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -305,6 +305,9 @@ There are several global variables you can use to introspect on Bats tests:
 - `$BATS_TEST_NUMBER` is the (1-based) index of the current test case in the test file.
 - `$BATS_SUITE_TEST_NUMBER` is the (1-based) index of the current test case in the test suite (over all files).
 - `$BATS_TMPDIR` is the location to a directory that may be used to store temporary files.
+- `$BATS_RUN_TMPDIR` is the location to the temporary directory used by bats to
+   store all its internal temporary files during the tests.
+   (default: `$BATS_TMPDIR/bats-run-$BATS_ROOT_PID-XXXXXX`)
 - `$BATS_FILE_EXTENSION` (default: `bats`) specifies the extension of test files that should be found when running a suite (via `bats [-r] suite_folder/`)
 
 ### Libraries and Add-ons

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -81,7 +81,7 @@ if [[ -z "${TMPDIR-}" ]]; then
 else
   export BATS_TMPDIR="${TMPDIR%/}"
 fi
-export BATS_RUN_TMPDIR="$BATS_TMPDIR/bats-run-$BATS_ROOT_PID"
+export BATS_RUN_TMPDIR=
 
 arguments=()
 
@@ -200,12 +200,19 @@ while [[ "$#" -ne 0 ]]; do
   shift
 done
 
-if [[ -d "$BATS_RUN_TMPDIR" ]]; then
-  printf "Error: BATS_RUN_TMPDIR (%s) already exists\n" "$BATS_RUN_TMPDIR" >&2
-  printf "Reusing old run directories can lead to unexpected results ... aborting!\n" >&2
-  exit 1
+if [[ -n "${BATS_RUN_TMPDIR:-}" ]];then
+  if [[ -d "$BATS_RUN_TMPDIR" ]]; then
+    printf "Error: BATS_RUN_TMPDIR (%s) already exists\n" "$BATS_RUN_TMPDIR" >&2
+    printf "Reusing old run directories can lead to unexpected results ... aborting!\n" >&2
+    exit 1
+  fi
+  if ! mkdir -p "$BATS_RUN_TMPDIR" ;then
+    printf "Error: Failed to create BATS_RUN_TMPDIR (%s)\n" "$BATS_RUN_TMPDIR" >&2
+    exit 1
+  fi
+else
+  BATS_RUN_TMPDIR=$(mktemp -d "${BATS_TMPDIR}/bats-run-$BATS_ROOT_PID-XXXXXX")
 fi
-mkdir -p "$BATS_RUN_TMPDIR"
 if [[ -n "$BATS_TEMPDIR_CLEANUP" ]]; then
   trap 'rm -rf "$BATS_RUN_TMPDIR"' ERR EXIT
 fi

--- a/man/bats.7
+++ b/man/bats.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BATS" "7" "November 2020" "bats-core" "Bash Automated Testing System"
+.TH "BATS" "7" "February 2021" "bats-core" "Bash Automated Testing System"
 .
 .SH "NAME"
 \fBbats\fR \- Bats test file format
@@ -174,6 +174,9 @@ There are several global variables you can use to introspect on Bats tests:
 .
 .IP "\(bu" 4
 \fB$BATS_TMPDIR\fR is the location to a directory that may be used to store temporary files\.
+.
+.IP "\(bu" 4
+\fB$BATS_RUN_TMPDIR\fR is the location to the temporary directory used by bats to store all its internal temporary files during the tests\. (default: \fB$BATS_TMPDIR/bats\-run\-$BATS_ROOT_PID\-XXXXXX\fR)
 .
 .IP "\(bu" 4
 \fB$BATS_FILE_EXTENSION\fR (default: \fBbats\fR) specifies the extension of test files that should be found when running a suite (via \fBbats [\-r] suite_folder/\fR)

--- a/man/bats.7.ronn
+++ b/man/bats.7.ronn
@@ -150,6 +150,9 @@ in the test file.
   case in the test suite (over all files).
 * `$BATS_TMPDIR` is the location to a directory that may be used to
 store temporary files.
+* `$BATS_RUN_TMPDIR` is the location to the temporary directory used by
+  bats to store all its internal temporary files during the tests.
+  (default: `$BATS_TMPDIR/bats-run-$BATS_ROOT_PID-XXXXXX`)
 * `$BATS_FILE_EXTENSION` (default: `bats`) specifies the extension of 
 test files that should be found when running a suite (via 
 `bats [-r] suite_folder/`)

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -761,3 +761,20 @@ EOF
 
   [[ -n "$tested_at_least_one_formatter" ]]
 }
+
+@test "run should exit if tmpdir exist" {
+  local dir
+  dir=$(mktemp -d "${BATS_RUN_TMPDIR}/BATS_RUN_TMPDIR_TEST.XXXXXX")
+  run bats --tempdir "${dir}" "$FIXTURE_ROOT/passing.bats"
+  [ "$status" -eq 1 ]
+  [ "${lines[0]}" == "Error: BATS_RUN_TMPDIR (${dir}) already exists" ]
+  [ "${lines[1]}" == "Reusing old run directories can lead to unexpected results ... aborting!" ]
+}
+
+@test "run should exit if tmpdir can't be created" {
+  local dir
+  dir=$(mktemp "${BATS_RUN_TMPDIR}/BATS_RUN_TMPDIR_TEST.XXXXXX")
+  run bats --tempdir "${dir}" "$FIXTURE_ROOT/passing.bats"
+  [ "$status" -eq 1 ]
+  [ "${lines[1]}" == "Error: Failed to create BATS_RUN_TMPDIR (${dir})" ]
+}

--- a/test/fixtures/parallel/must_not_parallelize_within_file.bats
+++ b/test/fixtures/parallel/must_not_parallelize_within_file.bats
@@ -1,5 +1,5 @@
 setup_file() {
-    export FILE_MARKER=$(mktemp)
+    export FILE_MARKER=$(mktemp "${BATS_RUN_TMPDIR}/file_marker.XXXXXX")
     if [[ -n "${DISABLE_IN_SETUP_FILE_FUNCTION}" ]]; then
         export BATS_NO_PARALLELIZE_WITHIN_FILE=true
         echo "setup_file() sets BATS_NO_PARALLELIZE_WITHIN_FILE=true" >&2

--- a/test/parallel.bats
+++ b/test/parallel.bats
@@ -136,12 +136,12 @@ check_parallel_tests() { # <expected maximum parallelity>
   # ensure that we really run parallelization across files!
   # (setup should have skipped already, if there was no GNU parallel)
   unset BATS_NO_PARALLELIZE_ACROSS_FILES
-  export FILE_MARKER=$(mktemp)
+  export FILE_MARKER=$(mktemp "${BATS_RUN_TMPDIR}/file_marker.XXXXXX")
   ! bats --jobs 2 "$FIXTURE_ROOT/must_not_parallelize_across_files/"
 }
 
 @test "--no-parallelize-across-files prevents parallelization across files" {
-  export FILE_MARKER=$(mktemp)
+  export FILE_MARKER=$(mktemp "${BATS_RUN_TMPDIR}/file_marker.XXXXXX")
   bats --jobs 2 --no-parallelize-across-files "$FIXTURE_ROOT/must_not_parallelize_across_files/"
 }
 
@@ -161,7 +161,7 @@ check_parallel_tests() { # <expected maximum parallelity>
   # ensure that we really run parallelization across files!
   # (setup should have skipped already, if there was no GNU parallel)
   unset BATS_NO_PARALLELIZE_ACROSS_FILES
-  export FILE_MARKER=$(mktemp)
+  export FILE_MARKER=$(mktemp "${BATS_RUN_TMPDIR}/file_marker.XXXXXX")
   ! bats --jobs 2 --no-parallelize-within-files "$FIXTURE_ROOT/must_not_parallelize_across_files/"
 }
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -3,9 +3,8 @@ emulate_bats_env() {
   export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
   export BATS_TEST_FILTER=
   export BATS_ROOT_PID=$$
-  export BATS_EMULATED_RUN_TMPDIR="$BATS_TMPDIR/bats-run-$BATS_ROOT_PID"
+  export BATS_EMULATED_RUN_TMPDIR=$(mktemp -d "${BATS_TMPDIR}/bats-run-test-tmpdir-${BATS_ROOT_PID}-XXXXXX")
   export BATS_RUN_TMPDIR="$BATS_EMULATED_RUN_TMPDIR"
-  mkdir -p "$BATS_RUN_TMPDIR"
 }
 
 fixtures() {


### PR DESCRIPTION
- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

Using mktemp is safer than using $PID and avoid race condition, especially when running inside docker because the PID is rarely != 1.
That PR allows to running multiples times the same tests safely with `--no-tempdir-cleanup` and avoid race condition too.
Without this PR we hit on the second run and is quite annoying :

```
Error: BATS_RUN_TMPDIR (/tmp/bats-run-1) already exists
Reusing old run directories can lead to unexpected results ... aborting!
```

As an example for debugging :
```bash
$ cat test.sh
mkdir -p "$PWD/tmp"
for BASHVER in 3.2 4.1 4.4;do
	docker build --build-arg bashver="${BASHVER}" --tag "bats/bats:bash-${BASHVER}" . || exit $?
	docker run -it "bash:${BASHVER}" --version || exit $?
	time docker run \
          -u "$(id -u):0" \
          -it \
          -v "/etc/passwd:/etc/passwd:ro" \
          -v "${PWD}/tmp:/tmp" \
          "bats/bats:bash-${BASHVER}" \
          --tap /opt/bats/test \
          --no-tempdir-cleanup \
          ${@:+--filter "${@}"} \
          || exit $?
done
$ ./test.sh '.*tmpdir.*'
```
Result after some run of bats core self tests :
```
$ ls -1 tmp/
bats-run-1-Jamgap
bats-run-1-KGLIOm
bats-run-1-kJLIJD
bats-run-1-NdbhKe
bats-run-1-npAgfd
bats-run-1-oklMGC
bats-run-test-tmpdir-9354-DPMCIb
bats-run-test-tmpdir-9354-kgppIg
bats-run-test-tmpdir-9354-ooIgGd
bats-run-test-tmpdir-9355-EkNegL
bats-run-test-tmpdir-9410-fbLkJa
bats-run-test-tmpdir-9410-gBFNEK
bats-run-test-tmpdir-9410-PBifMi
bats-run-test-tmpdir-9411-kclEOi
bats-run-test-tmpdir-9481-dPLPNB
bats-run-test-tmpdir-9481-elDdeH
bats-run-test-tmpdir-9481-nLAEbE
bats-run-test-tmpdir-9482-DEFDdi
bats-run-test-tmpdir-9540-cbCCdl
bats-run-test-tmpdir-9542-ngkhMF
bats-run-test-tmpdir-9597-mFaEac
bats-run-test-tmpdir-9599-lEaffJ
bats-run-test-tmpdir-9669-cpmdHK
bats-run-test-tmpdir-9671-CaipNk
```
