### PR TITLE
pretty mode: Print FD3 output below test name

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
   writing non compliant extended output (#412)
 * avoid collisions on `$BATS_RUN_TMPDIR` with `--no-tempdir-cleanup` and docker
   by using `mktemp` additionally to PID (#409)
+* pretty printer now puts text that is printed to FD 3 below the test name (#426)
 
 ## [1.3.0] - 2021-03-08
 

--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -259,20 +259,17 @@ bats provides a special file descriptor, `&3`, that you should use to print
 your custom text. Here are some detailed guidelines to refer to:
 
 - Printing **from within a test function**:
-  - To have text printed from within a test function you need to redirect the
-    output to file descriptor 3, eg `echo 'text' >&3`. This output will become
-    part of the TAP stream. You are encouraged to prepend text printed this way
-    with a hash (eg `echo '# text' >&3`) in order to produce 100% TAP compliant
+  - First you should consider if you want the text to be always visible or only
+    when the test fails. Text that is output directly to stdout or stderr (file
+    descriptor 1 or 2), ie `echo 'text'` is considered part of the test function
+    output and is printed only on test failures for diagnostic purposes,
+    regardless of the formatter used (TAP or pretty).
+  - To have text printed unconditionally from within a test function you need to
+    redirect the output to file descriptor 3, eg `echo 'text' >&3`. This output
+    will become part of the TAP stream. You are encouraged to prepend text printed
+    this way with a hash (eg `echo '# text' >&3`) in order to produce 100% TAP compliant
     output. Otherwise, depending on the 3rd-party tools you use to analyze the
     TAP stream, you can encounter unexpected behavior or errors.
-
-  - The pretty formatter that Bats uses by default to process the TAP stream
-    will filter out and not print text output to file descriptor 3.
-
-  - Text that is output directly to stdout or stderr (file descriptor 1 or 2),
-    ie `echo 'text'` is considered part of the test function output and is
-    printed only on test failures for diagnostic purposes, regardless of the
-    formatter used (TAP or pretty).
 
 - Printing **from within the `setup` or `teardown` functions**: The same hold
   true as for printing with test functions.

--- a/libexec/bats-core/bats-format-pretty
+++ b/libexec/bats-core/bats-format-pretty
@@ -34,6 +34,7 @@ trap update_screen_width WINCH
 update_screen_width
 
 begin() {
+  line_backoff_count=0
   go_to_column 0
   update_count_column_width
   buffer_with_truncation $((count_column_left - 1)) '   %s' "$name"
@@ -48,6 +49,7 @@ begin() {
 }
 
 pass() {
+  move_up $line_backoff_count
   go_to_column 0
   buffer ' ✓ %s' "$name"
   if [[ -n "$BATS_ENABLE_TIMING" ]]; then
@@ -55,6 +57,7 @@ pass() {
     buffer ' [%s]' "$1"
   fi
   advance
+  move_down $line_backoff_count
 }
 
 skip() {
@@ -62,12 +65,15 @@ skip() {
   if [[ -n "$reason" ]]; then
     reason=": $reason"
   fi
+  move_up $line_backoff_count
   go_to_column 0
   buffer ' - %s (skipped%s)' "$name" "$reason"
   advance
+  move_down $line_backoff_count
 }
 
 fail() {
+  move_up $line_backoff_count
   go_to_column 0
   set_color 1 bold
   buffer ' ✗ %s' "$name"
@@ -76,6 +82,7 @@ fail() {
     buffer ' [%s]' "$1"
   fi
   advance
+  move_down $line_backoff_count
 }
 
 log() {
@@ -123,6 +130,18 @@ buffer_with_truncation() {
     buffer '%s...' "${string:0:$((width - 4))}"
   else
     buffer '%s' "$string"
+  fi
+}
+
+move_up() {
+  if [[ $1 -gt 0 ]]; then # avoid moving if we got 0
+    buffer '\x1B[%dA' "$1"
+  fi
+}
+
+move_down() {
+  if [[ $1 -gt 0 ]]; then # avoid moving if we got 0
+    buffer '\x1B[%dB' "$1"
   fi
 }
 
@@ -223,6 +242,15 @@ bats_tap_stream_not_ok() {
 }
 
 bats_tap_stream_comment() {
+  # count the lines we printed after the begin text,
+  if (( line_backoff_count == 0 )); then
+    # if this is the first line after begin, go down one line
+    buffer "\n"
+    (( ++line_backoff_count )) # prefix-increment to avoid "error" due to returning 0
+  fi
+
+  (( ++line_backoff_count ))
+  (( line_backoff_count += ${#1} / screen_width)) # account for linebreaks due to length
   log "$1"
 }
 
@@ -230,8 +258,19 @@ bats_tap_stream_suite() {
   : #test_file="$1"
 }
 
+line_backoff_count=0
 bats_tap_stream_unknown() { # <full line>
-    printf "%s\n" "$1"
+    # count the lines we printed after the begin text,
+    if (( line_backoff_count == 0 )); then
+      # if this is the first line after begin, go down one line
+      buffer "\n"
+      (( ++line_backoff_count )) # prefix-increment to avoid "error" due to returning 0
+    fi
+
+    (( ++line_backoff_count ))
+    (( line_backoff_count += ${#1} / screen_width)) # account for linebreaks due to length
+    buffer "%s\n" "$1"
+    flush
 }
 
 bats_parse_internal_extended_tap


### PR DESCRIPTION
This should fix #425, #420.

While working on this I found the buffering to be somewhat overused. It is part of the initial commit for the pretty formatter but there is no rationale given, why it is needed. The advantages of buffering that I observed so far by not using:

1. control sequence group are printed atomically, this means:
  * CTRL+C will not leave the shell in a colorized state
  * reduced flicker of the progress counter
2. CTRL+C does not give broken pipe errors every once in a while

A disadvantage of the current solution is the implicit race between buffered and unbuffered output, which forces every output to become buffered or the buffer to be flushed quite often.

I think we should solve the two issues independently:

1. atomic prints of control sequences: only buffer short groups of output commands, maybe we can live with the flicker?
2. dealing explicitly with SIGINT to avoid the broken pipe issue

I hope that reducing the buffer lifetime will also increase the interactivity of pretty output.