### PR TITLE
Remove mentions of the now defunct irc channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ or look at the other communication channels.
 
 ## Contact
 
-- We are `#bats` on freenode;
-- Or leave a message on [gitter].
+- You can find and chat with us on our [Gitter].
 
 ## Version history
 
@@ -127,4 +126,4 @@ Bats is released under an MIT-style license; see `LICENSE.md` for details.
 See the [parent project](https://github.com/bats-core) at GitHub or the
 [AUTHORS](AUTHORS) file for the current project maintainer team.
 
-[gitter]: https://gitter.im/bats-core/bats-core?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+[gitter]: https://gitter.im/bats-core/bats-core

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
   (single use latch) (#516)
 * fix recurring errors on CTRL+C tests with NPM on Windows in selftest suite (#516)
 
+#### Documentation
+
+* remove links to defunct freenode IRC channel (#515)
+
 ## [1.5.0] - 2021-10-22
 
 ### Added

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -57,8 +57,7 @@ CONTRIBUTING.md file][atom].
 
 ## Quick links &#x1f517;
 
-- [Gitter channel →][gitterurl]: These messages sync with the IRC channel
-- [IRC Channel (#bats on freenode) →][ircurl]: These messages sync with Gitter
+- [Gitter channel →][gitterurl]: Feel free to come chat with us on Gitter
 - [README →][README]
 - [Code of conduct →][CODE_OF_CONDUCT]
 - [License information →][LICENSE]
@@ -101,7 +100,7 @@ specifics, see the [CODE_OF_CONDUCT][] file.
 Please check the [README][] or existing [issues][repoissues] first.
 
 If you cannot find an answer to your question, please feel free to hop on our 
-[gitter][gitterurl] [![Gitter](https://badges.gitter.im/bats-core/bats-core.svg)](https://gitter.im/bats-core/bats-core?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) or [via IRC (#bats on freenode)][ircurl].
+[Gitter][gitterurl]. [![Gitter](https://badges.gitter.im/bats-core/bats-core.svg)](https://gitter.im/bats-core/bats-core)
 
 ### Reporting issues
 
@@ -391,4 +390,3 @@ by the [Free Software Foundation](https://www.fsf.org/), 2016 under the [Free Ar
 [osmit]:          https://opensource.org/licenses/MIT
 
 [gitterurl]:      https://gitter.im/bats-core/bats-core
-[ircurl]:         https://kiwiirc.com/client/irc.freenode.net:+6697/#bats


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

freenode underwent [some changes](https://en.wikipedia.org/wiki/Freenode#Ownership_change_and_conflict), the most relevant being a wipe of the services database.