### PR TITLE
Docs: change reference from (deleted) `=<exit-code>` syntax to `-<exit-code>`

### DIFF
--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -59,7 +59,7 @@ If invoked with one of the following as the first argument, `run`
 will perform an implicit check on the exit status of the invoked command:
 
 ```pre
-    =N  expect exit status N (0-255), fail if otherwise
+    -N  expect exit status N (0-255), fail if otherwise
     ! expect nonzero exit status (1-255), fail if command succeeds
 ```
 


### PR DESCRIPTION
As per #578, this PR commit ~temporarily~ stops telling users about a removed feature, and tells them about its replacement.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
