### PR TITLE
Fix: Final line without newline omitted on bash 3.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * remove empty line after test with pretty formatter on some terminals (#481)
 * don't run setup_file/teardown_file on files without tests, e.g. due to
   filtering (#484)
+* print final line without newline on Bash 3.2 for midtest (ERREXIT) failures
+  too (#495, #145)
 
 #### Documentation
 

--- a/lib/bats-core/common.bash
+++ b/lib/bats-core/common.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+bats_prefix_lines_for_tap_output() {
+    while IFS= read -r line; do
+      printf '# %s\n' "$line" || break # avoid feedback loop when errors are redirected into BATS_OUT (see #353)
+    done
+    if [[ -n "$line" ]]; then
+      printf '# %s\n' "$line"
+    fi
+}

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -145,6 +145,9 @@ bats_file_teardown_trap() {
   bats_file_exit_trap
 }
 
+# shellcheck source=lib/bats-core/common.bash
+source "$BATS_ROOT/lib/bats-core/common.bash"
+
 bats_file_exit_trap() {
   trap - ERR EXIT
   if [[ -z "$BATS_SETUP_FILE_COMPLETED" || -z "$BATS_TEARDOWN_FILE_COMPLETED" ]]; then
@@ -160,12 +163,7 @@ bats_file_exit_trap() {
     printf "not ok %d %s\n" "$((test_number_in_suite + 1))" "$FAILURE_REASON failed" >&3
     bats_print_stack_trace "${BATS_STACK_TRACE[@]}" >&3
     bats_print_failed_command >&3
-    while IFS= read -r line; do
-      printf "# %s\n" "$line"
-    done <"$BATS_OUT" >&3
-    if [[ -n "$line" ]]; then
-      printf '# %s\n' "$line"
-    fi
+    bats_prefix_lines_for_tap_output < "$BATS_OUT" >&3
     rm -rf "$BATS_OUT"
     status=1
   fi

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -93,6 +93,9 @@ bats_teardown_trap() {
   bats_exit_trap
 }
 
+# shellcheck source=lib/bats-core/common.bash
+source "$BATS_ROOT/lib/bats-core/common.bash"
+
 bats_exit_trap() {
   local line
   local status
@@ -144,12 +147,7 @@ bats_exit_trap() {
   fi
 
   if [[ $print_bats_out ]]; then
-    while IFS= read -r line; do
-      printf '# %s\n' "$line" || break # avoid feedback loop when errors are redirected into BATS_OUT (see #353)
-    done <"$BATS_OUT" >&3
-    if [[ -n "$line" ]]; then
-      printf '# %s\n' "$line"
-    fi
+    bats_prefix_lines_for_tap_output < "$BATS_OUT" >&3
   fi
 
   if [[ $BATS_GATHER_TEST_OUTPUTS_IN ]]; then

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -553,13 +553,17 @@ END_OF_ERR_MSG
   printf 'num lines: %d\n' "${#lines[@]}" >&2
   printf 'LINE: %s\n' "${lines[@]}" >&2
   [ "$status" -eq 1 ]
-  [ "${#lines[@]}" -eq 7 ]
-  [ "${lines[1]}" = 'not ok 1 no final newline' ]
-  [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/no-final-newline.bats, line 2)" ]
-  [ "${lines[3]}" = "#   \`printf 'foo\nbar\nbaz' >&2 && return 1' failed" ]
+  [ "${#lines[@]}" -eq 11 ]
+  [ "${lines[1]}" = 'not ok 1 error in test' ]
+  [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/no-final-newline.bats, line 3)" ]
+  [ "${lines[3]}" = "#   \`false' failed" ]
   [ "${lines[4]}" = '# foo' ]
   [ "${lines[5]}" = '# bar' ]
-  [ "${lines[6]}" = '# baz' ]
+  [ "${lines[6]}" = 'not ok 2 test function returns nonzero' ]
+  [ "${lines[7]}" = '# (in test file /bats-core/test/fixtures/bats/no-final-newline.bats, line 7)' ]
+  [ "${lines[8]}" = "#   \`printf 'foo\nbar'' failed" ]
+  [ "${lines[9]}" = '# foo' ]
+  [ "${lines[10]}" = '# bar' ]
 }
 
 @test "run tests which consume stdin (see #197)" {

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -560,7 +560,7 @@ END_OF_ERR_MSG
   [ "${lines[4]}" = '# foo' ]
   [ "${lines[5]}" = '# bar' ]
   [ "${lines[6]}" = 'not ok 2 test function returns nonzero' ]
-  [ "${lines[7]}" = '# (in test file /bats-core/test/fixtures/bats/no-final-newline.bats, line 7)' ]
+  [ "${lines[7]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/no-final-newline.bats, line 7)" ]
   [ "${lines[8]}" = "#   \`printf 'foo\nbar'' failed" ]
   [ "${lines[9]}" = '# foo' ]
   [ "${lines[10]}" = '# bar' ]

--- a/test/fixtures/bats/no-final-newline.bats
+++ b/test/fixtures/bats/no-final-newline.bats
@@ -1,3 +1,9 @@
-@test "no final newline" {
-  printf 'foo\nbar\nbaz' >&2 && return 1
+@test "error in test" {
+  printf 'foo\nbar'
+  false
+}
+
+@test "test function returns nonzero" {
+  printf 'foo\nbar'
+  return 1
 }


### PR DESCRIPTION
Fixes #145 for real now.

The original fix only worked for tests that fail via non null `return` but does not work when there is a failure mid test. This is due to a missing `>&3` on printing the trailing line without newline. This breaks when stdout is redirected into `$BATS_OUT`  during tests.