### PR TITLE
Fix: TAP13 output is missing test name with timing report on failure

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * unbound variable errors in formatters when using `SHELLOPTS=nounset` (`-u`) (#558)
 * don't require `flock` *and* `shlock` for parallel mode test (#554)
+* print name of failing test when using TAP13 with timing information (#559, #555)
 
 ## [1.6.0] - 2022-02-24
 

--- a/libexec/bats-core/bats-format-tap13
+++ b/libexec/bats-core/bats-format-tap13
@@ -82,7 +82,7 @@ while IFS= read -r line; do
       add_yaml_entry "message" "|" # use a multiline string for this entry
     fi
     ((++number_of_printed_log_lines_for_this_test_so_far))
-    printf "    %s\n" "$(echo "\"${line}\"" | cut -b 3-)"
+    printf "    %s\n" "${line:2}"
     ;;
   'suite '*) ;;
   esac

--- a/libexec/bats-core/bats-format-tap13
+++ b/libexec/bats-core/bats-format-tap13
@@ -64,10 +64,10 @@ while IFS= read -r line; do
   'not ok '*)
     close_previous_yaml_block
     number_of_printed_log_lines_for_this_test_so_far=0
-    timing_expr="not ok [0-9]+ (.)+ in ([0-9])+ms$"
+    timing_expr="(not ok [0-9]+ .+) in ([0-9])+ms$"
     if [[ -n "${BATS_ENABLE_TIMING-}" ]]; then
       if [[ "$line" =~ $timing_expr ]]; then
-        printf "%s\n" "${BATS_REMATCH[1]}"
+        printf "%s\n" "${BASH_REMATCH[1]}"
         add_yaml_entry "duration_ms" "${BASH_REMATCH[2]}"
       else
         echo "Could not match failure line to timing regex: $line" >&2

--- a/test/tap13-formatter.bats
+++ b/test/tap13-formatter.bats
@@ -1,0 +1,53 @@
+load 'test_helper'
+fixtures bats
+
+@test "passing test" {
+    run bats --formatter tap13 "${FIXTURE_ROOT}/passing.bats"
+    
+    [ "${lines[0]}" == 'TAP version 13' ]
+    [ "${lines[1]}" == '1..1' ]
+    [ "${lines[2]}" == 'ok 1 a passing test' ]
+    [ "${#lines[@]}" -eq 3 ]
+}
+
+@test "failing test" {
+    run bats --formatter tap13 "${FIXTURE_ROOT}/failing.bats"
+    
+    [ "${lines[0]}" == 'TAP version 13' ]
+    [ "${lines[1]}" == '1..1' ]
+    [ "${lines[2]}" == 'not ok 1 a failing test' ]
+    [ "${lines[3]}" == '  ---' ]
+    [ "${lines[4]}" == '  message: |' ]
+    [ "${lines[5]}" == '     (in test file test/fixtures/bats/failing.bats, line 4)"' ]
+    [ "${lines[6]}" == "       \`eval \"( exit \${STATUS:-1} )\"' failed\"" ]
+    [ "${lines[7]}" == '  ...' ]
+    [ "${#lines[@]}" -eq 8 ]
+}
+
+@test "passing test with timing" {
+    run bats --formatter tap13 --timing "${FIXTURE_ROOT}/passing.bats"
+    
+    [ "${lines[0]}" == 'TAP version 13' ]
+    [ "${lines[1]}" == '1..1' ]
+    [ "${lines[2]}" == 'ok 1 a passing test' ]
+    [ "${lines[3]}" == '  ---' ]
+    [ "${lines[4]::15}" == '  duration_ms: ' ]
+    [ "${lines[5]}" == '  ...' ]
+
+    [ "${#lines[@]}" -eq 6 ]
+}
+
+@test "failing test with timing" {
+    run bats --formatter tap13 --timing "${FIXTURE_ROOT}/failing.bats"
+    
+    [ "${lines[0]}" == 'TAP version 13' ]
+    [ "${lines[1]}" == '1..1' ]
+    [ "${lines[2]}" == 'not ok 1 a failing test' ]
+    [ "${lines[3]}" == '  ---' ]
+    [ "${lines[4]::15}" == '  duration_ms: ' ]
+    [ "${lines[5]}" == '  message: |' ]
+    [ "${lines[6]}" == '     (in test file test/fixtures/bats/failing.bats, line 4)"' ]
+    [ "${lines[7]}" == "       \`eval \"( exit \${STATUS:-1} )\"' failed\"" ]
+    [ "${lines[8]}" == '  ...' ]
+    [ "${#lines[@]}" -eq 9 ]
+}

--- a/test/tap13-formatter.bats
+++ b/test/tap13-formatter.bats
@@ -1,5 +1,5 @@
 load 'test_helper'
-fixtures bats
+fixtures bats # reuse bats fixtures
 
 @test "passing test" {
     run bats --formatter tap13 "${FIXTURE_ROOT}/passing.bats"
@@ -18,8 +18,8 @@ fixtures bats
     [ "${lines[2]}" == 'not ok 1 a failing test' ]
     [ "${lines[3]}" == '  ---' ]
     [ "${lines[4]}" == '  message: |' ]
-    [ "${lines[5]}" == '     (in test file test/fixtures/bats/failing.bats, line 4)"' ]
-    [ "${lines[6]}" == "       \`eval \"( exit \${STATUS:-1} )\"' failed\"" ]
+    [ "${lines[5]}" == "    (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 4)" ]
+    [ "${lines[6]}" == "      \`eval \"( exit \${STATUS:-1} )\"' failed" ]
     [ "${lines[7]}" == '  ...' ]
     [ "${#lines[@]}" -eq 8 ]
 }
@@ -46,8 +46,8 @@ fixtures bats
     [ "${lines[3]}" == '  ---' ]
     [ "${lines[4]::15}" == '  duration_ms: ' ]
     [ "${lines[5]}" == '  message: |' ]
-    [ "${lines[6]}" == '     (in test file test/fixtures/bats/failing.bats, line 4)"' ]
-    [ "${lines[7]}" == "       \`eval \"( exit \${STATUS:-1} )\"' failed\"" ]
+    [ "${lines[6]}" == "    (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 4)" ]
+    [ "${lines[7]}" == "      \`eval \"( exit \${STATUS:-1} )\"' failed" ]
     [ "${lines[8]}" == '  ...' ]
     [ "${#lines[@]}" -eq 9 ]
 }


### PR DESCRIPTION
Fixes #555