### PR TITLE
libexec: bats-core: Handle unbound variable in bats-format-pretty

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * document `$BATS_VERSION` (#557)
 
+### Fixed
+
+* unbound variable errors in formatters when using `SHELLOPTS=nounset` (`-u`) (#558)
+
 ## [1.6.0] - 2022-02-24
 
 ### Added

--- a/libexec/bats-core/bats-format-pretty
+++ b/libexec/bats-core/bats-format-pretty
@@ -45,10 +45,12 @@ count=0
 screen_width=80
 update_count_column_width
 update_screen_width
+test_result=
 
 trap update_screen_width WINCH
 
 begin() {
+  test_result= # reset to avoid carrying over result state from previous test
   line_backoff_count=0
   go_to_column 0
   update_count_column_width
@@ -98,7 +100,7 @@ fail() {
 }
 
 log() {
-  case ${test_result:-} in
+  case ${test_result} in
     pass)
     clear_color
     ;;

--- a/libexec/bats-core/bats-format-pretty
+++ b/libexec/bats-core/bats-format-pretty
@@ -98,7 +98,7 @@ fail() {
 }
 
 log() {
-  case $test_result in
+  case ${test_result:-} in
     pass)
     clear_color
     ;;

--- a/libexec/bats-core/bats-format-tap13
+++ b/libexec/bats-core/bats-format-tap13
@@ -40,13 +40,15 @@ close_previous_yaml_block() {
 
 trap '' INT
 
+number_of_printed_log_lines_for_this_test_so_far=0
+
 while IFS= read -r line; do
   case "$line" in
   'begin '*) ;;
   'ok '*)
     close_previous_yaml_block
     number_of_printed_log_lines_for_this_test_so_far=0
-    if [[ -n "$BATS_ENABLE_TIMING" ]]; then
+    if [[ -n "${BATS_ENABLE_TIMING-}" ]]; then
       timing_expr="(ok [0-9]+ .+) in ([0-9]+)ms$"
       if [[ "$line" =~ $timing_expr ]]; then
         printf "%s\n" "${BASH_REMATCH[1]}"
@@ -63,7 +65,7 @@ while IFS= read -r line; do
     close_previous_yaml_block
     number_of_printed_log_lines_for_this_test_so_far=0
     timing_expr="not ok [0-9]+ (.)+ in ([0-9])+ms$"
-    if [[ -n "$BATS_ENABLE_TIMING" ]]; then
+    if [[ -n "${BATS_ENABLE_TIMING-}" ]]; then
       if [[ "$line" =~ $timing_expr ]]; then
         printf "%s\n" "${BATS_REMATCH[1]}"
         add_yaml_entry "duration_ms" "${BASH_REMATCH[2]}"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -729,10 +729,12 @@ END_OF_ERR_MSG
     tested_at_least_one_formatter=1
     echo "Formatter: ${formatter}"
     # the replay should be possible without errors
-    "$formatter" >/dev/null <<EOF
+    bash -u "$formatter" >/dev/null <<EOF
 1..1
 suite "$BATS_FIXTURE_ROOT/failing.bats"
+# output from setup_file
 begin 1 test_a_failing_test
+# fd3 output from test
 not ok 1 a failing test
 # (in test file test/fixtures/bats/failing.bats, line 4)
 #   \`eval "( exit ${STATUS:-1} )"' failed


### PR DESCRIPTION
When running bats with `-u`, it errors on this unbound variable

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
