### PR TITLE
README.md: Remove '2018' from headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bats-core: Bash Automated Testing System (2018)
+# Bats-core: Bash Automated Testing System
 
 [![Latest release](https://img.shields.io/github/release/bats-core/bats-core.svg)](https://github.com/bats-core/bats-core/releases/latest)
 [![npm package](https://img.shields.io/npm/v/bats.svg)](https://www.npmjs.com/package/bats)
@@ -115,7 +115,7 @@ There was an initial [call for maintainers][call-maintain] for the original Bats
 
 ## Copyright
 
-© 2017-2021 bats-core organization
+© 2017-2022 bats-core organization
 
 © 2011-2016 Sam Stephenson
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 #### Documentation
 
 * document `$BATS_VERSION` (#557)
+* remove 2018 in title, update copyright dates in README.md (#567)
 
 ### Fixed
 


### PR DESCRIPTION
I think the "2018" is now no longer needed, and only introduces unnecessary questions in the readers mind.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
