### PR TITLE
docs/writing-tests: Fix heading levels

### DIFF
--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -103,7 +103,7 @@ is equivalent to
 var=$(command args ...)
 ```
 
-#### Comment syntax
+## Comment syntax
 
 External tools (like `shellcheck`, `shfmt`, and various IDE's) may not support
 the standard `.bats` syntax.  Because of this, we provide a valid `bash`
@@ -120,7 +120,7 @@ function invoking_foo_without_arguments_prints_usage { #@test
 When using this syntax, the function name will be the title in the result output
 and the value checked when using `--filter`.
 
-### `load`: Share common code
+## `load`: Share common code
 
 You may want to share common code across multiple test files. Bats includes a
 convenient `load` command for sourcing a Bash source file relative to the
@@ -146,7 +146,7 @@ will _not_ be made available to callers of `load`.
 > it looks for `test_helper`). This behaviour is deprecated and subject to
 > change, please use exact filenames instead.
 
-### `skip`: Easily skip tests
+## `skip`: Easily skip tests
 
 Tests can be skipped by using the `skip` command at the point in a test you wish
 to skip.
@@ -184,7 +184,7 @@ Or you can skip conditionally:
 
 __Note:__ `setup` and `teardown` hooks still run for skipped tests.
 
-### `setup` and `teardown`: Pre- and post-test hooks
+## `setup` and `teardown`: Pre- and post-test hooks
 
 You can define special `setup` and `teardown` functions, which run before and
 after each test case, respectively. Use these to load fixtures, set up your
@@ -216,7 +216,7 @@ teardown_file # from file 2,  on leaving file 2
 </details>
 <!-- markdownlint-enable MD033 -->
 
-### Code outside of test cases
+## Code outside of test cases
 
 You can include code in your test file outside of `@test` functions.  For
 example, this may be useful if you want to check for dependencies and fail
@@ -225,7 +225,7 @@ outside of `@test`, `setup` or `teardown` functions must be redirected to
 `stderr` (`>&2`). Otherwise, the output may cause Bats to fail by polluting the
 TAP stream on `stdout`.
 
-### File descriptor 3 (read this if Bats hangs)
+## File descriptor 3 (read this if Bats hangs)
 
 Bats makes a separation between output from the code under test and output that
 forms the TAP stream (which is produced by Bats internals). This is done in
@@ -246,7 +246,7 @@ amount of time.
 **To prevent this from happening, close FD 3 explicitly when running any command
 that may launch long-running child processes**, e.g. `command_name 3>&-` .
 
-### Printing to the terminal
+## Printing to the terminal
 
 Bats produces output compliant with [version 12 of the TAP protocol][TAP]. The
 produced TAP stream is by default piped to a pretty formatter for human
@@ -290,7 +290,7 @@ your custom text. Here are some detailed guidelines to refer to:
 
 [tap-plan]: https://testanything.org/tap-specification.html#the-plan
 
-### Special variables
+## Special variables
 
 There are several global variables you can use to introspect on Bats tests:
 
@@ -309,7 +309,7 @@ There are several global variables you can use to introspect on Bats tests:
    (default: `$BATS_TMPDIR/bats-run-$BATS_ROOT_PID-XXXXXX`)
 - `$BATS_FILE_EXTENSION` (default: `bats`) specifies the extension of test files that should be found when running a suite (via `bats [-r] suite_folder/`)
 
-### Libraries and Add-ons
+## Libraries and Add-ons
 
 Bats supports loading external assertion libraries and helpers. Those under `bats-core` are officially supported libraries (integration tests welcome!):
 


### PR DESCRIPTION
All the headings after _When not to use `run`_ are one level too deep,
move them one level up.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
