### PR TITLE
--verbose: print command and stdout/err

### DIFF
--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -144,13 +144,13 @@ run() { # [--keep-empty-lines] [--output merged|separate|stderr|stdout] [--] <co
     ;;
   esac
 
-  # shellcheck disable=SC2034
-  BATS_TEST_COMMAND="${*}"
-  if $VERBOSE; then
-    printf "  %s\n" "${BATS_TEST_COMMAND}" >&3
-    printf "    %s\n" "${lines[@]:-}" >&3
+  if [[ $BATS_TRACE_LEVEL -gt 0 ]]; then
+    printf "$ %s\n" "$*"
   fi
-  
+  if [[ $BATS_TRACE_LEVEL -gt 1 ]]; then
+    printf "  %s\n" "${lines[@]}"
+  fi
+
   IFS="$origIFS"
   set "-$origFlags"
 }

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -144,6 +144,13 @@ run() { # [--keep-empty-lines] [--output merged|separate|stderr|stdout] [--] <co
     ;;
   esac
 
+  # shellcheck disable=SC2034
+  BATS_TEST_COMMAND="${*}"
+  if $VERBOSE; then
+    printf "  %s\n" "${BATS_TEST_COMMAND}" >&3
+    printf "    %s\n" "${lines[@]:-}" >&3
+  fi
+  
   IFS="$origIFS"
   set "-$origFlags"
 }

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -117,7 +117,8 @@ report_formatter=''
 recursive=
 export BATS_TEMPDIR_CLEANUP=1
 output=
-export VERBOSE="${VERBOSE:-false}"
+export BATS_VERBOSE=
+export BATS_TRACE_LEVEL=
 if [[ -z "${CI:-}" && -t 0 && -t 1 ]] && command -v tput >/dev/null; then
   formatter='pretty'
 fi
@@ -197,7 +198,18 @@ while [[ "$#" -ne 0 ]]; do
     shift
     ;;
   --verbose)
-      VERBOSE=true
+      BATS_VERBOSE=1
+    ;;
+  --trace|-x)
+      shift
+      BATS_TRACE_LEVEL="$1"
+      case "$BATS_TRACE_LEVEL" in
+        0|1|2)
+        ;;
+        *)
+          abort "Invalid trace level $BATS_TRACE_LEVEL"
+        ;;
+      esac
     ;;
   -*)
     abort "Bad command line option '$1'"

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -46,6 +46,7 @@ HELP_TEXT_HEADER
   -p, --pretty              Shorthand for "--formatter pretty"
   -r, --recursive           Include tests in subdirectories
   -t, --tap                 Shorthand for "--formatter tap"
+  --verbose                 Print command and STDOUT/ERR of test[s]
   -T, --timing              Add timing information to tests
   -v, --version             Display the version number
 
@@ -116,6 +117,7 @@ report_formatter=''
 recursive=
 export BATS_TEMPDIR_CLEANUP=1
 output=
+export VERBOSE="${VERBOSE:-false}"
 if [[ -z "${CI:-}" && -t 0 && -t 1 ]] && command -v tput >/dev/null; then
   formatter='pretty'
 fi
@@ -193,6 +195,9 @@ while [[ "$#" -ne 0 ]]; do
   --tempdir) # for internal test consumption only!
     BATS_RUN_TMPDIR="$2"
     shift
+    ;;
+  --verbose)
+      VERBOSE=true
     ;;
   -*)
     abort "Bad command line option '$1'"

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -109,17 +109,20 @@ bats_exit_trap() {
     bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
     bats_print_failed_command >&3
 
+    status=1
+  else
+    printf 'ok %d %s%s\n' "$BATS_SUITE_TEST_NUMBER" "${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}" \
+      "$skipped" >&3
+    status=0
+  fi
+
+  if [[ (-z "$BATS_TEST_COMPLETED" || -z "$BATS_TEARDOWN_COMPLETED" || "${BATS_INTERRUPTED-NOTSET}" != NOTSET) || -n "$BATS_VERBOSE" ]]; then
     while IFS= read -r line; do
       printf '# %s\n' "$line" || break # avoid feedback loop when errors are redirected into BATS_OUT (see #353)
     done <"$BATS_OUT" >&3
     if [[ -n "$line" ]]; then
       printf '# %s\n' "$line"
     fi
-    status=1
-  else
-    printf 'ok %d %s%s\n' "$BATS_SUITE_TEST_NUMBER" "${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}" \
-      "$skipped" >&3
-    status=0
   fi
 
   rm -f "$BATS_OUT"


### PR DESCRIPTION
Until https://github.com/bats-core/bats-core/pull/467 is settled, and because it's becoming larger than expected, I'd like to split it into this smaller piece.

## GOALS

1. Output command and stdout under the test in a legible format.
2. Don't break tests that target lines[\#]

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

```
@test "-v and --version print version number" {
  run bats -v
  [ $status -eq 0 ]
  [ $(expr "$output" : "Bats [0-9][0-9.]*") -ne 0 ]
}

❯ bin/bats --filter "-v" test             
 ✓ -v and --version print version number

1 test, 0 failures


❯ VERBOSE=true bin/bats --filter "-v" test
 ✓ -v and --version print version number
  bats -v
    Bats 1.4.1

1 test, 0 failures


❯ bin/bats --verbose --filter "-v" test
 ✓ -v and --version print version number
  bats -v
    Bats 1.4.1

1 test, 0 failures
```

```
@test "-v and --version print version number" {
  run bats -v
  [ $status -eq 1 ]
}

❯ bin/bats --filter "-v" test
 ✗ -v and --version print version number
   (in test file test/bats.bats, line 22)
     `[ $status -eq 1 ]' failed

1 test, 1 failure

❯ bin/bats --verbose --filter "-v" test
 ✗ -v and --version print version number
  bats -v
    Bats 1.4.1
   (in test file test/bats.bats, line 22)
     `[ $status -eq 1 ]' failed

1 test, 1 failure

```

```

@test "-v and --version print version number" {
  run bats -v
  run echo 123
  [ $status -eq 1 ]
}


❯ bin/bats --verbose --filter "-v" test
 ✗ -v and --version print version number
  bats -v
    Bats 1.4.1
  echo 123
    123
   (in test file test/bats.bats, line 23)
     `[ $status -eq 1 ]' failed

1 test, 1 failure

```


```
❯ bin/bats --verbose --filter "test count validator catches mismatch and returns non zero" test/bats.bats
 ✓ test count validator catches mismatch and returns non zero
  bash -c echo $'1..1\n' | bats_test_count_validator
    1..1
    # bats warning: Executed 0 instead of expected 1 tests
  bash -c echo $'1..1\nok 1\nok 2' | bats_test_count_validator
    1..1
    ok 1
    ok 2
    # bats warning: Executed 2 instead of expected 1 tests
  bash -c echo $'1..1\nok 1' | bats_test_count_validator
    1..1
    ok 1

1 test, 0 failures
```