### PR TITLE
usage.md: Fix link syntax

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,6 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 #### Documentation
 
 * document `$BATS_VERSION` (#557)
-* remove 2018 in title, update copyright dates in README.md (#567)
 
 ### Fixed
 
@@ -27,6 +26,11 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * print name of failing test when using TAP13 with timing information (#559, #555)
 * removed broken symlink, added regression test (#560)
 * don't show empty lines as `#` with pretty formatter  (#561)
+
+#### Documentation
+
+* remove 2018 in title, update copyright dates in README.md (#567)
+* fix broken links (#568)
 
 ## [1.6.0] - 2022-02-24
 

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -32,7 +32,7 @@ $ bats addition.bats
 
 If Bats is not connected to a terminal—in other words, if you run it from a
 continuous integration system, or redirect its output to a file—the results are
-displayed in human-readable, machine-parsable [TAP format][https://testanything.org].
+displayed in human-readable, machine-parsable [TAP format][tap-format].
 
 You can force TAP output from a terminal by invoking Bats with the `--formatter tap`
 option.
@@ -91,4 +91,5 @@ If you have files where tests within the file would interfere with each other, y
 If you want more finegrained control, you can `export BATS_NO_PARALLELIZE_WITHIN_FILE=true` in `setup_file()`
 or outside any function to disable parallelization only within the containing file.
 
+[tap-format]: https://testanything.org
 [gnu-parallel]: https://www.gnu.org/software/parallel/


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
