### PR TITLE
junit formatter: Don't put fd3 output from teardown_file into  <failure>

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ quotes around code blocks in error output (#506)
   (single use latch) (#516)
 * fix recurring errors on CTRL+C tests with NPM on Windows in selftest suite (#516)
 * fixed leaking of local variables from debug trap (#520)
+* don't mark FD3 output from `teardown_file` as `<failure>` in junit output (#532)
 
 #### Documentation
 

--- a/lib/bats-core/formatter.bash
+++ b/lib/bats-core/formatter.bash
@@ -43,15 +43,16 @@ function bats_parse_internal_extended_tap() {
             ;;
         'ok '*)
             ((++index))
-            scope=ok
             if [[ "$line" =~ $ok_line_regexpr ]]; then
                 ok_index="${BASH_REMATCH[1]}"
                 test_name="${BASH_REMATCH[2]}"
                 if [[ "$line" =~ $skip_line_regexpr ]]; then
+                    scope=skipped
                     test_name="${BASH_REMATCH[2]}" # cut off name before "# skip"
                     local skip_reason="${BASH_REMATCH[4]}"
                     bats_tap_stream_skipped "$ok_index" "$test_name" "$skip_reason"
                 else
+                    scope=ok
                     if [[ "$line" =~ $timing_expr ]]; then
                         bats_tap_stream_ok --duration "${BASH_REMATCH[1]}" "$ok_index" "$test_name"
                     else

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -220,13 +220,21 @@ bats_tap_stream_not_ok() { # [--duration <milliseconds>] <test index> <test name
 }
 
 bats_tap_stream_comment() { # <comment text without leading '# '> <scope>
-  if [[ "$2" == begin ]]; then
-    # everything that happens between begin and [not] ok is FD3 output from the test
-    log_system_out "$1"
-  else
-    # everything else is considered error output
-    log "$1"
-  fi
+  local comment="$1" scope="$2"
+  case "$scope" in
+    begin)
+      # everything that happens between begin and [not] ok is FD3 output from the test
+      log_system_out "$comment"
+    ;;
+    ok)
+      # non failed tests can produce FD3 output
+      log_system_out "$comment"
+    ;;
+    *)
+      # everything else is considered error output
+      log "$1"
+    ;;
+  esac
 }
 
 bats_tap_stream_suite() { # <file name>

--- a/test/fixtures/junit-formatter/issue_531.bats
+++ b/test/fixtures/junit-formatter/issue_531.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    echo "# setup_file stdout"
+    echo "# setup_file fd3" >&3
+}
+
+teardown_file() {
+    echo "# teardown_file stdout"
+    echo "# teardown_file fd3" >&3
+}
+
+@test "My test" {
+    echo "# test stdout"
+    echo "# test fd3" >&3
+}

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -138,3 +138,15 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
   [[ "${lines[17]}" == '    </testcase>' ]]
   [[ "${lines[18]}" == '</testsuite>' ]]
 }
+
+@test "junit does not mark tests with FD 3 output in teardown_file as failed (issue #531)" {
+  run -0 bats --formatter junit "$FIXTURE_ROOT/issue_531.bats"
+
+  [[ "${lines[2]}" == '<testsuite name="issue_531.bats" '*'>' ]]
+  [[ "${lines[3]}" == '    <testcase classname="issue_531.bats" '*'>' ]]
+  # only the outputs on FD3 should be visible on a successful test
+  [[ "${lines[4]}" == '        <system-out>test fd3' ]]
+  [[ "${lines[5]}" == 'teardown_file fd3</system-out>' ]]
+  [[ "${lines[6]}" == '    </testcase>' ]]
+  [[ "${lines[7]}" == '</testsuite>' ]]
+}


### PR DESCRIPTION
Fixes #531 