### PR TITLE
BATS_TMPDIR set order

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+* added checks and improved documentation for `$BATS_TMPDIR` (#410)
+
 ### Fixed
 
 * fix `bats_tap_stream_unknown: command not found` with pretty formatter, when

--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -304,7 +304,9 @@ There are several global variables you can use to introspect on Bats tests:
 - `$BATS_TEST_DESCRIPTION` is the description of the current test case.
 - `$BATS_TEST_NUMBER` is the (1-based) index of the current test case in the test file.
 - `$BATS_SUITE_TEST_NUMBER` is the (1-based) index of the current test case in the test suite (over all files).
-- `$BATS_TMPDIR` is the location to a directory that may be used to store temporary files.
+- `$BATS_TMPDIR` is the base temporary directory used by bats to create its
+   temporary files / directories.
+   (default: `$TMPDIR`. If `$TMPDIR` is not set, `/tmp` is used.)
 - `$BATS_RUN_TMPDIR` is the location to the temporary directory used by bats to
    store all its internal temporary files during the tests.
    (default: `$BATS_TMPDIR/bats-run-$BATS_ROOT_PID-XXXXXX`)

--- a/lib/bats-core/preprocessing.bash
+++ b/lib/bats-core/preprocessing.bash
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-if [[ -z "${TMPDIR:-}" ]]; then
-	export BATS_TMPDIR='/tmp'
-else
-	export BATS_TMPDIR="${TMPDIR%/}"
-fi
-
 BATS_TMPNAME="$BATS_RUN_TMPDIR/bats.$$"
 BATS_PARENT_TMPNAME="$BATS_RUN_TMPDIR/bats.$PPID"
 # shellcheck disable=SC2034

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -76,12 +76,16 @@ export BATS_TEST_PATTERN_COMMENT="[[:blank:]]*([^[:blank:]()]+)[[:blank:]]*\(?\)
 export BATS_TEST_FILTER=
 export PATH="$BATS_LIBEXEC:$PATH"
 export BATS_ROOT_PID=$$
-if [[ -z "${TMPDIR-}" ]]; then
-  export BATS_TMPDIR="/tmp"
-else
-  export BATS_TMPDIR="${TMPDIR%/}"
-fi
+export BATS_TMPDIR="${TMPDIR:-/tmp}"
 export BATS_RUN_TMPDIR=
+
+if [[ ! -d "${BATS_TMPDIR}" ]];then
+  printf "Error: BATS_TMPDIR (%s) do not exist or is not a directory" "${BATS_TMPDIR}" >&2
+  exit 1
+elif [[ ! -w "${BATS_TMPDIR}" ]];then
+  printf "Error: BATS_TMPDIR (%s) is not writable" "${BATS_TMPDIR}" >&2
+  exit 1
+fi
 
 arguments=()
 

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -80,7 +80,7 @@ export BATS_TMPDIR="${TMPDIR:-/tmp}"
 export BATS_RUN_TMPDIR=
 
 if [[ ! -d "${BATS_TMPDIR}" ]];then
-  printf "Error: BATS_TMPDIR (%s) do not exist or is not a directory" "${BATS_TMPDIR}" >&2
+  printf "Error: BATS_TMPDIR (%s) does not exist or is not a directory" "${BATS_TMPDIR}" >&2
   exit 1
 elif [[ ! -w "${BATS_TMPDIR}" ]];then
   printf "Error: BATS_TMPDIR (%s) is not writable" "${BATS_TMPDIR}" >&2

--- a/man/bats.7
+++ b/man/bats.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BATS" "7" "February 2021" "bats-core" "Bash Automated Testing System"
+.TH "BATS" "7" "March 2021" "bats-core" "Bash Automated Testing System"
 .
 .SH "NAME"
 \fBbats\fR \- Bats test file format
@@ -173,7 +173,7 @@ There are several global variables you can use to introspect on Bats tests:
 \fB$BATS_SUITE_TEST_NUMBER\fR is the (1\-based) index of the current test case in the test suite (over all files)\.
 .
 .IP "\(bu" 4
-\fB$BATS_TMPDIR\fR is the location to a directory that may be used to store temporary files\.
+\fB$BATS_TMPDIR\fR is the base temporary directory used by bats to create its temporary files / directories\. (default: \fB$TMPDIR\fR\. If \fB$TMPDIR\fR is not set, \fB/tmp\fR is used\.)
 .
 .IP "\(bu" 4
 \fB$BATS_RUN_TMPDIR\fR is the location to the temporary directory used by bats to store all its internal temporary files during the tests\. (default: \fB$BATS_TMPDIR/bats\-run\-$BATS_ROOT_PID\-XXXXXX\fR)

--- a/man/bats.7.ronn
+++ b/man/bats.7.ronn
@@ -148,8 +148,9 @@ case.
 in the test file.
 * `$BATS_SUITE_TEST_NUMBER` is the (1-based) index of the current test 
   case in the test suite (over all files).
-* `$BATS_TMPDIR` is the location to a directory that may be used to
-store temporary files.
+* `$BATS_TMPDIR` is the base temporary directory used by bats to create its
+  temporary files / directories.
+  (default: `$TMPDIR`. If `$TMPDIR` is not set, `/tmp` is used.)
 * `$BATS_RUN_TMPDIR` is the location to the temporary directory used by
   bats to store all its internal temporary files during the tests.
   (default: `$BATS_TMPDIR/bats-run-$BATS_ROOT_PID-XXXXXX`)

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -778,3 +778,19 @@ EOF
   [ "$status" -eq 1 ]
   [ "${lines[1]}" == "Error: Failed to create BATS_RUN_TMPDIR (${dir})" ]
 }
+
+@test "Fail if BATS_TMPDIR do not exist or is not writable" {
+  local BATS_TMPDIR
+  BATS_TMPDIR=$(mktemp -u "${BATS_RUN_TMPDIR}/donotexist.XXXXXX")
+  run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
+  [ "$status" -eq 1 ]
+  [ "${lines[0]}" = "Error: BATS_TMPDIR (${BATS_TMPDIR}) do not exist or is not a directory" ]
+}
+
+@test "Setting TMPDIR is ignored" {
+  expected="/tmp" run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
+  [ "$status" -eq 0 ]
+  BATS_TMPDIR="${BATS_RUN_TMPDIR}"
+  expected="/tmp" run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
+  [ "$status" -eq 0 ]
+}

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -779,12 +779,12 @@ EOF
   [ "${lines[1]}" == "Error: Failed to create BATS_RUN_TMPDIR (${dir})" ]
 }
 
-@test "Fail if BATS_TMPDIR do not exist or is not writable" {
+@test "Fail if BATS_TMPDIR does not exist or is not writable" {
   local BATS_TMPDIR
   BATS_TMPDIR=$(mktemp -u "${BATS_RUN_TMPDIR}/donotexist.XXXXXX")
   run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
   [ "$status" -eq 1 ]
-  [ "${lines[0]}" = "Error: BATS_TMPDIR (${BATS_TMPDIR}) do not exist or is not a directory" ]
+  [ "${lines[0]}" = "Error: BATS_TMPDIR (${BATS_TMPDIR}) does not exist or is not a directory" ]
 }
 
 @test "Setting TMPDIR is ignored" {

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -771,7 +771,7 @@ EOF
   [ "${lines[1]}" == "Reusing old run directories can lead to unexpected results ... aborting!" ]
 }
 
-@test "run should exit if tmpdir can't be created" {
+@test "run should exit if TMPDIR can't be created" {
   local dir
   dir=$(mktemp "${BATS_RUN_TMPDIR}/BATS_RUN_TMPDIR_TEST.XXXXXX")
   run bats --tempdir "${dir}" "$FIXTURE_ROOT/passing.bats"
@@ -780,17 +780,18 @@ EOF
 }
 
 @test "Fail if BATS_TMPDIR does not exist or is not writable" {
-  local BATS_TMPDIR
-  BATS_TMPDIR=$(mktemp -u "${BATS_RUN_TMPDIR}/donotexist.XXXXXX")
+  export TMPDIR=$(mktemp -u "${BATS_RUN_TMPDIR}/donotexist.XXXXXX")
   run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
+  echo "$output"
   [ "$status" -eq 1 ]
-  [ "${lines[0]}" = "Error: BATS_TMPDIR (${BATS_TMPDIR}) does not exist or is not a directory" ]
+  [ "${lines[0]}" = "Error: BATS_TMPDIR (${TMPDIR}) does not exist or is not a directory" ]
 }
 
-@test "Setting TMPDIR is ignored" {
+@test "Setting BATS_TMPDIR is ignored" {
+  unset TMPDIR # ensure we don't have a predefined value
   expected="/tmp" run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
+  echo "$output"
   [ "$status" -eq 0 ]
-  BATS_TMPDIR="${BATS_RUN_TMPDIR}"
-  expected="/tmp" run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
+  BATS_TMPDIR="${BATS_RUN_TMPDIR}" expected="/tmp" run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
   [ "$status" -eq 0 ]
 }

--- a/test/fixtures/bats/BATS_TMPDIR.bats
+++ b/test/fixtures/bats/BATS_TMPDIR.bats
@@ -1,0 +1,8 @@
+@test "BATS_TMPDIR is set" {
+  [ "${BATS_TMPDIR}" == "${expected:-}" ]
+}
+
+@test "BATS_RUN_TMPDIR has BATS_TMPDIR as a prefix" {
+  local regex="^${BATS_TMPDIR}/.+"
+  [[ ${BATS_RUN_TMPDIR} =~ ${regex} ]]
+}


### PR DESCRIPTION
- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

- Follow the ideas from #365 regarding the `$BATS_TMPDIR` init.
  - Use `BATS_TMPDIR` if set
  - Use `$TMPDIR` if `$BATS_TMPDIR` is not set
  - Use /tmp if `$TMPDIR` and `$BATS_TMPDIR` are not set

- Changed the doc according to the init process
- Add tests for those changes