### PR TITLE
Add --filter-status failed for running only failed tests from the last completed run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /bats-*.tgz
 # we don't have any deps; un-ignore if that changes
 /package-lock.json
+test/.bats/run-logs/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * using external formatters via `--formatter <absolute path>` (also works for
   `--report-formatter`) (#602)
+* running only tests that failed in the last run via `--filter-status failed` (#483)
 
 #### Documentation
 

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -41,6 +41,10 @@ HELP_TEXT_HEADER
                             or 'custom' which requires setting $BATS_BEGIN_CODE_QUOTE and 
                             $BATS_END_CODE_QUOTE. Can also be set via $BATS_CODE_QUOTE_STYLE
   -f, --filter <regex>      Only run tests that match the regular expression
+  --filter-status <status>  Only run tests with the given status in the last completed (no CTRL+C/SIGINT) run.
+                            Valid <status> values are:
+                              failed - runs tests that failed or were not present in the last run
+                              missed - runs tests that were not present in the last run
   -F, --formatter <type>    Switch between formatters: pretty (default),
                               tap (default w/o term), tap13, junit, /<absolute path to formatter>
   --gather-test-outputs-in <directory>

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -246,8 +246,9 @@ while [[ "$#" -ne 0 ]]; do
     shift
     BATS_CODE_QUOTE_STYLE="$1"
   ;;
-  --rerun-failed)
-    flags+=('--rerun-failed')
+  --filter-status)
+    shift
+    flags+=('--filter-status' "$1")
     ;;
   -*)
     abort "Bad command line option '$1'"

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -246,6 +246,9 @@ while [[ "$#" -ne 0 ]]; do
     shift
     BATS_CODE_QUOTE_STYLE="$1"
   ;;
+  --rerun-failed)
+    flags+=('--rerun-failed')
+    ;;
   -*)
     abort "Bad command line option '$1'"
     ;;

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -5,7 +5,6 @@ flags=('--dummy-flag')
 num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS:-1}
 extended_syntax=''
 BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
-bats_rerun_failed=''
 
 while [[ "$#" -ne 0 ]]; do
   case "$1" in

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -3,20 +3,12 @@ set -eET
 
 flags=('--dummy-flag')
 num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS:-1}
-filter=''
 extended_syntax=''
 BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
 bats_rerun_failed=''
 
 while [[ "$#" -ne 0 ]]; do
   case "$1" in
-  -c) ;;
-
-  -f)
-    shift
-    filter="$1"
-    flags+=('-f' "$filter")
-    ;;
   -j)
     shift
     num_jobs="$1"

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -264,12 +264,7 @@ bats_run_tests() {
       if [[ $test_name ]]; then
         ((++test_number_in_suite))
         ((++test_number_in_file))
-        # deal with empty flags to avoid spurious "unbound variable" errors on Bash 4.3 and lower
-        if [[ "${#flags[@]}" -gt 0 ]]; then
-          "$BATS_LIBEXEC/bats-exec-test" "${flags[@]}" "$filename" "$test_name" "$test_number_in_suite" "$test_number_in_file" || bats_exec_file_status=1
-        else
-          "$BATS_LIBEXEC/bats-exec-test" "$filename" "$test_name" "$test_number_in_suite" "$test_number_in_file" || bats_exec_file_status=1
-        fi
+        "$BATS_LIBEXEC/bats-exec-test" "${flags[@]}" "$filename" "$test_name" "$test_number_in_suite" "$test_number_in_file" || bats_exec_file_status=1
       fi
     done
   fi

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -23,9 +23,6 @@ while [[ "$#" -ne 0 ]]; do
     # use singular to allow for users to override in file
     BATS_NO_PARALLELIZE_WITHIN_FILE=1
     ;;
-  --rerun-failed)
-    flags+=(--rerun-failed)
-    ;;
   --dummy-flag)
     ;;
   --trace)

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -6,6 +6,7 @@ num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS:-1}
 filter=''
 extended_syntax=''
 BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
+bats_rerun_failed=''
 
 while [[ "$#" -ne 0 ]]; do
   case "$1" in
@@ -30,6 +31,9 @@ while [[ "$#" -ne 0 ]]; do
   --no-parallelize-within-files)
     # use singular to allow for users to override in file
     BATS_NO_PARALLELIZE_WITHIN_FILE=1
+    ;;
+  --rerun-failed)
+    flags+=(--rerun-failed)
     ;;
   --dummy-flag)
     ;;

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -6,6 +6,7 @@ filter=''
 num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS:-1}
 bats_no_parallelize_across_files=${BATS_NO_PARALLELIZE_ACROSS_FILES-}
 bats_no_parallelize_within_files=
+bats_rerun_failed=
 flags=('--dummy-flag') # add a dummy flag to prevent unset varialeb errors on empty array expansion in old bash versions
 setup_suite_file=''
 BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
@@ -42,6 +43,10 @@ while [[ "$#" -ne 0 ]]; do
   --no-parallelize-within-files)
     bats_no_parallelize_within_files=1
     flags+=("--no-parallelize-within-files")
+    ;;
+  --rerun-failed)
+    bats_rerun_failed=1
+    flags+=("--rerun-failed")
     ;;
   --dummy-flag)
     ;;
@@ -86,37 +91,59 @@ fi
 # create a file that contains all (filtered) tests to run from all files
 TESTS_LIST_FILE="${BATS_RUN_TMPDIR}/test_list_file.txt"
 
-all_tests=()
-for filename in "$@"; do
-  if [[ ! -f "$filename" ]]; then
-    abort "Test file \"${filename}\" does not exist"
-  fi
-
-  test_names=()
-  test_dupes=()
-  while read -r line; do
-    if [[ ! "$line" =~ ^bats_test_function\  ]]; then
-      continue
+bats_gather_tests() {
+  all_tests=()
+  for filename in "$@"; do
+    if [[ ! -f "$filename" ]]; then
+      abort "Test file \"${filename}\" does not exist"
     fi
-    line="${line%$'\r'}"
-    line="${line#* }"
-    test_line=$(printf "%s\t%s" "$filename" "$line")
-    all_tests+=("$test_line")
-    printf "%s\n" "$test_line" >>"$TESTS_LIST_FILE"
-    # avoid unbound variable errors on empty array expansion with old bash versions
-    if [[ ${#test_names[@]} -gt 0 && " ${test_names[*]} " == *" $line "* ]]; then
-      test_dupes+=("$line")
-      continue
+
+    test_names=()
+    test_dupes=()
+    while read -r line; do
+      if [[ ! "$line" =~ ^bats_test_function\  ]]; then
+        continue
+      fi
+      line="${line%$'\r'}"
+      line="${line#* }"
+      test_line=$(printf "%s\t%s" "$filename" "$line")
+      all_tests+=("$test_line")
+      printf "%s\n" "$test_line" >>"$TESTS_LIST_FILE"
+      # avoid unbound variable errors on empty array expansion with old bash versions
+      if [[ ${#test_names[@]} -gt 0 && " ${test_names[*]} " == *" $line "* ]]; then
+        test_dupes+=("$line")
+        continue
+      fi
+      test_names+=("$line")
+    done < <(BATS_TEST_FILTER="$filter" bats-preprocess "$filename")
+
+    if [[ "${#test_dupes[@]}" -ne 0 ]]; then
+      abort "Duplicate test name(s) in file \"${filename}\": ${test_dupes[*]}"
     fi
-    test_names+=("$line")
-  done < <(BATS_TEST_FILTER="$filter" bats-preprocess "$filename")
+  done
 
-  if [[ "${#test_dupes[@]}" -ne 0 ]]; then
-    abort "Duplicate test name(s) in file \"${filename}\": ${test_dupes[*]}"
-  fi
-done
+  test_count="${#all_tests[@]}"
+}
 
-test_count="${#all_tests[@]}"
+if [[ -n "$bats_rerun_failed" ]]; then  
+  mkdir -p "$PWD/.bats"
+  export BATS_RERUN_FAILED_FILE="$PWD/.bats/rerun-failed-tests.list"
+  export BATS_RERUN_FAILED_TMPFILE="${BATS_RERUN_FAILED_FILE}.tmp"
+  if [[ -s "$BATS_RERUN_FAILED_FILE" ]]; then
+    test_count="$(wc -l < "$BATS_RERUN_FAILED_FILE")"
+    cp "$BATS_RERUN_FAILED_FILE" "$TESTS_LIST_FILE"
+  elif [[ -f "$BATS_RERUN_FAILED_FILE" ]]; then
+    printf "There where no failed tests in the last recorded run.\n" >&2
+    printf "Delete the file '%s' to run all tests again.\n" "${BATS_RERUN_FAILED_FILE#"$PWD/"}" >&2
+    test_count=0
+  else
+    printf "No recording of previos runs found. Running all tests!\n" >&2
+    bats_gather_tests "$@"
+  fi 
+  : >"$BATS_RERUN_FAILED_TMPFILE" # truncate the file if it exists, else create
+else
+  bats_gather_tests "$@"
+fi
 
 if [[ -n "$count_only_flag" ]]; then
   printf '%d\n' "${test_count}"
@@ -177,6 +204,12 @@ bats_suite_exit_trap() {
   fi
   if [[ ${BATS_INTERRUPTED-NOTSET} != NOTSET ]]; then
     printf "\n# Received SIGINT, aborting ...\n\n"
+  fi
+  
+  if [[ -n "$bats_rerun_failed" && "${BATS_INTERRUPTED-NOTSET}" == NOTSET ]]; then
+    # only overwrite file once we finished with all tests
+    # else we would discard tests when aborting a test run with CTRL+C
+    mv "$BATS_RERUN_FAILED_TMPFILE" "$BATS_RERUN_FAILED_FILE"
   fi
   exit "$bats_exec_suite_status"
 }

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -170,8 +170,6 @@ if [[ -n "$filter_status" ]]; then
 
   if IFS='' read -d $'\n' -r BATS_PREVIOUS_RUNLOG_FILE < <(ls -1r "$BATS_RUN_LOGS_DIRECTORY"); then
     BATS_PREVIOUS_RUNLOG_FILE="$BATS_RUN_LOGS_DIRECTORY/$BATS_PREVIOUS_RUNLOG_FILE"
-    # TODO: only when this case is used do we get the failures where all tests are run after a missing test has been added
-    # this can happen when doing multiple runs in the same second (e.g. bats internal tests)
     if [[ $BATS_PREVIOUS_RUNLOG_FILE == "$BATS_RUNLOG_FILE" ]]; then
       count=$(find "$BATS_RUN_LOGS_DIRECTORY" -name "$BATS_RUNLOG_DATE*" | wc -l)
       BATS_RUNLOG_FILE="$BATS_RUN_LOGS_DIRECTORY/${BATS_RUNLOG_DATE}-$count.log"
@@ -194,6 +192,8 @@ if [[ -n "$filter_status" ]]; then
           last_filtered_tests+=("${line#status-filtered "$filter_status" }")
         ;;
         "status-filtered "*) # ignore other status-filtered lines
+        ;;
+        "#"*) # allow for comments
         ;;
         *)
           printf "Error: %s:%d: Invalid format: %s\n" "$BATS_PREVIOUS_RUNLOG_FILE" "$i" "$line" >&2

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -24,7 +24,6 @@ while [[ "$#" -ne 0 ]]; do
   -f)
     shift
     filter="$1"
-    flags+=('-f' "$filter")
     ;;
   -j)
     shift

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -169,9 +169,9 @@ if [[ -n "$filter_status" ]]; then
   if IFS='' read -d $'\n' -r BATS_PREVIOUS_RUNLOG_FILE < <(ls -1r "$BATS_RUN_LOGS_DIRECTORY"); then
     BATS_PREVIOUS_RUNLOG_FILE="$BATS_RUN_LOGS_DIRECTORY/$BATS_PREVIOUS_RUNLOG_FILE"
     # this can happen when doing multiple runs in the same second (e.g. bats internal tests)
-    if [[ $BATS_RUN_LOGS_DIRECTORY/$BATS_PREVIOUS_RUNLOG_FILE == "$BATS_RUNLOG_FILE" ]]; then
+    if [[ $BATS_PREVIOUS_RUNLOG_FILE == "$BATS_RUNLOG_FILE" ]]; then
       count=$(find "$BATS_RUN_LOGS_DIRECTORY" -name "$BATS_RUNLOG_DATE*" | wc -l)
-      BATS_RUNLOG_FILE="${BATS_RUNLOG_DATE}_$count.log"
+      BATS_RUNLOG_FILE="$BATS_RUN_LOGS_DIRECTORY/${BATS_RUNLOG_DATE}-$count.log"
     fi
     failed_tests=()
     passed_tests=()

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -189,7 +189,7 @@ if [[ -n "$filter_status" ]]; then
           failed_tests+=("${line#failed }")
         ;;
         "status-filtered $filter_status"*) # pick up tests that were filtered in the last round for the same status
-          last_filtered_tests+=("${line#status-filtered "$filter_status"}")
+          last_filtered_tests+=("${line#status-filtered "$filter_status" }")
         ;;
         "status-filtered "*) # ignore other status-filtered lines
         ;;

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -205,7 +205,7 @@ if [[ -n "$filter_status" ]]; then
         printf "%s\n" "$line" 
         filtered_tests+=("$line")
       else
-        printf "status-filtered %s %s\n" "$filter_status" "$test_line" >> "$BATS_RUNLOG_FILE"
+        printf "status-filtered %s %s\n" "$filter_status" "$line" >> "$BATS_RUNLOG_FILE"
       fi
     done > "$TESTS_LIST_FILE"
 

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -6,7 +6,7 @@ filter=''
 num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS:-1}
 bats_no_parallelize_across_files=${BATS_NO_PARALLELIZE_ACROSS_FILES-}
 bats_no_parallelize_within_files=
-bats_rerun_failed=
+filter_status=''
 flags=('--dummy-flag') # add a dummy flag to prevent unset varialeb errors on empty array expansion in old bash versions
 setup_suite_file=''
 BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
@@ -43,9 +43,9 @@ while [[ "$#" -ne 0 ]]; do
     bats_no_parallelize_within_files=1
     flags+=("--no-parallelize-within-files")
     ;;
-  --rerun-failed)
-    bats_rerun_failed=1
-    flags+=("--rerun-failed")
+  --filter-status)
+    shift
+    filter_status="$1"
     ;;
   --dummy-flag)
     ;;
@@ -124,24 +124,103 @@ bats_gather_tests() {
   test_count="${#all_tests[@]}"
 }
 
-if [[ -n "$bats_rerun_failed" ]]; then  
-  mkdir -p "$PWD/.bats"
-  export BATS_RERUN_FAILED_FILE="$PWD/.bats/rerun-failed-tests.list"
-  export BATS_RERUN_FAILED_TMPFILE="${BATS_RERUN_FAILED_FILE}.tmp"
-  if [[ -s "$BATS_RERUN_FAILED_FILE" ]]; then
-    test_count="$(wc -l < "$BATS_RERUN_FAILED_FILE")"
-    cp "$BATS_RERUN_FAILED_FILE" "$TESTS_LIST_FILE"
-  elif [[ -f "$BATS_RERUN_FAILED_FILE" ]]; then
-    printf "There where no failed tests in the last recorded run.\n" >&2
-    printf "Delete the file '%s' to run all tests again.\n" "${BATS_RERUN_FAILED_FILE#"$PWD/"}" >&2
-    test_count=0
+TEST_ROOT=${1%/*}
+BATS_RUN_LOGS_DIRECTORY="$TEST_ROOT/.bats/run-logs"
+if [[ ! -d "$BATS_RUN_LOGS_DIRECTORY" ]]; then
+  if [[ -n "$filter_status" ]]; then
+    printf "Error: --filter-status needs '%s/' to save failed tests. Please create this folder, add it to .gitignore and try again.\n" "$BATS_RUN_LOGS_DIRECTORY"
+    exit 1
   else
-    printf "No recording of previos runs found. Running all tests!\n" >&2
-    bats_gather_tests "$@"
-  fi 
-  : >"$BATS_RERUN_FAILED_TMPFILE" # truncate the file if it exists, else create
+    BATS_RUN_LOGS_DIRECTORY=
+  fi
+  # discard via sink instead of having a conditional later
+  export BATS_RUNLOG_FILE='/dev/null'
 else
-  bats_gather_tests "$@"
+  BATS_RUNLOG_DATE=$(date -Iseconds)
+  export BATS_RUNLOG_FILE="$BATS_RUN_LOGS_DIRECTORY/${BATS_RUNLOG_DATE}.log"
+fi
+
+bats_gather_tests "$@"
+
+if [[ -n "$filter_status" ]]; then  
+  source "$BATS_ROOT/lib/bats-core/common.bash"
+  case "$filter_status" in
+    failed)
+      bats_filter_test_by_status() { # <line>
+        ! bats_binary_search "$1" "passed_tests"
+      }
+    ;;
+    passed)
+      bats_filter_test_by_status() {
+        ! bats_binary_search "$1" "failed_tests"
+      }
+    ;;
+    missed)
+      bats_filter_test_by_status() {
+        ! bats_binary_search "$1" "failed_tests" && ! bats_binary_search "$1" "passed_tests" 
+      }
+    ;;
+    *)
+      printf "Error: Unknown value '%s' for --filter-status. Valid values are 'failed' and 'passing'.\n" "$filter_status">&2
+      exit 1
+    ;;
+  esac
+
+  if IFS='' read -d $'\n' -r BATS_PREVIOUS_RUNLOG_FILE < <(ls -1r "$BATS_RUN_LOGS_DIRECTORY"); then
+    BATS_PREVIOUS_RUNLOG_FILE="$BATS_RUN_LOGS_DIRECTORY/$BATS_PREVIOUS_RUNLOG_FILE"
+    # this can happen when doing multiple runs in the same second (e.g. bats internal tests)
+    if [[ $BATS_RUN_LOGS_DIRECTORY/$BATS_PREVIOUS_RUNLOG_FILE == "$BATS_RUNLOG_FILE" ]]; then
+      count=$(find "$BATS_RUN_LOGS_DIRECTORY" -name "$BATS_RUNLOG_DATE*" | wc -l)
+      BATS_RUNLOG_FILE="${BATS_RUNLOG_DATE}_$count.log"
+    fi
+    failed_tests=()
+    passed_tests=()
+    # store tests that were already filtered out in the last run for the same filter reason
+    last_filtered_tests=()
+    i=0
+    while read -rd $'\n' line; do
+      ((++i))
+      case "$line" in
+        "passed "*)
+          passed_tests+=("${line#passed }")
+        ;;
+        "failed "*)
+          failed_tests+=("${line#failed }")
+        ;;
+        "status-filtered $filter_status"*) # pick up tests that were filtered in the last round for the same status
+          last_filtered_tests+=("${line#status-filtered "$filter_status"}")
+        ;;
+        "status-filtered "*) # ignore other status-filtered lines
+        ;;
+        *)
+          printf "Error: %s:%d: Invalid format: %s\n" "$BATS_PREVIOUS_RUNLOG_FILE" "$i" "$line" >&2
+          exit 1
+        ;;
+      esac
+    done < <(sort "$BATS_PREVIOUS_RUNLOG_FILE")
+
+    filtered_tests=()
+    for line in "${all_tests[@]}"; do
+      if bats_filter_test_by_status "$line" && ! bats_binary_search "$line" last_filtered_tests; then
+        printf "%s\n" "$line" 
+        filtered_tests+=("$line")
+      else
+        printf "status-filtered %s %s\n" "$filter_status" "$test_line" >> "$BATS_RUNLOG_FILE"
+      fi
+    done > "$TESTS_LIST_FILE"
+
+    # save filtered tests to exclude them again in next round
+    for test_line in "${last_filtered_tests[@]}"; do 
+      printf "status-filtered %s %s\n" "$filter_status" "$test_line"
+    done >> "$BATS_RUNLOG_FILE"
+
+    test_count="${#filtered_tests[@]}"
+    if [[ ${#failed_tests} -eq 0 && ${#filtered_tests[@]} -eq 0 ]]; then
+      printf "There where no failed tests in the last recorded run.\n" >&2
+    fi
+  else
+    printf "No recording of previous runs found. Running all tests!\n" >&2
+  fi
 fi
 
 if [[ -n "$count_only_flag" ]]; then
@@ -205,10 +284,9 @@ bats_suite_exit_trap() {
     printf "\n# Received SIGINT, aborting ...\n\n"
   fi
   
-  if [[ -n "$bats_rerun_failed" && "${BATS_INTERRUPTED-NOTSET}" == NOTSET ]]; then
-    # only overwrite file once we finished with all tests
-    # else we would discard tests when aborting a test run with CTRL+C
-    mv "$BATS_RERUN_FAILED_TMPFILE" "$BATS_RERUN_FAILED_FILE"
+  if [[ -d "$BATS_RUN_LOGS_DIRECTORY" && -n "${BATS_INTERRUPTED}" ]]; then
+    # aborting a test run with CTRL+C does not save the runlog file
+    rm "$BATS_RUNLOG_FILE"
   fi
   exit "$bats_exec_suite_status"
 }

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -143,6 +143,7 @@ fi
 bats_gather_tests "$@"
 
 if [[ -n "$filter_status" ]]; then  
+  # shellcheck source=lib/bats-core/common.bash
   source "$BATS_ROOT/lib/bats-core/common.bash"
   case "$filter_status" in
     failed)

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -136,7 +136,8 @@ if [[ ! -d "$BATS_RUN_LOGS_DIRECTORY" ]]; then
   # discard via sink instead of having a conditional later
   export BATS_RUNLOG_FILE='/dev/null'
 else
-  BATS_RUNLOG_DATE=$(date -Iseconds)
+  # use UTC (-u) to avoid problems with TZ changes
+  BATS_RUNLOG_DATE=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
   export BATS_RUNLOG_FILE="$BATS_RUN_LOGS_DIRECTORY/${BATS_RUNLOG_DATE}.log"
 fi
 
@@ -169,6 +170,7 @@ if [[ -n "$filter_status" ]]; then
 
   if IFS='' read -d $'\n' -r BATS_PREVIOUS_RUNLOG_FILE < <(ls -1r "$BATS_RUN_LOGS_DIRECTORY"); then
     BATS_PREVIOUS_RUNLOG_FILE="$BATS_RUN_LOGS_DIRECTORY/$BATS_PREVIOUS_RUNLOG_FILE"
+    # TODO: only when this case is used do we get the failures where all tests are run after a missing test has been added
     # this can happen when doing multiple runs in the same second (e.g. bats internal tests)
     if [[ $BATS_PREVIOUS_RUNLOG_FILE == "$BATS_RUNLOG_FILE" ]]; then
       count=$(find "$BATS_RUN_LOGS_DIRECTORY" -name "$BATS_RUNLOG_DATE*" | wc -l)
@@ -203,7 +205,7 @@ if [[ -n "$filter_status" ]]; then
     filtered_tests=()
     for line in "${all_tests[@]}"; do
       if bats_filter_test_by_status "$line" && ! bats_binary_search "$line" last_filtered_tests; then
-        printf "%s\n" "$line" 
+        printf "%s\n" "$line"
         filtered_tests+=("$line")
       else
         printf "status-filtered %s %s\n" "$filter_status" "$line" >> "$BATS_RUNLOG_FILE"

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -163,7 +163,7 @@ if [[ -n "$filter_status" ]]; then
       }
     ;;
     *)
-      printf "Error: Unknown value '%s' for --filter-status. Valid values are 'failed' and 'passing'.\n" "$filter_status">&2
+      printf "Error: Unknown value '%s' for --filter-status. Valid values are 'failed' and 'missed'.\n" "$filter_status">&2
       exit 1
     ;;
   esac

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -12,6 +12,7 @@ BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS="${BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS:-}"
 BATS_VERBOSE_RUN="${BATS_VERBOSE_RUN:-}"
 BATS_GATHER_TEST_OUTPUTS_IN="${BATS_GATHER_TEST_OUTPUTS_IN:-}"
 BATS_TEST_NAME_PREFIX="${BATS_TEST_NAME_PREFIX:-}"
+bats_rerun_failed=
 
 while [[ "$#" -ne 0 ]]; do
   case "$1" in
@@ -48,6 +49,9 @@ while [[ "$#" -ne 0 ]]; do
   --gather-test-outputs-in)
     shift
     BATS_GATHER_TEST_OUTPUTS_IN="$1"
+    ;;
+  --rerun-failed)
+    bats_rerun_failed=1
     ;;
   *)
     break
@@ -135,6 +139,9 @@ bats_exit_trap() {
   local print_bats_out="${BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS}"
 
   if [[ -z "$BATS_TEST_COMPLETED" || -z "$BATS_TEARDOWN_COMPLETED" || "${BATS_INTERRUPTED-NOTSET}" != NOTSET ]]; then
+    if [[ -n "$bats_rerun_failed" ]]; then
+      printf "%s\t%s\n" "$BATS_TEST_FILENAME" "$BATS_TEST_NAME" >> "${BATS_RERUN_FAILED_TMPFILE}"
+    fi
     if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
       # For some versions of bash, `$?` may not be set properly for some error
       # conditions before triggering the EXIT trap directly (see #72 and #81).

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -10,7 +10,7 @@ BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS="${BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS:-}"
 BATS_VERBOSE_RUN="${BATS_VERBOSE_RUN:-}"
 BATS_GATHER_TEST_OUTPUTS_IN="${BATS_GATHER_TEST_OUTPUTS_IN:-}"
 BATS_TEST_NAME_PREFIX="${BATS_TEST_NAME_PREFIX:-}"
-bats_rerun_failed=
+BATS_RERUN_FAILED=
 
 while [[ "$#" -ne 0 ]]; do
   case "$1" in
@@ -40,7 +40,7 @@ while [[ "$#" -ne 0 ]]; do
     BATS_GATHER_TEST_OUTPUTS_IN="$1"
     ;;
   --rerun-failed)
-    bats_rerun_failed=1
+    BATS_RERUN_FAILED=1
     ;;
   *)
     break
@@ -128,7 +128,7 @@ bats_exit_trap() {
   local print_bats_out="${BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS}"
 
   if [[ -z "$BATS_TEST_COMPLETED" || -z "$BATS_TEARDOWN_COMPLETED" || "${BATS_INTERRUPTED-NOTSET}" != NOTSET ]]; then
-    if [[ -n "$bats_rerun_failed" ]]; then
+    if [[ -n "$BATS_RERUN_FAILED" ]]; then
       printf "%s\t%s\n" "$BATS_TEST_FILENAME" "$BATS_TEST_NAME" >> "${BATS_RERUN_FAILED_TMPFILE}"
     fi
     if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -10,7 +10,6 @@ BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS="${BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS:-}"
 BATS_VERBOSE_RUN="${BATS_VERBOSE_RUN:-}"
 BATS_GATHER_TEST_OUTPUTS_IN="${BATS_GATHER_TEST_OUTPUTS_IN:-}"
 BATS_TEST_NAME_PREFIX="${BATS_TEST_NAME_PREFIX:-}"
-BATS_RERUN_FAILED=
 
 while [[ "$#" -ne 0 ]]; do
   case "$1" in
@@ -38,9 +37,6 @@ while [[ "$#" -ne 0 ]]; do
   --gather-test-outputs-in)
     shift
     BATS_GATHER_TEST_OUTPUTS_IN="$1"
-    ;;
-  --rerun-failed)
-    BATS_RERUN_FAILED=1
     ;;
   *)
     break
@@ -128,9 +124,6 @@ bats_exit_trap() {
   local print_bats_out="${BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS}"
 
   if [[ -z "$BATS_TEST_COMPLETED" || -z "$BATS_TEARDOWN_COMPLETED" || "${BATS_INTERRUPTED-NOTSET}" != NOTSET ]]; then
-    if [[ -n "$BATS_RERUN_FAILED" ]]; then
-      printf "%s\t%s\n" "$BATS_TEST_FILENAME" "$BATS_TEST_NAME" >> "${BATS_RERUN_FAILED_TMPFILE}"
-    fi
     if [[ "$BATS_ERROR_STATUS" -eq 0 ]]; then
       # For some versions of bash, `$?` may not be set properly for some error
       # conditions before triggering the EXIT trap directly (see #72 and #81).
@@ -155,11 +148,15 @@ bats_exit_trap() {
 
     print_bats_out=1
     status=1
+    local state=failed
   else
     printf 'ok %d %s%s\n' "$BATS_SUITE_TEST_NUMBER" "${BATS_TEST_NAME_PREFIX:-}${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}" \
       "$skipped" >&3
     status=0
+    local state=passed
   fi
+
+  printf "%s %s\t%s\n" "$state" "$BATS_TEST_FILENAME" "$BATS_TEST_NAME" >> "$BATS_RUNLOG_FILE"
 
   if [[ $print_bats_out ]]; then
     bats_prefix_lines_for_tap_output < "$BATS_OUT" | bats_replace_filename >&3

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -2,8 +2,6 @@
 set -eET
 
 # Variables used in other scripts.
-BATS_COUNT_ONLY=''
-BATS_TEST_FILTER=''
 BATS_ENABLE_TIMING=''
 BATS_EXTENDED_SYNTAX=''
 BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
@@ -16,15 +14,6 @@ bats_rerun_failed=
 
 while [[ "$#" -ne 0 ]]; do
   case "$1" in
-  -c)
-    # shellcheck disable=SC2034
-    BATS_COUNT_ONLY=1
-    ;;
-  -f)
-    shift
-    # shellcheck disable=SC2034
-    BATS_TEST_FILTER="$1"
-    ;;
   -T)
     BATS_ENABLE_TIMING='-T'
     ;;

--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -59,6 +59,11 @@ OPTIONS
   * `-F`, `--formatter <type>`:
     Switch between formatters: pretty (default), tap (default w/o term), tap13, junit,
     `/<absolute path to formatter>`
+  * `--filter-status <status>`
+    Only run tests with the given status in the last completed (no CTRL+C/SIGINT) run.
+    Valid <status> values are:
+      failed - runs tests that failed or were not present in the last run
+      missed - runs tests that were not present in the last run
   * `--gather-test-outputs-in <directory>`:
     Gather the output of failing *and* passing tests as files in directory
   * `-h`, `--help`:

--- a/shellcheck.sh
+++ b/shellcheck.sh
@@ -7,7 +7,7 @@ while IFS=  read -r -d $'\0'; do
     targets+=("$REPLY")
 done < <(
   find . -type f \( -name \*.bash -o -name \*.sh \) -print0; \
-  find . -name '*.bats' -not -name '*_no_shellcheck*' -print0; \
+  find . -type f -name '*.bats' -not -name '*_no_shellcheck*' -print0; \
   find libexec -type f -print0;
   find bin -type f -print0)
 

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1259,7 +1259,7 @@ END_OF_ERR_MSG
   # add a new test that was missed before
   echo $'@test missed { :; }' >> "many_passing_and_one_failing.bats"
 
-  cat .bats/run-logs/*
+  find .bats/run-logs/ -type f -print -exec cat {} \;
 
   run -1 bats --tap --filter-status failed "many_passing_and_one_failing.bats"
   # now we should only run the failing test

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1139,7 +1139,7 @@ END_OF_ERR_MSG
   [ "${lines[0]}" == 'ERROR: Unknown BATS_CODE_QUOTE_STYLE: three' ]
 }
 
-@test "Debug trap must only override variables that are prefixed with bats_ (issue #519)" {
+@test "Debug trap must only override variables that are prefixed with BATS_ (issue #519)" {
   # use declare -p to gather variables in pristine bash and bats @test environment
   # then compare which ones are introduced in @test compared to bash
 

--- a/test/common.bats
+++ b/test/common.bats
@@ -39,3 +39,34 @@
     bats_require_minimum_version 0.1.2
     [ "${BATS_GUARANTEED_MINIMUM_VERSION}" = 0.2.3 ]
 }
+
+@test bats_binary_search {
+    bats_require_minimum_version 1.5.0
+
+    run -2 bats_binary_search "search-value"
+    [ "$output" = "ERROR: bats_binary_search requires exactly 2 arguments: <search value> <array name>" ]
+
+    # unset array = empty array: a bit unfortunate but we can't tell the difference (on older Bash?)
+    unset no_array
+    run -1 bats_binary_search "search-value" "no_array"
+
+    # shellcheck disable=SC2034
+    empty_array=()
+    run -1 bats_binary_search "search-value" "empty_array"
+
+    # shellcheck disable=SC2034
+    odd_length_array=(1 2 3)
+    run -1 bats_binary_search a odd_length_array
+    run -0 bats_binary_search 1 odd_length_array
+    run -0 bats_binary_search 2 odd_length_array
+    run -0 bats_binary_search 3 odd_length_array
+
+    # shellcheck disable=SC2034
+    even_length_array=(1 2 3 4)
+    run -1 bats_binary_search a even_length_array
+    run -0 bats_binary_search 1 even_length_array
+    run -0 bats_binary_search 2 even_length_array
+    run -0 bats_binary_search 3 even_length_array
+    run -0 bats_binary_search 4 even_length_array
+
+}

--- a/test/fixtures/bats/many_passing_and_one_failing.bats
+++ b/test/fixtures/bats/many_passing_and_one_failing.bats
@@ -1,0 +1,15 @@
+@test "a passing test" {
+  true
+}
+
+@test "another passing test" {
+  true
+}
+
+@test "a failing test" {
+  false
+}
+
+@test "yet another passing test" {
+  true
+}

--- a/test/fixtures/bats/sigint_in_failing_test.bats
+++ b/test/fixtures/bats/sigint_in_failing_test.bats
@@ -1,0 +1,15 @@
+setup() {
+    load '../../concurrent-coordination'
+}
+
+@test "failing" {
+    if [[ -z "${DONT_ABORT:-}" ]]; then
+        # emulate CTRL-C by sending SIGINT to the whole process group
+        kill -SIGINT -- -$BATS_ROOT_PID
+    fi
+    false
+}
+
+@test "passing" {
+    :
+}

--- a/test/fixtures/bats/sigint_in_failing_test.bats
+++ b/test/fixtures/bats/sigint_in_failing_test.bats
@@ -1,11 +1,7 @@
-setup() {
-    load '../../concurrent-coordination'
-}
-
 @test "failing" {
     if [[ -z "${DONT_ABORT:-}" ]]; then
         # emulate CTRL-C by sending SIGINT to the whole process group
-        kill -SIGINT -- -$BATS_ROOT_PID
+        kill -SIGINT -- -"$BATS_ROOT_PID"
     fi
     false
 }


### PR DESCRIPTION
Often only a little subset of tests is failing. While working on fixing them, running other tests just takes up time. While the filtering function can be used to filter down to a small number of tests, it can become cumbersome to select all tests that failed.  This flag to Bats introduces that feature. What this PR does:

- check for .bats/run-logs/ in the test directory (suite dir or containing dir of first test file)
  - if this directory exists, a log of all passed/failed tests will be written
  - if a test run is aborted via SIGINT/CTRL+C no log will be stored
- when `--filter-status` is activated it picks the most recent log in .bats/run-logs
  - if no log does exist, we assume a first run and will run all tests (subject to filtering/file selection)
  - if the log exist, run all tests of the specified status in the last run (+missed tests: tests that were not encountered in the last run e.g., due to renaming/adding them)

TODO:
- documentation
  - [x] man page
  - [x] --help text

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
