### PR TITLE
install.sh: consider multilib

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ set -e
 
 BATS_ROOT="${0%/*}"
 PREFIX="$1"
+LIBDIR="${2:-lib}"
 
 if [[ -z "$PREFIX" ]]; then
   printf '%s\n' \
@@ -12,10 +13,10 @@ if [[ -z "$PREFIX" ]]; then
   exit 1
 fi
 
-install -d -m 755 "$PREFIX"/{bin,libexec/bats-core,lib/bats-core,share/man/man{1,7}}
+install -d -m 755 "$PREFIX"/{bin,libexec/bats-core,${LIBDIR}/bats-core,share/man/man{1,7}}
 install -m 755 "$BATS_ROOT/bin"/* "$PREFIX/bin"
 install -m 755 "$BATS_ROOT/libexec/bats-core"/* "$PREFIX/libexec/bats-core"
-install -m 755 "$BATS_ROOT/lib/bats-core"/* "$PREFIX/lib/bats-core"
+install -m 755 "$BATS_ROOT/lib/bats-core"/* "$PREFIX/${LIBDIR}/bats-core"
 install -m 644 "$BATS_ROOT/man/bats.1" "$PREFIX/share/man/man1"
 install -m 644 "$BATS_ROOT/man/bats.7" "$PREFIX/share/man/man7"
 

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ if [[ -z "$PREFIX" ]]; then
   exit 1
 fi
 
-install -d -m 755 "$PREFIX"/{bin,libexec/bats-core,${LIBDIR}/bats-core,share/man/man{1,7}}
+install -d -m 755 "$PREFIX"/{bin,libexec/bats-core,"${LIBDIR}"/bats-core,share/man/man{1,7}}
 install -m 755 "$BATS_ROOT/bin"/* "$PREFIX/bin"
 install -m 755 "$BATS_ROOT/libexec/bats-core"/* "$PREFIX/libexec/bats-core"
 install -m 755 "$BATS_ROOT/lib/bats-core"/* "$PREFIX/${LIBDIR}/bats-core"

--- a/test/install.bats
+++ b/test/install.bats
@@ -57,7 +57,7 @@ setup() {
 }
 
 @test "install.sh creates a multilib valid installation, and uninstall.sh undos it" {
-  rm -rf $INSTALL_DIR
+  rm -rf "$INSTALL_DIR"
   LIBDIR="lib64"
   run "$PATH_TO_INSTALL_SHELL" "$INSTALL_DIR" "$LIBDIR"
   [ "$status" -eq 0 ]
@@ -147,5 +147,5 @@ setup() {
 }
 
 teardown() {
-  rm -rf $INSTALL_DIR
+  rm -rf "$INSTALL_DIR"
 }

--- a/test/install.bats
+++ b/test/install.bats
@@ -17,6 +17,52 @@ setup() {
   [ "$status" -eq 0 ]
   [ "$output" == "Installed Bats to $INSTALL_DIR/bin/bats" ]
   [ -x "$INSTALL_DIR/bin/bats" ]
+  [ -x "$INSTALL_DIR/lib/bats-core/formatter.bash" ]
+  [ -x "$INSTALL_DIR/lib/bats-core/preprocessing.bash" ]
+  [ -x "$INSTALL_DIR/lib/bats-core/semaphore.bash" ]
+  [ -x "$INSTALL_DIR/lib/bats-core/test_functions.bash" ]
+  [ -x "$INSTALL_DIR/lib/bats-core/tracing.bash" ]
+  [ -x "$INSTALL_DIR/lib/bats-core/validator.bash" ]
+  [ -x "$INSTALL_DIR/libexec/bats-core/bats" ]
+  [ -x "$INSTALL_DIR/libexec/bats-core/bats-exec-suite" ]
+  [ -x "$INSTALL_DIR/libexec/bats-core/bats-exec-test" ]
+  [ -x "$INSTALL_DIR/libexec/bats-core/bats-format-junit" ]
+  [ -x "$INSTALL_DIR/libexec/bats-core/bats-format-pretty" ]
+  [ -x "$INSTALL_DIR/libexec/bats-core/bats-preprocess" ]
+  [ -f "$INSTALL_DIR/share/man/man1/bats.1" ]
+  [ -f "$INSTALL_DIR/share/man/man7/bats.7" ]
+
+  run "$INSTALL_DIR/bin/bats" -v
+  [ "$status" -eq 0 ]
+  [ "${output%% *}" == 'Bats' ]
+
+  run "$PATH_TO_UNINSTALL_SHELL" "$INSTALL_DIR"
+  [ "$status" -eq 0 ]
+  [ ! -x "$INSTALL_DIR/bin/bats" ]
+  [ ! -x "$INSTALL_DIR/libexec/bats-core/bats" ]
+  [ ! -x "$INSTALL_DIR/libexec/bats-core/bats-exec-suite" ]
+  [ ! -x "$INSTALL_DIR/libexec/bats-core/bats-exec-test" ]
+  [ ! -x "$INSTALL_DIR/libexec/bats-core/bats-format-junit" ]
+  [ ! -x "$INSTALL_DIR/libexec/bats-core/bats-format-pretty" ]
+  [ ! -x "$INSTALL_DIR/libexec/bats-core/bats-preprocess" ]
+  [ ! -x "$INSTALL_DIR/libexec/bats-core" ]
+  [ ! -x "$INSTALL_DIR/share/man/man1/bats.1" ]
+  [ ! -x "$INSTALL_DIR/share/man/man7/bats.7" ]
+}
+
+@test "install.sh creates a multilib valid installation, and uninstall.sh undos it" {
+  rm -rf $INSTALL_DIR
+  LIBDIR="lib64"
+  run "$PATH_TO_INSTALL_SHELL" "$INSTALL_DIR" "$LIBDIR"
+  [ "$status" -eq 0 ]
+  [ "$output" == "Installed Bats to $INSTALL_DIR/bin/bats" ]
+  [ -x "$INSTALL_DIR/bin/bats" ]
+  [ -x "$INSTALL_DIR/$LIBDIR/bats-core/formatter.bash" ]
+  [ -x "$INSTALL_DIR/$LIBDIR/bats-core/preprocessing.bash" ]
+  [ -x "$INSTALL_DIR/$LIBDIR/bats-core/semaphore.bash" ]
+  [ -x "$INSTALL_DIR/$LIBDIR/bats-core/test_functions.bash" ]
+  [ -x "$INSTALL_DIR/$LIBDIR/bats-core/tracing.bash" ]
+  [ -x "$INSTALL_DIR/$LIBDIR/bats-core/validator.bash" ]
   [ -x "$INSTALL_DIR/libexec/bats-core/bats" ]
   [ -x "$INSTALL_DIR/libexec/bats-core/bats-exec-suite" ]
   [ -x "$INSTALL_DIR/libexec/bats-core/bats-exec-test" ]
@@ -86,4 +132,8 @@ setup() {
   run "$bats_symlink" -v
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
+}
+
+teardown() {
+  rm -rf $INSTALL_DIR
 }

--- a/test/install.bats
+++ b/test/install.bats
@@ -39,6 +39,12 @@ setup() {
   run "$PATH_TO_UNINSTALL_SHELL" "$INSTALL_DIR"
   [ "$status" -eq 0 ]
   [ ! -x "$INSTALL_DIR/bin/bats" ]
+  [ ! -x "$INSTALL_DIR/lib/bats-core/formatter.bash" ]
+  [ ! -x "$INSTALL_DIR/lib/bats-core/preprocessing.bash" ]
+  [ ! -x "$INSTALL_DIR/lib/bats-core/semaphore.bash" ]
+  [ ! -x "$INSTALL_DIR/lib/bats-core/test_functions.bash" ]
+  [ ! -x "$INSTALL_DIR/lib/bats-core/tracing.bash" ]
+  [ ! -x "$INSTALL_DIR/lib/bats-core/validator.bash" ]
   [ ! -x "$INSTALL_DIR/libexec/bats-core/bats" ]
   [ ! -x "$INSTALL_DIR/libexec/bats-core/bats-exec-suite" ]
   [ ! -x "$INSTALL_DIR/libexec/bats-core/bats-exec-test" ]
@@ -76,9 +82,15 @@ setup() {
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
 
-  run "$PATH_TO_UNINSTALL_SHELL" "$INSTALL_DIR"
+  run "$PATH_TO_UNINSTALL_SHELL" "$INSTALL_DIR" "$LIBDIR"
   [ "$status" -eq 0 ]
   [ ! -x "$INSTALL_DIR/bin/bats" ]
+  [ ! -x "$INSTALL_DIR/$LIBDIR/bats-core/formatter.bash" ]
+  [ ! -x "$INSTALL_DIR/$LIBDIR/bats-core/preprocessing.bash" ]
+  [ ! -x "$INSTALL_DIR/$LIBDIR/bats-core/semaphore.bash" ]
+  [ ! -x "$INSTALL_DIR/$LIBDIR/bats-core/test_functions.bash" ]
+  [ ! -x "$INSTALL_DIR/$LIBDIR/bats-core/tracing.bash" ]
+  [ ! -x "$INSTALL_DIR/$LIBDIR/bats-core/validator.bash" ]
   [ ! -x "$INSTALL_DIR/libexec/bats-core/bats" ]
   [ ! -x "$INSTALL_DIR/libexec/bats-core/bats-exec-suite" ]
   [ ! -x "$INSTALL_DIR/libexec/bats-core/bats-exec-test" ]

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,6 +4,7 @@ set -e
 
 BATS_ROOT="${0%/*}"
 PREFIX="$1"
+LIBDIR="${2:-lib}"
 
 if [[ -z "$PREFIX" ]]; then
   printf '%s\n' \
@@ -25,7 +26,7 @@ for elt in "$BATS_ROOT/libexec/bats-core"/*; do
 done
 [[ -d "$d" ]] && rmdir "$d"
 
-d="$PREFIX/lib/bats-core"
+d="$PREFIX/${LIBDIR}/bats-core"
 for elt in "$BATS_ROOT/lib/bats-core"/*; do
   elt=${elt##*/}
   rm -f "$d/$elt"


### PR DESCRIPTION
It may install files to /usr/lib64 when multilib is enabled. Add an
optional parameter for install.sh to support it.

Signed-off-by: Kai Kang <kai.kang@windriver.com>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
