### PR TITLE
Allow `load` from `test_functions.bash` to load `.sh` files

### DIFF
--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -16,6 +16,8 @@ load() {
     file="${BATS_TEST_DIRNAME}/${file}.bash"
   elif [[ -f "${BATS_TEST_DIRNAME}/${file}" ]]; then
     file="${BATS_TEST_DIRNAME}/${file}"
+  elif [[ -f "${BATS_TEST_DIRNAME}/${file}.sh" ]]; then
+    file="${BATS_TEST_DIRNAME}/${file}.sh"
   fi
 
   if [[ ! -f "$file" ]] && ! type -P "$file" >/dev/null; then

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -196,8 +196,13 @@ fixtures bats
   [ $status -eq 0 ]
 }
 
-@test "load sources relative scripts with filename extension" {
+@test "load sources relative scripts with .bash filename extension" {
   HELPER_NAME="test_helper.bash" run bats "$FIXTURE_ROOT/load.bats"
+  [ $status -eq 0 ]
+}
+
+@test "load sources relative scripts with .sh filename extension" {
+  HELPER_NAME="test_helper2.sh" run bats "$FIXTURE_ROOT/load.bats"
   [ $status -eq 0 ]
 }
 

--- a/test/fixtures/bats/test_helper2.sh
+++ b/test/fixtures/bats/test_helper2.sh
@@ -1,0 +1,3 @@
+help_me() {
+  true
+}


### PR DESCRIPTION
As per #454, this allows loading `.sh` files with the `load` function. It checks for the file last to preserve backwards compatibility. It also adds a test case for this situation

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
