### PR TITLE
Fix bats-assert's tests

### DIFF
--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -111,17 +111,18 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
   local origFlags="$-"
   set +eET
   local origIFS="$IFS"
-  status=0
   if [[ $keep_empty_lines ]]; then
     # 'output', 'status', 'lines' are global variables available to tests.
     # preserve trailing newlines by appending . and removing it later
     # shellcheck disable=SC2034
-    output="$($pre_command "$@"; status=$?; printf .; exit $status)" || status="$?"
+    output="$($pre_command "$@"; status=$?; printf .; exit $status)"
+    status=$?
     output="${output%.}"
   else
     # 'output', 'status', 'lines' are global variables available to tests.
     # shellcheck disable=SC2034
-    output="$($pre_command "$@")" || status="$?"
+    output="$($pre_command "$@")"
+    status=$?
   fi
 
   bats_separate_lines lines output

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -115,14 +115,12 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
     # 'output', 'status', 'lines' are global variables available to tests.
     # preserve trailing newlines by appending . and removing it later
     # shellcheck disable=SC2034
-    output="$($pre_command "$@"; status=$?; printf .; exit $status)"
-    status=$?
+    output="$($pre_command "$@"; status=$?; printf .; exit $status)" && status=0 || status=$?
     output="${output%.}"
   else
     # 'output', 'status', 'lines' are global variables available to tests.
     # shellcheck disable=SC2034
-    output="$($pre_command "$@")"
-    status=$?
+    output="$($pre_command "$@")" && status=0 || status=$?
   fi
 
   bats_separate_lines lines output


### PR DESCRIPTION
which rely on check run's status within another run,
thus overriding status before executing the command is problematic.