### PR TITLE
Add bats_require_minimum_version and use for BW02

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,8 +15,11 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * Pretty formatter print filename when entering file (#561)
 * BATS_TEST_NAME_PREFIX allows prefixing test names on stdout and in reports (#561)
 * setup_suite and teardown_suite (#571, #585)
-* out-of-band warning infrastructure and first warning BW01 
-  (run command not found) (#586)
+* out-of-band warning infrastructure, with following warnings:
+  * BW01: run command not found (exit code 127)  (#586)
+  * BW02: run uses flags without proper `bats_require_minimum_version` guard (#587)
+* `bats_require_minimum_version` to guard code that would not run on older
+  versions (#587)
 
 #### Documentation
 
@@ -31,6 +34,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * don't show empty lines as `#` with pretty formatter  (#561)
 * prevent `teardown`, `teardown_file`, and `teardown_suite` from overriding bats'
   exit code by setting `$status` (e.g. via calling `run`) (#581, #575)
+  * **CRITICAL**: this can return exit code 0 despite failed tests, thus preventing
+    your CI from reporting test failures! The regression happened in version 1.6.0.
 * `run --keep-empty-lines` now reports 0 lines on empty `$output` (#583)
 
 #### Documentation

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'bats-core'
-copyright = '2021, bats-core organization'
+copyright = '2022, bats-core organization'
 author = 'bats-core organization'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,4 +14,4 @@ Versions before v1.2.1 are documented over `there <https://github.com/bats-core/
    writing-tests
    gotchas
    faq
-
+   warnings/index

--- a/docs/source/warnings/BW01.rst
+++ b/docs/source/warnings/BW01.rst
@@ -1,0 +1,17 @@
+BW01: `run`'s command `<command>` exited with code 127, indicating 'Command not found'. Use run's return code checks, e.g. `run -127`, to fix this message.
+===========================================================================================================================================================
+
+Due to `run`'s default behavior of always succeeding, errors in the command string can remain hidden from the user, e.g.[here](https://github.com/bats-core/bats-core/issues/578).
+As a proxy for this problem, the return code is checked for value 127 ("Command not found").
+
+How to fix
+----------
+
+If your command should actually return code 127, then you can simply use `run -127 <your command>` to state your intent and the message will go away.
+
+If your command should not return 127, you should fix the problem with the command.
+Take a careful look at the command string in the warning message, to see if it contains code that you did not intend to run.
+
+If your command should sometimes return 127, but never 0, you can use `run ! <your command>`.
+
+If your command can sometimes return 127 and sometimes 0, the please submit an issue.

--- a/docs/source/warnings/BW02.rst
+++ b/docs/source/warnings/BW02.rst
@@ -1,0 +1,46 @@
+BW02: <feature> requires at least BATS_VERSION=<version>. Use `bats_require_minimum_version <version>` to fix this message.
+===========================================================================================================================
+
+Using a feature that is only available starting with a certain version can be a problem when your tests also run on older versions of Bats.
+In most cases, running this code in older versions will generate an error due to a missing command.
+However, in cases like `run`'s where old version simply take all parameters as command to execute, the failure can be silent.
+
+How to fix
+----------
+
+When you encounter this warning, you can simply guard your code with `bats_require_minimum_version <version>` as the message says.
+For example, consider the following code:
+
+.. code-block:: bash
+
+    @test test {
+        bats_require_minimum_version 1.5.0
+        # pre 1.5.0 the flag --separate-stderr would be interpreted as command to run
+        run --separate-stderr some-command 
+        [ $output = "blablabla" ]
+    }
+
+
+The call to `bats_require_minimum_version` can be put anywhere before the warning generating command, even in `setup`, `setup_file`, or even outside any function.
+This can be used to give fine control over the version dependencies:
+
+.. code-block:: bash
+
+    @test test {
+        bats_require_minimum_version 1.5.0
+        # pre 1.5.0 the flag --separate-stderr would be interpreted as command to run
+        run --separate-stderr some-command 
+        [ $output = "blablabla" ]
+    }
+
+    @test test2 {
+        run some-other-command # no problem executing on earlier version
+    }
+
+
+If the above code is executed on a system with a `BATS_VERSION` pre 1.5.0, the first test will fail on `bats_require_minimum_version 1.5.0`.
+
+Instances:
+----------
+
+- run's non command parameters like `--keep-empty-lines` are only available since 1.5.0

--- a/docs/source/warnings/index.rst
+++ b/docs/source/warnings/index.rst
@@ -1,0 +1,4 @@
+.. toctree::
+
+    BW01
+    BW02

--- a/lib/bats-core/common.bash
+++ b/lib/bats-core/common.bash
@@ -22,3 +22,44 @@ function bats_replace_filename() {
 bats_quote_code() { # <var> <code>
 	printf -v "$1" -- "%s%s%s" "$BATS_BEGIN_CODE_QUOTE" "$2" "$BATS_END_CODE_QUOTE"
 }
+
+bats_check_valid_version() {
+  if [[ ! $1 =~ [0-9]+.[0-9]+.[0-9]+ ]]; then
+    printf "ERROR: version '%s' must be of format <major>.<minor>.<patch>!\n" "$1" >&2
+    exit 1
+  fi
+}
+
+# compares two versions. Return 0 when version1 < version2
+bats_version_lt() { # <version1> <version2>
+  bats_check_valid_version "$1"
+  bats_check_valid_version "$2"
+
+  local -a version1_parts version2_parts
+  IFS=. read -ra version1_parts <<< "$1"
+  IFS=. read -ra version2_parts <<< "$2"
+
+  for i in {0..2}; do
+    if (( version1_parts[i] < version2_parts[i] )); then
+      return 0
+    elif (( version1_parts[i] > version2_parts[i] )); then
+      return 1
+    fi
+  done
+  # if we made it this far, they are equal -> also not less then
+  return 2 # use other failing return code to distinguish equal from gt
+}
+
+# ensure a minimum version of bats is running or exit with failure
+bats_require_minimum_version() { # <required version>
+  local required_minimum_version=$1
+
+  if bats_version_lt "$BATS_VERSION" "$required_minimum_version"; then
+    printf "BATS_VERSION=%s does not meet required minimum %s\n" "$BATS_VERSION" "$required_minimum_version"
+    exit 1
+  fi
+
+  if bats_version_lt "$BATS_GUARANTEED_MINIMUM_VERSION" "$required_minimum_version"; then
+    BATS_GUARANTEED_MINIMUM_VERSION="$required_minimum_version"
+  fi
+}

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -198,8 +198,10 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
   local expected_rc=
   local keep_empty_lines=
   local output_case=merged
+  local has_flags=
   # parse options starting with -
   while [[ $# -gt 0 ]] && [[ $1 == -* || $1 == '!' ]]; do
+    has_flags=1
     case "$1" in
       '!')
         expected_rc=-1
@@ -231,6 +233,10 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
     esac
     shift
   done
+
+  if [[ -n $has_flags ]]; then
+    bats_warn_minimum_guaranteed_version "Using flags on \`run\`" 1.5.0
+  fi
 
   local pre_command=
 

--- a/lib/bats-core/warnings.bash
+++ b/lib/bats-core/warnings.bash
@@ -6,6 +6,7 @@ BATS_WARNING_SHORT_DESCS=(
   'PADDING'
   # see issue #578 for context
   "\`run\`'s command \`%s\` exited with code 127, indicating 'Command not found'. Use run's return code checks, e.g. \`run -127\`, to fix this message."
+  "%s requires at least BATS_VERSION=%s. Use \`bats_require_minimum_version %s\` to fix this message."
 )
 
 # generate a warning report for the parent call's call site
@@ -21,5 +22,12 @@ bats_generate_warning() { # <warning number> [<printf args for warning string>..
   else
     printf "Invalid Bats warning number '%s'. It must be an integer between 1 and %d." "$warning_number" "$((${#BATS_WARNING_SHORT_DESCS[@]} - 1))" >&2
     exit 1
+  fi
+}
+
+# generate a warning if the BATS_GUARANTEED_MINIMUM_VERSION is not high enough
+bats_warn_minimum_guaranteed_version() { # <feature> <minimum required version>
+  if bats_version_lt "$BATS_GUARANTEED_MINIMUM_VERSION" "$2"; then
+    bats_generate_warning 2 "$1" "$2" "$2"
   fi
 }

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -88,6 +88,7 @@ export PATH="$BATS_LIBEXEC:$PATH"
 export BATS_ROOT_PID=$$
 export BATS_TMPDIR="${TMPDIR:-/tmp}"
 export BATS_RUN_TMPDIR=
+export BATS_GUARANTEED_MINIMUM_VERSION=0.0.0
 
 if [[ ! -d "${BATS_TMPDIR}" ]];then
   printf "Error: BATS_TMPDIR (%s) does not exist or is not a directory" "${BATS_TMPDIR}" >&2

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1062,6 +1062,7 @@ EOF
 }
 
 @test "pretty formatter summary is colorized red on failure" {
+  bats_require_minimum_version 1.5.0
   run -1 bats --pretty "$FIXTURE_ROOT/failing.bats"
   
   [ "${lines[4]}" == $'\033[0m\033[31;1m' ] # TODO: avoid checking for the leading reset too
@@ -1070,6 +1071,7 @@ EOF
 }
 
 @test "pretty formatter summary is colorized green on success" {
+  bats_require_minimum_version 1.5.0
   run -0 bats --pretty "$FIXTURE_ROOT/passing.bats"
 
   [ "${lines[2]}" == $'\033[0m\033[32;1m' ] # TODO: avoid checking for the leading reset too
@@ -1094,6 +1096,7 @@ EOF
 }
 
 @test "--show-output-of-passing-tests works as expected" {
+  bats_require_minimum_version 1.5.0
   run -0 bats --show-output-of-passing-tests "$FIXTURE_ROOT/show-output-of-passing-tests.bats"
   [ "${lines[0]}" == '1..1' ]
   [ "${lines[1]}" == 'ok 1 test' ]
@@ -1102,20 +1105,22 @@ EOF
 }
 
 @test "--verbose-run prints output" {
+  bats_require_minimum_version 1.5.0
   run -1 bats --verbose-run "$FIXTURE_ROOT/verbose-run.bats"
   [ "${lines[0]}" == '1..1' ]
   [ "${lines[1]}" == 'not ok 1 test' ]
-  [ "${lines[2]}" == "# (in test file $RELATIVE_FIXTURE_ROOT/verbose-run.bats, line 2)" ]
+  [ "${lines[2]}" == "# (in test file $RELATIVE_FIXTURE_ROOT/verbose-run.bats, line 3)" ]
   [ "${lines[3]}" == "#   \`run ! echo test' failed, expected nonzero exit code!" ]
   [ "${lines[4]}" == '# test' ]
   [ ${#lines[@]} -eq 5 ]
 }
 
 @test "BATS_VERBOSE_RUN=1 also prints output" {
+  bats_require_minimum_version 1.5.0
   run -1 env BATS_VERBOSE_RUN=1 bats "$FIXTURE_ROOT/verbose-run.bats"
   [ "${lines[0]}" == '1..1' ]
   [ "${lines[1]}" == 'not ok 1 test' ]
-  [ "${lines[2]}" == "# (in test file $RELATIVE_FIXTURE_ROOT/verbose-run.bats, line 2)" ]
+  [ "${lines[2]}" == "# (in test file $RELATIVE_FIXTURE_ROOT/verbose-run.bats, line 3)" ]
   [ "${lines[3]}" == "#   \`run ! echo test' failed, expected nonzero exit code!" ]
   [ "${lines[4]}" == '# test' ]
   [ ${#lines[@]} -eq 5 ]
@@ -1152,6 +1157,7 @@ EOF
     skip "this test requires flock not to be installed"
   fi
 
+  bats_require_minimum_version 1.5.0
   run ! bats --jobs 2 "$FIXTURE_ROOT/parallel.bats"
   [ "${lines[0]}" == "ERROR: flock/shlock is required for parallelization within files!" ]
   [ "${#lines[@]}" -eq 1 ]
@@ -1162,6 +1168,7 @@ EOF
 }
 
 @test "BATS_CODE_QUOTE_STYLE works with any two characters (even unicode)" {
+  bats_require_minimum_version 1.5.0
   BATS_CODE_QUOTE_STYLE='``' run -1 bats --tap "${FIXTURE_ROOT}/failing.bats"
   # shellcheck disable=SC2016
   [ "${lines[3]}" == '#   `eval "( exit ${STATUS:-1} )"` failed' ]
@@ -1172,6 +1179,8 @@ EOF
     # for example, this happens on windows!
     skip 'Unicode chars are not counted as one char in this system'
   fi
+
+  bats_require_minimum_version 1.5.0
   run -1 bats --tap "${FIXTURE_ROOT}/failing.bats"
   # shellcheck disable=SC2016
   [ "${lines[3]}" == '#   😁eval "( exit ${STATUS:-1} )"😂 failed' ]
@@ -1180,6 +1189,8 @@ EOF
 @test "BATS_CODE_QUOTE_STYLE=custom requires BATS_CODE_QUOTE_BEGIN/END" {
   # unset because they are set in the surrounding scope
   unset BATS_BEGIN_CODE_QUOTE BATS_END_CODE_QUOTE
+
+  bats_require_minimum_version 1.5.0
 
   BATS_CODE_QUOTE_STYLE=custom run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
   [ "${lines[0]}" == 'ERROR: BATS_CODE_QUOTE_STYLE=custom requires BATS_BEGIN_CODE_QUOTE and BATS_END_CODE_QUOTE to be set' ]
@@ -1194,6 +1205,7 @@ EOF
 }
 
 @test "Warn about invalid BATS_CODE_QUOTE_STYLE" {
+  bats_require_minimum_version 1.5.0
   BATS_CODE_QUOTE_STYLE='' run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
   [ "${lines[0]}" == 'ERROR: Unknown BATS_CODE_QUOTE_STYLE: ' ]
 
@@ -1240,6 +1252,7 @@ EOF
   # add variables that should be ignored like PIPESTATUS here
   BASH_DECLARED_VARIABLES=$(env -i PIPESTATUS= "$BASH" -c "declare -p")
   local BATS_DECLARED_VARIABLES_FILE="${BATS_TEST_TMPDIR}/variables.log"
+  bats_require_minimum_version 1.5.0
   # now capture bats @test environment
   run -0 env -i PATH="$PATH" BATS_DECLARED_VARIABLES_FILE="$BATS_DECLARED_VARIABLES_FILE"  bash "${BATS_ROOT}/bin/bats" "${FIXTURE_ROOT}/issue-519.bats"
   # use function to allow failing via !, run is a bit unwiedly with the pipe and subshells
@@ -1255,6 +1268,7 @@ EOF
 @test "Don't wait for disowned background jobs to finish because of open FDs (#205)" {
     SECONDS=0
     export LOG_FILE="$BATS_TEST_TMPDIR/fds.log"
+    bats_require_minimum_version 1.5.0
     run -0 bats --show-output-of-passing-tests --tap "${FIXTURE_ROOT}/issue-205.bats"
     echo "Whole suite took: $SECONDS seconds"
     FDS_LOG=$(<"$LOG_FILE")
@@ -1270,6 +1284,7 @@ EOF
 }
 
 @test "Setting status in teardown* does not override exit code (see issue #575)" {
+  bats_require_minimum_version 1.5.0
   TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=0 run -0 bats "$FIXTURE_ROOT/teardown_override_status.bats"
   TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=0 run -1 bats "$FIXTURE_ROOT/teardown_override_status.bats"
   TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=1 STATUS=0 run -1 bats "$FIXTURE_ROOT/teardown_override_status.bats"

--- a/test/common.bats
+++ b/test/common.bats
@@ -1,0 +1,39 @@
+@test bats_version_lt {
+    run ! bats_version_lt 1.0.0   1.0
+    [ "$output" = "ERROR: version '1.0' must be of format <major>.<minor>.<patch>!" ]
+
+    run ! bats_version_lt 1.0   1.0.0
+    [ "$output" = "ERROR: version '1.0' must be of format <major>.<minor>.<patch>!" ]
+
+    
+    run -0 bats_version_lt  1.0.0  2.0.0
+    run -0 bats_version_lt  1.2.0  2.0.0
+    run -0 bats_version_lt  1.2.3  2.0.0
+    run -0 bats_version_lt  1.0.0  1.1.0
+    run -0 bats_version_lt  1.0.2  1.1.0
+    run -0 bats_version_lt  1.0.0  1.0.1
+
+    run -1 bats_version_lt  2.0.0  1.0.0
+    run -1 bats_version_lt  2.0.0  1.2.0
+    run -1 bats_version_lt  2.0.0  1.2.3
+    run -1 bats_version_lt  1.1.0  1.0.0
+    run -1 bats_version_lt  1.1.0  1.0.2
+    run -1 bats_version_lt  1.0.1  1.0.0
+
+    run -2 bats_version_lt  1.0.0  1.0.0
+}
+
+@test bats_require_minimum_version {
+    [ "$BATS_GUARANTEED_MINIMUM_VERSION" = 0.0.0 ] # check default
+
+    bats_require_minimum_version 0.1.2 # (a version that should be safe not to fail)
+    [ "${BATS_GUARANTEED_MINIMUM_VERSION}" = 0.1.2 ]
+
+    # a higher version should upgrade
+    bats_require_minimum_version 0.2.3
+    [ "${BATS_GUARANTEED_MINIMUM_VERSION}" = 0.2.3 ]
+
+    # a lower version shoudl not change
+    bats_require_minimum_version 0.1.2
+    [ "${BATS_GUARANTEED_MINIMUM_VERSION}" = 0.2.3 ]
+}

--- a/test/common.bats
+++ b/test/common.bats
@@ -1,4 +1,6 @@
+
 @test bats_version_lt {
+    bats_require_minimum_version 1.5.0
     run ! bats_version_lt 1.0.0   1.0
     [ "$output" = "ERROR: version '1.0' must be of format <major>.<minor>.<patch>!" ]
 

--- a/test/file_setup_teardown.bats
+++ b/test/file_setup_teardown.bats
@@ -1,3 +1,5 @@
+bats_require_minimum_version 1.5.0
+
 load 'test_helper'
 fixtures file_setup_teardown
 

--- a/test/fixtures/bats/print_output_on_failure.bats
+++ b/test/fixtures/bats/print_output_on_failure.bats
@@ -1,7 +1,7 @@
 @test "no failure prints no output" {
     run echo success
 }
-
+bats_require_minimum_version 1.5.0 # don't be fooled by order, this will run before the test above!
 @test "failure prints output" {
     run -1 echo "fail hard"
 }

--- a/test/fixtures/bats/verbose-run.bats
+++ b/test/fixtures/bats/verbose-run.bats
@@ -1,3 +1,4 @@
 @test "test" {
+    bats_require_minimum_version 1.5.0
     run ! echo test
 }

--- a/test/fixtures/run/failing.bats
+++ b/test/fixtures/run/failing.bats
@@ -1,3 +1,4 @@
+bats_require_minimum_version 1.5.0
 @test "run -0 false" {
   run -0 false
 }

--- a/test/fixtures/warnings/BW01_check_exit_code_is_127.bats
+++ b/test/fixtures/warnings/BW01_check_exit_code_is_127.bats
@@ -1,3 +1,4 @@
 @test "Don't trigger BW01 with checked exit code 127" {
+    bats_require_minimum_version 1.5.0
     run -127 =0 actually-intended-command with some args
 }

--- a/test/fixtures/warnings/BW02.bats
+++ b/test/fixtures/warnings/BW02.bats
@@ -1,0 +1,3 @@
+@test "Trigger BW02" {
+    run --keep-empty-lines true
+}

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -140,6 +140,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 }
 
 @test "junit does not mark tests with FD 3 output in teardown_file as failed (issue #531)" {
+  bats_require_minimum_version 1.5.0
   run -0 bats --formatter junit "$FIXTURE_ROOT/issue_531.bats"
 
   [[ "${lines[2]}" == '<testsuite name="issue_531.bats" '*'>' ]]

--- a/test/load.bats
+++ b/test/load.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup() {
   load test_helper
   fixtures load

--- a/test/parallel.bats
+++ b/test/parallel.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 load test_helper
 fixtures parallel
 

--- a/test/run.bats
+++ b/test/run.bats
@@ -1,5 +1,6 @@
 load test_helper
 fixtures run
+bats_require_minimum_version 1.5.0
 
 @test "run --keep-empty-lines preserves leading empty lines" {
     run --keep-empty-lines -- echo -n $'\na'
@@ -90,19 +91,19 @@ print-stderr-stdout() {
   echo "$output"
   [ "${lines[0]}" == 1..5 ]
   [ "${lines[1]}" == "not ok 1 run -0 false" ]
-  [ "${lines[2]}" == "# (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 2)" ]
+  [ "${lines[2]}" == "# (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 3)" ]
   [ "${lines[3]}" == "#   \`run -0 false' failed, expected exit code 0, got 1" ]
   [ "${lines[4]}" == "not ok 2 run -1 echo hi" ]
-  [ "${lines[5]}" == "# (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 6)" ]
+  [ "${lines[5]}" == "# (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 7)" ]
   [ "${lines[6]}" == "#   \`run -1 echo hi' failed, expected exit code 1, got 0" ]
   [ "${lines[7]}" == "not ok 3 run -2 exit 3" ]
-  [ "${lines[8]}" == "# (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 10)" ]
+  [ "${lines[8]}" == "# (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 11)" ]
   [ "${lines[9]}" == "#   \`run -2 exit 3' failed, expected exit code 2, got 3" ]
   [ "${lines[10]}" == "not ok 4 run ! true" ]
-  [ "${lines[11]}" == "# (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 14)" ]
+  [ "${lines[11]}" == "# (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 15)" ]
   [ "${lines[12]}" == "#   \`run ! true' failed, expected nonzero exit code!" ]
   [ "${lines[13]}" == "not ok 5 run multiple pass/fails" ]
-  [ "${lines[14]}" == "# (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 21)" ]
+  [ "${lines[14]}" == "# (in test file ${RELATIVE_FIXTURE_ROOT}/failing.bats, line 22)" ]
   [ "${lines[15]}" == "#   \`run -1 /etc' failed, expected exit code 1, got 126" ]
 }
 

--- a/test/suite_setup_teardown.bats
+++ b/test/suite_setup_teardown.bats
@@ -1,5 +1,6 @@
 load test_helper
 fixtures suite_setup_teardown
+bats_require_minimum_version 1.5.0
 
 setup() {
     export LOGFILE="$BATS_TEST_TMPDIR/log"

--- a/test/trace.bats
+++ b/test/trace.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-
+bats_require_minimum_version 1.5.0
 setup() {
     load test_helper
     fixtures trace

--- a/test/warnings.bats
+++ b/test/warnings.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup() {
     load test_helper
     fixtures warnings
@@ -25,7 +27,7 @@ setup() {
     [ "${lines[1]}" == "ok 1 Trigger BW01" ]
     [ "${lines[2]}" == "The following warnings were encountered during tests:" ]
     [ "${lines[3]}" == "BW01: \`run\`'s command \`=0 actually-intended-command with some args\` exited with code 127, indicating 'Command not found'. Use run's return code checks, e.g. \`run -127\`, to fix this message." ]
-    [ "${lines[4]}" == "      (from function \`run' in file ${RELATIVE_BATS_ROOT}lib/bats-core/test_functions.bash, line 293," ]
+    [[ "${lines[4]}" == "      (from function \`run' in file ${RELATIVE_BATS_ROOT}lib/bats-core/test_functions.bash, line"* ]]
     [ "${lines[5]}" == "       in test file $RELATIVE_FIXTURE_ROOT/BW01.bats, line 3)" ]
 }
 
@@ -41,4 +43,15 @@ setup() {
     [ "${lines[0]}" == "1..1" ]
     [ "${lines[1]}" == "ok 1 Don't trigger BW01 with exit code !=127 and no check" ]
     [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "BW02 is printed when run uses parameters without guaranteed version >= 1.5.0" {
+    run -0 bats "$FIXTURE_ROOT/BW02.bats"
+    [ "${lines[0]}" == "1..1" ]
+    [ "${lines[1]}" == "ok 1 Trigger BW02" ]
+    [ "${lines[2]}" == "The following warnings were encountered during tests:" ]
+    [ "${lines[3]}" == "BW02: Using flags on \`run\` requires at least BATS_VERSION=1.5.0. Use \`bats_require_minimum_version 1.5.0\` to fix this message." ]
+    [[ "${lines[4]}" == "      (from function \`bats_warn_minimum_guaranteed_version' in file ${RELATIVE_BATS_ROOT}lib/bats-core/warnings.bash, line 31,"* ]]
+    [[ "${lines[5]}" == "       from function \`run' in file ${RELATIVE_BATS_ROOT}lib/bats-core/test_functions.bash, line"* ]]
+    [ "${lines[6]}" ==  "       in test file $RELATIVE_FIXTURE_ROOT/BW02.bats, line 2)" ]
 }


### PR DESCRIPTION
Fixes #556 

- adds bats_require_minimum_version
- adds BW02 (using run flags without requiring at least 1.5.0)
- add documentation for warnings