### PR TITLE
FAQ: add entry for negation `!`

### DIFF
--- a/docs/source/gotchas.rst
+++ b/docs/source/gotchas.rst
@@ -9,6 +9,14 @@ convention of using return code 0 to signify success and everything non-zero to 
 
 Please adhere to this idiom while using bats, or you will constantly work against your environment.
 
+My negated statement (e.g. ! true) does not fail the test, even when it should.
+-------------------------------------------------------------------------------
+
+Bash deliberately excludes negated return values from causing a pipeline to exit (see bash's `-e` option). You'll need to use the form `! x || false` or (recommended) use `run` and check for `[ $status != 0 ]`.
+
+If the negated command is the final statement in a test, that final statement's (negated) exit status will propagate through to the test's return code as usual.
+Negated statements of the form `! x || false` will explicitly fail the test when the pipeline returns true, regardless of where they occur in the test.
+
 I cannot register a test multiple times via for loop.
 -----------------------------------------------------
 


### PR DESCRIPTION
#462

- [ x] I have reviewed the [Contributor Guidelines][contributor].
- [ x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
