### PR TITLE
bats: add bazel support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,7 +4,10 @@
 
 sh_library(
     name = "bats_lib",
-    srcs = glob(["libexec/**"]),
+    srcs = glob([
+        "libexec/**",
+        "lib/**",
+    ]),
 )
 
 sh_binary(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,17 @@
+# BATS: Bash Automated Testing System
+# This is the BUILD.bazel file for compiling the bats binary.
+# Additional rules might need to be added to enable the other bats libraries.
+
+sh_library(
+    name = "bats_lib",
+    srcs = glob(["libexec/**"]),
+)
+
+sh_binary(
+    name = "bats",
+    srcs = ["bin/bats"],
+    deps = [
+        ":bats_lib",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,8 +10,8 @@ sh_library(
 sh_binary(
     name = "bats",
     srcs = ["bin/bats"],
+    visibility = ["//visibility:public"],
     deps = [
         ":bats_lib",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,18 @@
+workspace(
+    name = "bats_core",
+)
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()

--- a/bats.bzl
+++ b/bats.bzl
@@ -1,4 +1,16 @@
 # Bazel rules for running bats tests.
+#
+# Example of use, assuming bats_core is loaded in the @bats_core workspace:
+#
+# load("@bats_core//:bats.bzl", "bats_test")
+#
+# bats_test(
+#   name = "my_simple_test",
+#   srcs = ["my_simple_test.bats"],
+#   deps = [
+#     ":some_other_sh_library",
+#   ],
+# )
 
 load("@bazel_skylib//lib:shell.bzl", "shell")
 

--- a/bats.bzl
+++ b/bats.bzl
@@ -36,8 +36,6 @@ def _exec_test_impl(ctx):
 bats_test = rule(
     doc = """
       Runs a bats (Bash Automated Test System) test.
-
-      bats-support and bats-assert extensions are available by default.
     """,
     attrs = {
         "srcs": attr.label_list(
@@ -48,7 +46,7 @@ bats_test = rule(
             doc = "Extra arguments to pass to the command.",
         ),
         "deps": attr.label_list(
-            doc = "Extra dependencies to make available when test runs.",
+            doc = "Extra dependencies (other bats libraries?) to make available when test runs.",
             allow_files = True,
         ),
         "_command": attr.label(

--- a/bats.bzl
+++ b/bats.bzl
@@ -1,0 +1,62 @@
+# Bazel rules for running bats tests.
+
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+EXEC_TEST_TEMPLATE = """
+#!/usr/bin/env bash
+set -e
+export TERM=dumb  # because of tputs
+"{command}" {args} {srcs}
+"""
+
+def _exec_test_impl(ctx):
+    # Generic test that runs an executable.  Right now, this is only
+    # used for bats_test, but this might be used in the future for
+    # shellcheck_test and others.
+    runfiles = ctx.runfiles(
+        files = ctx.files.srcs + ctx.files.deps,
+        collect_data = True,
+    )
+    runfiles = runfiles.merge(ctx.attr._command.default_runfiles)
+    srcs = [f.short_path for f in ctx.files.srcs]
+    script = EXEC_TEST_TEMPLATE.format(
+        command = ctx.executable._command.short_path,
+        args = " ".join([shell.quote(x) for x in ctx.attr.extra_args]),
+        srcs = " ".join([shell.quote(x) for x in srcs]),
+    )
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        is_executable = True,
+        content = script,
+    )
+    return DefaultInfo(
+        runfiles = runfiles,
+    )
+
+bats_test = rule(
+    doc = """
+      Runs a bats (Bash Automated Test System) test.
+
+      bats-support and bats-assert extensions are available by default.
+    """,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = [".bats"],
+            doc = "\"bats\" tests to run.",
+        ),
+        "extra_args": attr.string_list(
+            doc = "Extra arguments to pass to the command.",
+        ),
+        "deps": attr.label_list(
+            doc = "Extra dependencies to make available when test runs.",
+            allow_files = True,
+        ),
+        "_command": attr.label(
+            default = Label("@bats_core//:bats"),
+            executable = True,
+            cfg = "host",
+        ),
+    },
+    test = True,
+    implementation = _exec_test_impl,
+)

--- a/bin/bats
+++ b/bin/bats
@@ -54,6 +54,11 @@ if ! BATS_PATH=$(bats_readlinkf "${BASH_SOURCE[0]}" 2>/dev/null); then
   BATS_PATH=$(bats_readlinkf "${BASH_SOURCE[0]}")
 fi
 
-export BATS_ROOT=${BATS_PATH%/*/*}
+# In most execution environments, the bats binary will be located in
+# ${BATS_ROOT}/bin/bats.  However, in the bazel environment, sometimes the bats
+# binary produced by a sh_binary rule ends up in ${BATS_ROOT]/bats.  Let's
+# be flexible to handle both cases:
+export BATS_ROOT="${BATS_PATH%/bats}"
+export BATS_ROOT="${BATS_ROOT%/bin}"
 export -f bats_readlinkf
 exec env BATS_ROOT="$BATS_ROOT" "$BATS_ROOT/libexec/bats-core/bats" "$@"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 quotes around code blocks in error output (#506)
 * an example/regression test for running background tasks without blocking the
   test run (#525, #535)
-* Added support for bazel (BUILD.bazel file, and bats.bzl) (#515)
+* Added support for bazel (BUILD.bazel file, and bats.bzl) (#545)
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 quotes around code blocks in error output (#506)
 * an example/regression test for running background tasks without blocking the
   test run (#525, #535)
+* Added support for bazel (BUILD.bazel file, and bats.bzl) (#515)
 
 ### Fixed
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -4,21 +4,12 @@ bats_test(
     name = "bats_test_suite",
     srcs = ["bats.bats"],
     deps = [
-        "concurrent-coordination.bash",
-        "file_setup_teardown.bats",
-        "install.bats",
-        "junit-formatter.bats",
-        "parallel.bats",
-        "pretty-formatter.bats",
-        "root.bats",
-        "run.bats",
-        "suite.bats",
-        "test_helper.bash",
-        "trace.bats",
         # Because of a space in a filename, this directory must be handled
         # specially (like this, instead of a glob):
         "fixtures/bats/.",
     ] + glob([
+        "*.bats",
+        "*.bash",
         "fixtures/*",
         "fixtures/bats/evaluation_count/**",
         "fixtures/bats/issue-433/**",

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -7,17 +7,11 @@ bats_test(
         # Because of a space in a filename, this directory must be handled
         # specially (like this, instead of a glob):
         "fixtures/bats/.",
-    ] + glob([
-        "*.bats",
-        "*.bash",
-        "fixtures/*",
-        "fixtures/bats/evaluation_count/**",
-        "fixtures/bats/issue-433/**",
-        "fixtures/file_setup_teardown/**",
-        "fixtures/junit-formatter/**",
-        "fixtures/parallel/**",
-        "fixtures/run/**",
-        "fixtures/suite/**",
-        "fixtures/trace/**",
-    ]),
+    ] + glob(
+        ["**"],
+        exclude = [
+            "BUILD.bazel",
+            "fixtures/bats/*",
+        ],
+    ),
 )

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,0 +1,32 @@
+load("//:bats.bzl", "bats_test")
+
+bats_test(
+    name = "bats_test_suite",
+    srcs = ["bats.bats"],
+    deps = [
+        "concurrent-coordination.bash",
+        "file_setup_teardown.bats",
+        "install.bats",
+        "junit-formatter.bats",
+        "parallel.bats",
+        "pretty-formatter.bats",
+        "root.bats",
+        "run.bats",
+        "suite.bats",
+        "test_helper.bash",
+        "trace.bats",
+        # Because of a space in a filename, this directory must be handled
+        # specially (like this, instead of a glob):
+        "fixtures/bats/.",
+    ] + glob([
+        "fixtures/*",
+        "fixtures/bats/evaluation_count/**",
+        "fixtures/bats/issue-433/**",
+        "fixtures/file_setup_teardown/**",
+        "fixtures/junit-formatter/**",
+        "fixtures/parallel/**",
+        "fixtures/run/**",
+        "fixtures/suite/**",
+        "fixtures/trace/**",
+    ]),
+)


### PR DESCRIPTION
Motivation: my real goal was to fix the path-to-bats issue created when bats is invoked in certain bazel environments (a naive sh_binary rule will place bats in `${BATS_ROOT}/bats_core/bats` instead of `${BATS_ROOT}/bats_core/bin/bats`, but while I was at it, I figured I would contribute my BUILD.bazel file as well.

To demonstrate this bug fix, I'm also contributing all of the additional bazel-related files necessary to integrate bats_core into a bazel build flow.  This will save your users from having to roll-their-own -- they will be able to simply add a dependency on bats_core to their WORKSPACES file and go.  The files I added to make this happen are:

* `WORKSPACES` defines the bazel workspace (what dependencies bats needs to run. In this case, we're just importing a standard bazel library that lets us do shell-escaping of command line arguments correctly.
* `BUILD.bazel` defines the sh_binary rule to compile the "bats" tool in bazel's hermetic build environment, for use by other bazel rules.
* `bats.bzl` is a bazel library that defines a `bats_test` rule that users can add to their own BUILD files to quickly run bats tests.  Under the hood, this library depends on the `bats` tool compiled in the previous file.
* `test/BUILD.bazel` is an example of importing the bats_test rule and using it to run the entire bats regression suite.

TESTED:
`bazel test //test:bats_test_suite` executes correctly and passes.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
