### PR TITLE
Fix/missing function pretty formatter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+* fix `bats_tap_stream_unknown: command not found` with pretty formatter, when
+  writing non compliant extended output (#412)
+
 ## [1.3.0] - 2021-03-08
 
 ### Added

--- a/docs/source/docker-usage.md
+++ b/docs/source/docker-usage.md
@@ -18,21 +18,21 @@ Receiving objects: 100% (1222/1222), 327.28 KiB | 1.70 MiB/s, done.
 Resolving deltas: 100% (661/661), done.
 
 $ cd bats-core/
-$ docker build --tag bats:latest .
+$ docker build --tag bats/bats:latest .
 ...
-$ docker run -it bats:latest --formatter tap /opt/bats/test
+$ docker run -it bats/bats:latest --formatter tap /opt/bats/test
 ```
 
 To mount your tests into the container, first build the image as above. Then, for example with `bats`:
 ```bash
-$ docker run -it -v "$PWD:/opt/bats" bats:latest /opt/bats/test
+$ docker run -it -v "$PWD:/opt/bats" bats/bats:latest /opt/bats/test
 ```
 This runs the `test/` directory from the bats-core repository inside the bats Docker container.
 
 For test suites that are intended to run in isolation from the project (i.e. the tests do not depend on project files outside of the test directory), you can mount the test directory by itself and execute the tests like so:
 
 ```bash
-$ docker run -it -v "$PWD/test:/test" bats:latest /test
+$ docker run -it -v "$PWD/test:/test" bats/bats:latest /test
 ```
 
 ## Docker Gotchas
@@ -46,7 +46,7 @@ Relying on functionality provided by your environment (ssh keys or agent, instal
 Docker operates on a principle of isolation, and bundles all dependencies required into the Docker image. These can be mounted in at runtime (for test files, configuration, etc). For binary dependencies it may be better to extend the base Docker image with further tools and files.
 
 ```dockerfile
-FROM bats
+FROM bats/bats
 
 RUN \ 
   apk \

--- a/libexec/bats-core/bats-format-pretty
+++ b/libexec/bats-core/bats-format-pretty
@@ -195,7 +195,7 @@ bats_tap_stream_begin() {
   begin
   flush
 }
-  
+
 bats_tap_stream_ok() {
   index="$1"
   ((++passed))
@@ -228,6 +228,10 @@ bats_tap_stream_comment() {
 
 bats_tap_stream_suite() {
   : #test_file="$1"
+}
+
+bats_tap_stream_unknown() { # <full line>
+    printf "%s\n" "$1"
 }
 
 bats_parse_internal_extended_tap


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].

- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

Hello, my firsts words are go thank you all for your effort maintaining and improving this tool. It works so good.
After some days creating tests, I have found an issue related to pretty formated.

I have realised that I got an error when trying to format an unknown tap (it was an unknown tap that was generated becausethe function I was trying to test was not working properly) using pretty formatter. I have added my fix to the files that are on my laptop and the issue was fixed so I here you are a PR with the required changes. Here you are the error I got.
`/usr/local/lib/bats-core/formatter.bash: line 91: bats_tap_stream_unknown: command not found`

I have just copied the same definition that is placed on tap formatter so hopefully it is fine.

I think my changes follow all the requirements. Anyway, please, let me know if I can improve anything on my PR before merging it.

Thanks,
Jeronimo.