### PR TITLE
Fix typo in `libexec/bats-core/bats`

### DIFF
--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -109,8 +109,8 @@ set -- "${arguments[@]}"
 arguments=()
 
 unset flags recursive formatter_flags
-flags=('--dummy-flag') # add a dummy flag to prevent unset varialeb errors on empty array expansion in old bash versions
-formatter_flags=('--dummy-flag') # add a dummy flag to prevent unset varialeb errors on empty array expansion in old bash versions
+flags=('--dummy-flag') # add a dummy flag to prevent unset variable errors on empty array expansion in old bash versions
+formatter_flags=('--dummy-flag') # add a dummy flag to prevent unset variable errors on empty array expansion in old bash versions
 formatter='tap'
 report_formatter=''
 recursive=


### PR DESCRIPTION
Fixes a typo in `libexec/bats-core/bats`

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
