### PR TITLE
Add test/example for running background tasks without preventing the test run from finishing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * new flag `--code-quote-style` (and `$BATS_CODE_QUOTE_STYLE`) to customize
 quotes around code blocks in error output (#506)
+* an example/regression test for running background tasks without blocking the
+  test run (#525)
 
 ### Fixed
 

--- a/docs/source/gotchas.rst
+++ b/docs/source/gotchas.rst
@@ -118,3 +118,14 @@ don't abort the test when they fail, unless they are the last command before the
 making their exit code the return code.
 
 `[ ]`  does not suffer from this, but is no replacement for all `[[ ]]` usecases. Appending ` || false` will work in all cases.
+
+Background tasks prevent the test run from terminating when finished
+--------------------------------------------------------------------
+
+When running a task in background, it will inherit the opened FDs of the process it was forked from.
+This means that the background task forked from a Bats test will hold the FD for the pipe to the formatter that prints to the terminal,
+thus keeping it open until the background task finished.
+Due to implementation internals of Bats and bash, this pipe might be held in multiple FDs which all have to be closed by the background task.
+
+You can use `close_non_std_fds from `test/fixtures/bats/issue-205.bats` in the background job to close all FDs except stdin, stdout and stderr, thus solving the problem.
+More details about the issue can be found in [#205](https://github.com/bats-core/bats-core/issues/205#issuecomment-973572596).

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1305,3 +1305,10 @@ EOF
   }
   check_no_new_variables
 }
+
+@test "Don't wait for disowned background jobs to finish because of open FDs (#205)" {
+    SECONDS=0
+    run -0 bats --show-output-of-passing-tests --tap "${FIXTURE_ROOT}/issue-205.bats"
+    echo $SECONDS
+    [ $SECONDS -lt 10 ]
+}

--- a/test/fixtures/bats/issue-205.bats
+++ b/test/fixtures/bats/issue-205.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+function bgfunc {
+    close_non_std_fds
+    sleep 10
+    echo "bgfunc done"
+    return 0
+}
+
+function get_open_fds() {
+    if [[ -d /proc/$$/fd ]]; then # Linux
+        read -d '' -ra open_fds < <(ls -1 /proc/$$/fd) || true
+    elif command -v lsof >/dev/null ; then # MacOS
+        local -a fds
+        IFS=$'\n' read -d '' -ra fds < <(lsof -F f -p $$) || true
+        open_fds=()
+        for fd in "${fds[@]}"; do
+            case $fd in 
+                f[0-9]*) # filter non fd entries (mainly pid?)
+                    open_fds+=("${fd#f}") # cut off f prefix
+                ;;
+            esac
+        done
+    elif command -v procstat >/dev/null ; then # BSDs
+        local -a columns header
+        {
+            read -r -a header
+            local fd_column_index=-1
+            for ((i=0; i<${#header[@]}; ++i)); do
+                if [[ ${header[$i]} == *FD* ]]; then
+                    fd_column_index=$i
+                    break
+                fi
+            done
+            if [[ $fd_column_index -eq -1 ]]; then
+                printf "Could not find FD column in procstat" >&2
+                exit 1
+            fi
+            while read -r -a columns; do
+                local fd=${columns[$fd_column_index]}
+                if [[ $fd == [0-9]* ]]; then # only take up numeric entries
+                    open_fds+=("$fd")
+                fi
+            done
+        } < <(procstat fds $$)
+    else
+        # TODO: MSYS (Windows)
+        printf "Neither FD discovery mechanism available\n" >&2
+        exit 1
+    fi
+}
+
+function close_non_std_fds() {
+    get_open_fds
+    for fd in "${open_fds[@]}"; do
+        if [[ $fd -gt 2 ]]; then
+            printf "Close %d\n" "$fd"
+            eval "exec $fd>&-"
+        else
+            printf "Retain %d\n" "$fd"
+        fi
+    done
+}
+
+function otherfunc {
+    bgfunc &
+    PID=$!
+    disown
+    return 0
+}
+
+@test "min bg" {
+    echo "sec: $SECONDS"
+    otherfunc
+    sleep 1 # leave some space for the background job to print/fail early
+    kill -s 0 -- $PID # fail it the process already finished due to error!
+    echo "sec: $SECONDS"
+}


### PR DESCRIPTION
Fixes #205.

Adds regression test and example helper (close_non_std_fds).

- [x] documentation