### PR TITLE
Fix: `run --keep-empty-lines` reported one line for empty output, should be zero

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * don't show empty lines as `#` with pretty formatter  (#561)
 * prevent `teardown`, `teardown_file`, and `teardown_suite` from overriding bats'
   exit code by setting `$status` (e.g. via calling `run`) (#581, #575)
+* `run --keep-empty-lines` now reports 0 lines on empty `$output` (#583)
 
 #### Documentation
 

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -175,9 +175,11 @@ bats_separate_lines() { # <output-array> <input-var>
   local input_var_name="$2"
   if [[ $keep_empty_lines ]]; then
     local bats_separate_lines_lines=()
-    while IFS= read -r line; do
-      bats_separate_lines_lines+=("$line")
-    done <<<"${!input_var_name}"
+    if [[ -n "${!input_var_name}" ]]; then # avoid getting an empty line for empty input
+      while IFS= read -r line; do
+        bats_separate_lines_lines+=("$line")
+      done <<<"${!input_var_name}"
+    fi
     eval "${output_array_name}=(\"\${bats_separate_lines_lines[@]}\")"
   else
     # shellcheck disable=SC2034,SC2206

--- a/test/run.bats
+++ b/test/run.bats
@@ -43,6 +43,12 @@ fixtures run
     [ ${#lines[@]} -eq 2 ]
 }
 
+@test "--keep-empty-lines has zero lines for empty output (see #573)" {
+    run --keep-empty-lines true
+    printf "'%s'\n" "${lines[@]}"
+    [ ${#lines[@]} -eq 0 ]
+}
+
 print-stderr-stdout() {
     printf stdout
     printf stderr >&2


### PR DESCRIPTION
Fixes #573 