### PR TITLE
Add a $command variable, and colorize summary

### DIFF
--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -31,11 +31,12 @@ nonexistent filename, exits with a `1` status code and prints an error message.
 }
 ```
 
-The `$status` variable contains the status code of the command, and the
+The `$status` variable contains the status code of the command, the
 `$output` variable contains the combined contents of the command's standard
-output and standard error streams.
+output and standard error streams, and the `${command[*]}` array contains the
+command and command arguments passed to `run` for execution.
 
-A third special variable, the `$lines` array, is available for easily accessing
+Another special variable, the `$lines` array, is available for easily accessing
 individual lines of output. For example, if you want to test that invoking `foo`
 without any arguments prints usage information on the first line:
 
@@ -107,7 +108,7 @@ var=$(command args ...)
 
 External tools (like `shellcheck`, `shfmt`, and various IDE's) may not support
 the standard `.bats` syntax.  Because of this, we provide a valid `bash`
-alterntative:
+alternative:
 
 ```bash
 function invoking_foo_without_arguments_prints_usage { #@test

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -33,11 +33,14 @@ run() {
   local origFlags="$-"
   set +eET
   local origIFS="$IFS"
-  # 'output', 'status', 'lines' are global variables available to tests.
+  # 'output', 'status', 'command' and 'lines'
+  # are global variables available to tests.
   # shellcheck disable=SC2034
   output="$("$@" 2>&1)"
   # shellcheck disable=SC2034
   status="$?"
+  # shellcheck disable=SC2034
+  command=("$@")
   # shellcheck disable=SC2034,SC2206
   IFS=$'\n' lines=($output)
   IFS="$origIFS"

--- a/libexec/bats-core/bats-format-pretty
+++ b/libexec/bats-core/bats-format-pretty
@@ -92,6 +92,12 @@ log() {
 }
 
 summary() {
+  if  [ "$failures" -eq 0 ] ; then
+    set_color 2 bold
+  else
+    set_color 1 bold
+  fi
+
   buffer '\n%d test' "$count"
   if [[ "$count" -ne 1 ]]; then
     buffer 's'
@@ -116,6 +122,7 @@ summary() {
   fi
 
   buffer '\n'
+  clear_color
 }
 
 buffer_with_truncation() {

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -796,3 +796,23 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" != *"No such file or directory"* ]] || exit 1 # ensure failures are detected with old bash
 }
+
+@test "test content of 'command' variable" {
+  run bats -v
+  [[ "${command[*]}" == "bats -v" ]] && [[ "$output" == Bats* ]]
+}
+
+@test "test color in summary" {
+  # pick up some test (no matter which), and run in with color in summary
+  run bats --pretty --filter 'no arguments' "$BATS_TEST_FILENAME"
+  # Save results for analysis on failure
+  echo output content:
+  echo "$output" | od -c
+
+  # Now check for opening and closing escape sequences
+  # shellcheck disable=SC2086
+  echo $output | grep -q $'0 failures.\033\[0m'
+  # shellcheck disable=SC2086
+  echo $output | grep -q $'\033\[32;1m.1 test'
+}
+


### PR DESCRIPTION
Fixes #163 

Motivation:
* See https://github.com/bats-core/bats-core/issues/163 for $command motivation. I second it and also it's helpful when the command passed to `run` contains multiple shell vars, so $command shows the final.
* Our test pass is fairly long and it's super convenient to have colorized summary (pass/fail) at the end of manual runs

We use bats with these fixes for a long time now, time for a PR.


- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
