### PR TITLE
Fix broken link in writing-tests.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 Bats is a [TAP](https://testanything.org/)-compliant testing framework for Bash.  It provides a simple
 way to verify that the UNIX programs you write behave as expected.
 
-[TAP]: https://testanything.org
-
 A Bats test file is a Bash script with special syntax for defining test cases.
 Under the hood, each test case is just a function with a description.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ quotes around code blocks in error output (#506)
 
 * remove links to defunct freenode IRC channel (#515)
 * improved grammar (#534)
+* fixed link to TAP spec (#537)
 
 ## [1.5.0] - 2021-10-22
 

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -32,7 +32,7 @@ $ bats addition.bats
 
 If Bats is not connected to a terminal—in other words, if you run it from a
 continuous integration system, or redirect its output to a file—the results are
-displayed in human-readable, machine-parsable [TAP format][TAP].
+displayed in human-readable, machine-parsable [TAP format][https://testanything.org].
 
 You can force TAP output from a terminal by invoking Bats with the `--formatter tap`
 option.

--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -225,7 +225,7 @@ that may launch long-running child processes**, e.g. `command_name 3>&-` .
 
 ## Printing to the terminal
 
-Bats produces output compliant with [version 12 of the TAP protocol][TAP]. The
+Bats produces output compliant with [version 12 of the TAP protocol](https://testanything.org/tap-specification.html). The
 produced TAP stream is by default piped to a pretty formatter for human
 consumption, but if Bats is called with the `-t` flag, then the TAP stream is
 directly printed to the console.


### PR DESCRIPTION
I was reading the docs and noticed this broken link.

I'm not sure what the original intended target was, so I made it a link to the TAP specification.

- [ X] I have reviewed the [Contributor Guidelines][contributor].
- [ X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
