### PR TITLE
Fix errors in free code not being reported

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * the docker container now uses [tini](https://github.com/krallin/tini) as the
   container entrypoint to improve signal forwarding (#407)
 * script to uninstall bats from a given prefix (#400)
+* replace preprocessed file path (e.g. `/tmp/bats-run-22908-NP0f9h/bats.23102.src`)
+  with original filename in stdout/err (but not FD3!) (#429)
 
 #### Documentation
 
@@ -36,6 +38,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
   a block (#442)
 * fixed some typos in comments (#447)
 * ensure `/code` exists in docker container, to make examples work again  (#440)
+* also display error messages from free code (#429)
 
 ## [1.3.0] - 2021-03-08
 

--- a/lib/bats-core/formatter.bash
+++ b/lib/bats-core/formatter.bash
@@ -109,3 +109,20 @@ remove_prefix() {
     printf "%s" "$path"
   fi
 }
+
+normalize_base_path() { # <target variable> <base path>
+    # the relative path root to use for reporting filenames
+    # this is mainly intended for suite mode, where this will be the suite root folder
+    local base_path="$2"
+    # use the containing directory when --base-path is a file
+    if [[ ! -d "$base_path" ]]; then
+        base_path="$(dirname "$base_path")"
+    fi
+    # get the absolute path
+    base_path="$(cd "$base_path"; pwd)"
+    # ensure the path ends with / to strip that later on
+    if [[ "${base_path}" != *"/" ]]; then
+        base_path="$base_path/"
+    fi
+    printf -v "$1" "%s" "$base_path"
+}

--- a/lib/bats-core/formatter.bash
+++ b/lib/bats-core/formatter.bash
@@ -119,7 +119,7 @@ normalize_base_path() { # <target variable> <base path>
         base_path="$(dirname "$base_path")"
     fi
     # get the absolute path
-    base_path="$(cd "$base_path"; pwd)"
+    base_path="$(cd "$base_path" && pwd)"
     # ensure the path ends with / to strip that later on
     if [[ "${base_path}" != *"/" ]]; then
         base_path="$base_path/"

--- a/lib/bats-core/tracing.bash
+++ b/lib/bats-core/tracing.bash
@@ -20,6 +20,9 @@ bats_capture_stack_trace() {
 				;;
 			esac
 		fi
+		if [[ "${BASH_SOURCE[$i + 1]}" == *"bats-exec-file" ]] && [[ "$funcname" == 'source' ]]; then
+			break
+		fi
 	done
 }
 
@@ -43,7 +46,10 @@ bats_print_stack_trace() {
 
 		local fn
 		bats_frame_function "$frame" 'fn'
-		if [[ "$fn" != "$BATS_TEST_NAME" ]]; then
+		if [[ "$fn" != "$BATS_TEST_NAME" ]] && 
+			# don't print "from function `source'"",
+			# when failing in free code during `source $test_file` from bats-exec-file
+			! [[ "$fn" == 'source' &&  $index -eq $count ]]; then 
 			printf "from function \`%s' " "$fn"
 		fi
 

--- a/lib/bats-core/tracing.bash
+++ b/lib/bats-core/tracing.bash
@@ -64,6 +64,9 @@ bats_print_stack_trace() {
 }
 
 bats_print_failed_command() {
+	if [[ ${#BATS_STACK_TRACE[@]} -eq 0 ]]; then
+		return 
+	fi
 	local frame="${BATS_STACK_TRACE[${#BATS_STACK_TRACE[@]} - 1]}"
 	local filename
 	local lineno

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -239,6 +239,10 @@ if [[ "$report_formatter" == "junit" ]]; then
   report_formatter_flags+=('--base-path' "${arguments[0]}")
 fi
 
+if [[ "$formatter" == "pretty" ]]; then
+  formatter_flags+=('--base-path' "${arguments[0]}")
+fi
+
 # if we don't need to filter extended syntax, use the faster formatter
 if [[ "$formatter" == tap && -z "$report_formatter" ]]; then
   formatter="cat"

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -79,6 +79,7 @@ bats_run_setup_file() {
   # shellcheck disable=2034
   BATS_TEST_COMPLETED= # used in tracing.bash
 
+  BATS_SOURCE_FILE_COMPLETED=
   BATS_SETUP_FILE_COMPLETED=
   BATS_TEARDOWN_FILE_COMPLETED=
   # shellcheck disable=2034
@@ -87,15 +88,15 @@ bats_run_setup_file() {
 
   touch "$BATS_OUT"
 
-  trap 'exit 1' ERR
+  trap 'bats_error_trap' ERR
+  trap 'bats_file_teardown_trap' EXIT
 
   local status=0
   # get the setup_file/teardown_file functions for this file (if it has them)
   # shellcheck disable=SC1090
   source "$BATS_TEST_SOURCE"  >  >(bats_replace_filename) 2>&1
 
-  trap 'bats_error_trap' ERR
-  trap 'bats_file_teardown_trap' EXIT
+  BATS_SOURCE_FILE_COMPLETED=1
 
   setup_file > >(bats_replace_filename >>"$BATS_OUT") 2>&1
 
@@ -135,8 +136,12 @@ bats_file_exit_trap() {
   if [[ -z "$BATS_SETUP_FILE_COMPLETED" || -z "$BATS_TEARDOWN_FILE_COMPLETED" ]]; then
     if [[ -z "$BATS_SETUP_FILE_COMPLETED" ]]; then
       FAILURE_REASON='setup_file'
-    else
+    elif [[ -z "$BATS_TEARDOWN_FILE_COMPLETED" ]]; then
       FAILURE_REASON='teardown_file'
+    elif [[ -z "$BATS_SOURCE_FILE_COMPLETED" ]]; then
+      FAILURE_REASON='source'
+    else
+      FAILURE_REASON='unknown internal'
     fi
     printf "not ok %d %s\n" "$((test_number_in_suite + 1))" "$FAILURE_REASON failed" >&3
     bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -210,10 +210,9 @@ bats_run_tests_in_parallel() {
   return $status
 }
 
-bats_run_tests() {
-  status=0
-  tests_to_run=()
+bats_read_tests_list_file() {
   local line_number=0
+  tests_to_run=()
   # the global test number must be visible to traps -> not local
   first_test_number_in_suite=''
   while read -r test_line; do
@@ -235,6 +234,11 @@ bats_run_tests() {
 
   test_number_in_suite="$first_test_number_in_suite"
   test_number_in_file=0
+}
+
+bats_run_tests() {
+  status=0
+
   if [[ "$num_jobs" != 1 && "${BATS_NO_PARALLELIZE_WITHIN_FILE-False}" == False ]]; then
     export BATS_SEMAPHORE_NUMBER_OF_SLOTS="$num_jobs"
     bats_run_tests_in_parallel "$BATS_RUN_TMPDIR/parallel_output" || status=1
@@ -261,6 +265,7 @@ if [[ -n "$extended_syntax" ]]; then
 fi
 
 bats_preprocess_source "$filename"
+bats_read_tests_list_file
 bats_run_setup_file
 bats_run_tests
 bats_run_teardown_file

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -84,16 +84,32 @@ bats_run_setup_file() {
   # shellcheck disable=2034
   BATS_ERROR_STATUS= # used in tracing.bash
   trap 'bats_debug_trap "$BASH_SOURCE"' DEBUG
+
+  touch "$BATS_OUT"
+
+  trap 'exit 1' ERR
+
+  local status=0
+  # get the setup_file/teardown_file functions for this file (if it has them)
+  # shellcheck disable=SC1090
+  source "$BATS_TEST_SOURCE"  >  >(bats_replace_filename) 2>&1
+
   trap 'bats_error_trap' ERR
   trap 'bats_file_teardown_trap' EXIT
 
-  touch "$BATS_OUT"
-  # get the setup_file/teardown_file functions for this file (if it has them)
-  # shellcheck disable=SC1090
-  source "$BATS_TEST_SOURCE"
-  setup_file >>"$BATS_OUT" 2>&1
+  setup_file > >(bats_replace_filename >>"$BATS_OUT") 2>&1
 
   BATS_SETUP_FILE_COMPLETED=1
+}
+
+function bats_replace_filename() {
+  local line
+  while read -r line; do
+    printf "%s\n" "${line//$BATS_TEST_SOURCE/$filename}"
+  done
+  if [[ -n "$line" ]]; then
+    printf "%s\n" "${line//$BATS_TEST_SOURCE/$filename}"
+  fi
 }
 
 bats_run_teardown_file() {

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -134,15 +134,10 @@ IFS=$'\n' read -d '' -r -a  BATS_UNIQUE_TEST_FILENAMES < <(printf "%s\n" "$@"| n
 
 if [[ "$num_jobs" -gt 1 ]] && [[ -z "$bats_no_parallelize_across_files" ]]; then
   # run files in parallel to get the maximum pool of parallel tasks
-  if [[ ${#flags[@]} -eq 0 ]]; then
-    # if there are no flags, our quoting below would keep an empty arg, which is wrong
-    parallel "${bats_parallel_args[@]}" --keep-order --jobs "$num_jobs" bats-exec-file "{}" "$TESTS_LIST_FILE"  ::: "${BATS_UNIQUE_TEST_FILENAMES[@]}" 2>&1 || status=1
-  else
-    # shellcheck disable=SC2086,SC2068
-    # we need to handle the quoting of ${flags[@]} ourselves,
-    # because parallel can only quote it as one
-    parallel --keep-order --jobs "$num_jobs" bats-exec-file "$(printf "%q " "${flags[@]}")" "{}" "$TESTS_LIST_FILE"  ::: "${BATS_UNIQUE_TEST_FILENAMES[@]}" 2>&1 || status=1
-  fi
+  # shellcheck disable=SC2086,SC2068
+  # we need to handle the quoting of ${flags[@]} ourselves,
+  # because parallel can only quote it as one
+  parallel --keep-order --jobs "$num_jobs" bats-exec-file "$(printf "%q " "${flags[@]}")" "{}" "$TESTS_LIST_FILE"  ::: "${BATS_UNIQUE_TEST_FILENAMES[@]}" 2>&1 || status=1
 else
   for filename in "${BATS_UNIQUE_TEST_FILENAMES[@]}"; do
     bats-exec-file "${flags[@]}" "$filename" "${TESTS_LIST_FILE}" || status=1

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -5,7 +5,6 @@ count_only_flag=''
 filter=''
 num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS-1}
 have_gnu_parallel=
-bats_parallel_args=()
 bats_no_parallelize_across_files=${BATS_NO_PARALLELIZE_ACROSS_FILES-}
 bats_no_parallelize_within_files=
 flags=('--dummy-flag') # add a dummy flag to prevent unset varialeb errors on empty array expansion in old bash versions

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -1,25 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=lib/bats-core/formatter.bash
+source "$BATS_ROOT/lib/bats-core/formatter.bash"
+
 BASE_PATH=.
+
 
 while [[ "$#" -ne 0 ]]; do
   case "$1" in
     --base-path)
       shift
-      # the relative path root to use for reporting filenames
-      # this is mainly intended for suite mode, where this will be the suite root folder
-      BASE_PATH="$1"
-      # use the containing directory when --base-path is a file
-      if [[ ! -d "$BASE_PATH" ]]; then
-        BASE_PATH="$(dirname "$BASE_PATH")"
-      fi
-      # get the absolute path
-      BASE_PATH="$(cd "$BASE_PATH"; pwd)"
-      # ensure the path ends with / to strip that later on
-      if [[ "${BASE_PATH}" != *"/" ]]; then
-        BASE_PATH="$BASE_PATH/"
-      fi
+      normalize_base_path BASE_PATH "$1"
     ;;
   esac
   shift
@@ -179,9 +171,6 @@ finish_suite() {
   finish_file # must come after suite flush to not print the last file before the others
   suite_footer
 }
-
-# shellcheck source=lib/bats-core/formatter.bash
-source "$BATS_ROOT/lib/bats-core/formatter.bash"
 
 bats_tap_stream_plan() { #  <number of tests>
   :

--- a/libexec/bats-core/bats-format-pretty
+++ b/libexec/bats-core/bats-format-pretty
@@ -256,7 +256,8 @@ bats_tap_stream_comment() { # <comment> <scope>
 }
 
 bats_tap_stream_suite() {
-  : #test_file="$1"
+  #test_file="$1"
+  line_backoff_count=0
 }
 
 line_backoff_count=0

--- a/libexec/bats-core/bats-format-pretty
+++ b/libexec/bats-core/bats-format-pretty
@@ -272,8 +272,8 @@ bats_tap_stream_suite() {
 line_backoff_count=0
 bats_tap_stream_unknown() { # <full line> <scope>
     local scope=$2
-    # count the lines we printed after the begin text,
-    if [[ $line_backoff_count -eq 0 && $scope == begin ]]; then
+    # count the lines we printed after the begin text, (or after suite, in case of syntax errors)
+    if [[ $line_backoff_count -eq 0 && ( $scope == begin ||  $scope == suite )]]; then
       # if this is the first line after begin, go down one line
       buffer "\n"
       (( ++line_backoff_count )) # prefix-increment to avoid "error" due to returning 0

--- a/libexec/bats-core/bats-format-pretty
+++ b/libexec/bats-core/bats-format-pretty
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 set -e
 
+# shellcheck source=lib/bats-core/formatter.bash
+source "$BATS_ROOT/lib/bats-core/formatter.bash"
+
+BASE_PATH=.
+
 while [[ "$#" -ne 0 ]]; do
   case "$1" in
   -T)
     BATS_ENABLE_TIMING="-T"
+    ;;
+  --base-path)
+    shift
+    normalize_base_path BASE_PATH "$1"
     ;;
   esac
   shift
@@ -195,9 +204,6 @@ finish() {
 
 trap finish EXIT
 
-# shellcheck source=lib/bats-core/formatter.bash
-source "$BATS_ROOT/lib/bats-core/formatter.bash"
-
 bats_tap_stream_plan() {
   count="$1"
   index=0
@@ -258,6 +264,9 @@ bats_tap_stream_comment() { # <comment> <scope>
 bats_tap_stream_suite() {
   #test_file="$1"
   line_backoff_count=0
+  index=
+  # indicate filename for failures
+  name="File $(remove_prefix "$BASE_PATH" "$1")"
 }
 
 line_backoff_count=0

--- a/libexec/bats-core/bats-format-pretty
+++ b/libexec/bats-core/bats-format-pretty
@@ -241,9 +241,10 @@ bats_tap_stream_not_ok() {
   fi
 }
 
-bats_tap_stream_comment() {
+bats_tap_stream_comment() { # <comment> <scope>
+  local scope=$2
   # count the lines we printed after the begin text,
-  if (( line_backoff_count == 0 )); then
+  if [[ $line_backoff_count -eq 0 && $scope == begin ]]; then
     # if this is the first line after begin, go down one line
     buffer "\n"
     (( ++line_backoff_count )) # prefix-increment to avoid "error" due to returning 0
@@ -259,9 +260,10 @@ bats_tap_stream_suite() {
 }
 
 line_backoff_count=0
-bats_tap_stream_unknown() { # <full line>
+bats_tap_stream_unknown() { # <full line> <scope>
+    local scope=$2
     # count the lines we printed after the begin text,
-    if (( line_backoff_count == 0 )); then
+    if [[ $line_backoff_count -eq 0 && $scope == begin ]]; then
       # if this is the first line after begin, go down one line
       buffer "\n"
       (( ++line_backoff_count )) # prefix-increment to avoid "error" due to returning 0

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -796,3 +796,14 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" != *"No such file or directory"* ]] || exit 1 # ensure failures are detected with old bash
 }
+
+@test "Failure in free code (see #399)" {
+  run bats --tap "$FIXTURE_ROOT/failure_in_free_code.bats"
+  echo "$output"
+  [ "$status" -ne 0 ]
+  [ "${lines[0]}" == 1..1 ]
+  [ "${lines[1]}" == 'not ok 1 setup_file failed' ]
+  [ "${lines[2]}" == "# (from function \`helper' in file $RELATIVE_FIXTURE_ROOT/failure_in_free_code.bats, line 4," ]
+  [ "${lines[3]}" == "#  in test file $RELATIVE_FIXTURE_ROOT/failure_in_free_code.bats, line 7)" ]
+  [ "${lines[4]}" == "#   \`helper' failed" ]
+}

--- a/test/fixtures/bats/failure_in_free_code.bats
+++ b/test/fixtures/bats/failure_in_free_code.bats
@@ -1,0 +1,11 @@
+
+
+helper() {
+  false
+}
+
+helper
+
+@test "everything is ok" {
+  true
+}


### PR DESCRIPTION
Fixes #399, also fixes #423. As a bonus, this PR introduces changes to replace the preprocessed temporary filepath with the original test file's path in stdout and stderr (but not FD3!).

TODOs:
- [x] add a label where the test name would be, when a failure during setup_file or source aborted testing
![Screenshot from 2021-04-16 17-09-13](https://user-images.githubusercontent.com/37703201/115045290-a7c7a100-9ed6-11eb-8432-73e13c4c6890.png)
- [x] add changelog entry


- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
