### PR TITLE
fix: pre-4.4 bash workaround for empty arrays with 'set -u'.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ quotes around code blocks in error output (#506)
 * fix recurring errors on CTRL+C tests with NPM on Windows in selftest suite (#516)
 * fixed leaking of local variables from debug trap (#520)
 * don't mark FD3 output from `teardown_file` as `<failure>` in junit output (#532)
+* fix unbound variable error with Bash pre 4.4 (#550)
 
 #### Documentation
 

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -2,7 +2,7 @@
 set -eET
 
 export flags=('--dummy-flag')
-num_jobs=1
+num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS:-1}
 filter=''
 extended_syntax=''
 BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eET
 
-export flags=()
+export flags=('--dummy-flag')
 num_jobs=1
 filter=''
 extended_syntax=''

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -3,7 +3,7 @@ set -e
 
 count_only_flag=''
 filter=''
-num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS-1}
+num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS:-1}
 bats_no_parallelize_across_files=${BATS_NO_PARALLELIZE_ACROSS_FILES-}
 bats_no_parallelize_within_files=
 flags=('--dummy-flag') # add a dummy flag to prevent unset varialeb errors on empty array expansion in old bash versions

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -30,6 +30,8 @@ while [[ "$#" -ne 0 ]]; do
     # shellcheck disable=SC2034
     BATS_EXTENDED_SYNTAX='-x'
     ;;
+  --dummy-flag)
+    ;;
   --trace)
     (( ++BATS_TRACE_LEVEL )) # avoid returning 0
     ;;

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -371,10 +371,24 @@ setup() {
 @test 'ensure compatibility with unofficial Bash strict mode' {
   local expected='ok 1 unofficial Bash strict mode conditions met'
 
+  if [[ -n "$BATS_NUMBER_OF_PARALLEL_JOBS" ]]; then
+    if [[ -z "$BATS_NO_PARALLELIZE_ACROSS_FILES" ]]; then
+      type -p parallel &>/dev/null || skip "Don't check file parallelized without GNU parallel"
+    fi
+    (type -p flock &>/dev/null || type -p shlock &>/dev/null) || skip "Don't check parallelized without flock/shlock "
+  fi
+
+  # PATH required for windows
+  # HOME required to avoid error from GNU Parallel
   # Run Bats under SHELLOPTS=nounset (recursive `set -u`) to catch 
   # as many unset variable accesses as possible.
-  run run_under_clean_bats_env env SHELLOPTS=nounset \
-    "${BATS_ROOT}/bin/bats" "$FIXTURE_ROOT/unofficial_bash_strict_mode.bats"
+  run env - \
+          "PATH=$PATH" \
+          "HOME=$HOME" \
+          "BATS_NO_PARALLELIZE_ACROSS_FILES=$BATS_NO_PARALLELIZE_ACROSS_FILES" \
+          "BATS_NUMBER_OF_PARALLEL_JOBS=$BATS_NUMBER_OF_PARALLEL_JOBS" \
+          SHELLOPTS=nounset \
+      "${BATS_ROOT}/bin/bats" "$FIXTURE_ROOT/unofficial_bash_strict_mode.bats"
   if [[ "$status" -ne 0 || "${lines[1]}" != "$expected" ]]; then
     cat <<END_OF_ERR_MSG
 

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -647,6 +647,9 @@ END_OF_ERR_MSG
 }
 
 @test "Don't hang on CTRL-C (issue #353)" {
+  if [[ "$BATS_NUMBER_OF_PARALLEL_JOBS" -gt 1 ]]; then
+    skip "Aborts don't work in parallel mode"
+  fi
   load 'concurrent-coordination'
   # shellcheck disable=SC2031,SC2030
   export SINGLE_USE_LATCH_DIR="${BATS_TEST_TMPDIR}"

--- a/test/file_setup_teardown.bats
+++ b/test/file_setup_teardown.bats
@@ -94,6 +94,9 @@ not ok 1 failing test
 }
 
 @test "teardown_file should run even after user abort via CTRL-C" {
+  if [[ "$BATS_NUMBER_OF_PARALLEL_JOBS" -gt 1 ]]; then
+    skip "Aborts don't work in parallel mode"
+  fi
   # shellcheck disable=SC2031,SC2030
   export LOG="$BATS_TEST_TMPDIR/teardown_file_abort.log"
   # guarantee that background processes get their own process group -> pid=pgid

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -27,10 +27,3 @@ emit_debug_output() {
   # shellcheck disable=SC2154
   printf '%s\n' 'output:' "$output" >&2
 }
-
-run_under_clean_bats_env() {
-  # we want the variable names to be separate
-  # shellcheck disable=SC2086
-  unset ${!BATS_@}
-  "$@"
-}


### PR DESCRIPTION
Add a workaround (akin to ff630de5) to prevent pre-4.4 bash versions
throwing an unbound variable error for empty arrays when dereferenced
using '{[@]}'. This bash behavior/bug manifests itself when tests are
run with 'set -u' as error like this:

/usr/libexec/bats-core/bats-exec-file: line 225: flags[@]: unbound variable

This happens on CentOS-7 (`GNU bash, version 4.2.46(2)-release (x86_64-unknown-linux-gnu)`)
with all versions of bats.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it
