### PR TITLE
bats.7.ronn: Fix mispelling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,12 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
   versions >=1.5.0 (#593)
 * add documentation for `bats_require_minimum_version` (#595)
 
+### Fixed
+
+#### Documentation
+
+* typos (#596)
+
 ## [1.7.0] - 2022-05-14
 
 ### Added

--- a/man/bats.7.ronn
+++ b/man/bats.7.ronn
@@ -38,7 +38,7 @@ Options:
        --separate-stderr
                 split stderr and stdout
        --keep-empty-lines
-                retain emtpy lines in `${lines[@]}`/`${stderr_lines[@]}`
+                retain empty lines in `${lines[@]}`/`${stderr_lines[@]}`
 
 Many Bats tests need to run a command and then make assertions about
 its exit status and output. Bats includes a `run` helper that invokes


### PR DESCRIPTION
"em**tp**y" → "empty"

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
