### PR TITLE
improve grammar for 'return variable' gotcha

### DIFF
--- a/docs/source/gotchas.rst
+++ b/docs/source/gotchas.rst
@@ -36,8 +36,8 @@ If you need such a feature, please let us know about your usecase.
 
 As a workaround you can use environment variables to pass parameters.
 
-Testing functions that return their results via a variable.
------------------------------------------------------------
+Why can't my function return results via a variable when using `run`?
+---------------------------------------------------------------------
 
 The `run` function executes its command in a subshell which means the changes to variables won't be available in the calling shell.
 


### PR DESCRIPTION
The current version reads poorly to me.

- [ x] I have reviewed the [Contributor Guidelines][contributor].
- [ x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
