### PR TITLE
Don't leak variables from debug trap

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,7 +151,7 @@ jobs:
           time docker run -it -v $PWD:/opt/bats alpine sh -c "apk add bash ncurses; /opt/bats/bin/bats  --print-output-on-failure --tap /opt/bats/test"
 
   freebsd:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     strategy:
       matrix:
         packages:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ quotes around code blocks in error output (#506)
 * removed leftover debug file `/tmp/latch` in selftest suite
   (single use latch) (#516)
 * fix recurring errors on CTRL+C tests with NPM on Windows in selftest suite (#516)
+* fixed leaking of local variables from debug trap (#520)
 
 #### Documentation
 

--- a/lib/bats-core/tracing.bash
+++ b/lib/bats-core/tracing.bash
@@ -148,8 +148,10 @@ bats_trim_filename() {
 # normalize a windows path from e.g. C:/directory to /c/directory
 # The path must point to an existing/accessable directory, not a file!
 bats_normalize_windows_dir_path() { # <output-var> <path>
-	local output_var="$1"
-	local path="$2"
+	local output_var="$1" path="$2"
+	if [[ "$output_var" != NORMALIZED_INPUT ]]; then
+		local NORMALIZED_INPUT
+	fi
 	if [[ $path == ?:* ]]; then
 		NORMALIZED_INPUT="$(cd "$path" || exit 1; pwd)"
 	else
@@ -284,6 +286,7 @@ bats_add_debug_exclude_path() { # <path>
 		return 1
 	fi
 	if [[ "$OSTYPE" == cygwin || "$OSTYPE" == msys ]]; then
+		local normalized_dir
 		bats_normalize_windows_dir_path normalized_dir "$1"
 		BATS_DEBUG_EXCLUDE_PATHS+=("$normalized_dir")
 	else

--- a/lib/bats-core/tracing.bash
+++ b/lib/bats-core/tracing.bash
@@ -236,7 +236,7 @@ bats_debug_trap() {
 	local NORMALIZED_INPUT
 	bats_normalize_windows_dir_path NORMALIZED_INPUT "${1%/*}"
 	local file_excluded='' path
-	for path in "${_BATS_DEBUG_EXCLUDE_PATHS[@]}"; do
+	for path in "${BATS_DEBUG_EXCLUDE_PATHS[@]}"; do
 		if [[ "$NORMALIZED_INPUT" == "$path"* ]]; then
 			file_excluded=1
 			break
@@ -285,14 +285,14 @@ bats_add_debug_exclude_path() { # <path>
 	fi
 	if [[ "$OSTYPE" == cygwin || "$OSTYPE" == msys ]]; then
 		bats_normalize_windows_dir_path normalized_dir "$1"
-		_BATS_DEBUG_EXCLUDE_PATHS+=("$normalized_dir")
+		BATS_DEBUG_EXCLUDE_PATHS+=("$normalized_dir")
 	else
-		_BATS_DEBUG_EXCLUDE_PATHS+=("$1")
+		BATS_DEBUG_EXCLUDE_PATHS+=("$1")
 	fi
 }
 
 bats_setup_tracing() {
-	_BATS_DEBUG_EXCLUDE_PATHS=()
+	BATS_DEBUG_EXCLUDE_PATHS=()
 	# exclude some paths by default
 	bats_add_debug_exclude_path "$BATS_ROOT/lib/"
 	bats_add_debug_exclude_path "$BATS_ROOT/libexec/"
@@ -311,6 +311,7 @@ bats_setup_tracing() {
 		done < <(find "$PWD" -type d -name bats-assert -o -name bats-support)
 	fi
 
+	local exclude_paths path
 	# exclude user defined libraries
 	IFS=':' read -r exclude_paths <<< "${BATS_DEBUG_EXCLUDE_PATHS:-}"
 	for path in "${exclude_paths[@]}"; do

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1264,17 +1264,18 @@ EOF
 
   # make declare's output more readable and suitable for `comm`
   normalize_variable_list() {
-    while IFS=' =' read -r _declare flags variable value; do
+    # `declare -p`: declare -X VAR_NAME="VALUE"
+    while IFS=' =' read -r _declare _ variable _; do
         if [[ "$_declare" == declare ]]; then # skip multiline variables' values
           printf "%s\n" "$variable"
         fi
     done | sort
   }
   # get the bash baseline (add variables that should be ignored (e.g. PIPESTATUS) here)
-  BASH_DECLARED_VARIABLES=$(env -i PIPESTATUS= bash -c "declare -p")
+  BASH_DECLARED_VARIABLES=$(env -i PIPESTATUS= "$BASH" -c "declare -p")
   local BATS_DECLARED_VARIABLES_FILE="${BATS_TEST_TMPDIR}/variables.log"
   # now capture bats @test environment
-  run -0 env -i BATS_DECLARED_VARIABLES_FILE="$BATS_DECLARED_VARIABLES_FILE"  "${BATS_ROOT}/bin/bats" "${FIXTURE_ROOT}/issue-519.bats"
+  run -0 env -i BATS_DECLARED_VARIABLES_FILE="$BATS_DECLARED_VARIABLES_FILE"  "$BASH" "${BATS_ROOT}/bin/bats" "${FIXTURE_ROOT}/issue-519.bats"
   # use function to allow failing via !, run is a bit unwiedly with the pipe and subshells
   check_no_new_variables() {
     # -23 -> only look at additions on the bats list

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1295,7 +1295,7 @@ EOF
   BASH_DECLARED_VARIABLES=$(env -i PIPESTATUS= "$BASH" -c "declare -p")
   local BATS_DECLARED_VARIABLES_FILE="${BATS_TEST_TMPDIR}/variables.log"
   # now capture bats @test environment
-  run -0 env -i BATS_DECLARED_VARIABLES_FILE="$BATS_DECLARED_VARIABLES_FILE"  "$BASH" "${BATS_ROOT}/bin/bats" "${FIXTURE_ROOT}/issue-519.bats"
+  run -0 env -i PATH="$PATH" BATS_DECLARED_VARIABLES_FILE="$BATS_DECLARED_VARIABLES_FILE"  bash "${BATS_ROOT}/bin/bats" "${FIXTURE_ROOT}/issue-519.bats"
   # use function to allow failing via !, run is a bit unwiedly with the pipe and subshells
   check_no_new_variables() {
     # -23 -> only look at additions on the bats list

--- a/test/fixtures/bats/issue-519.bats
+++ b/test/fixtures/bats/issue-519.bats
@@ -1,0 +1,3 @@
+@test "no unprefixed variables" {
+    declare -p >"${BATS_DECLARED_VARIABLES_FILE?}"
+}


### PR DESCRIPTION
Refs #519 

Adds a regression test that ensures we don't leak any variables. A more stringent test would also check if we did not change the value of existing variables mid execution via the debug trap. However, this will be harder to get right.