### PR TITLE
warnings.bash: Add shebang

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ### Fixed
 
+* added missing shebang  (#597)
+
 #### Documentation
 
 * typos (#596)

--- a/lib/bats-core/warnings.bash
+++ b/lib/bats-core/warnings.bash
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # shellcheck source=lib/bats-core/tracing.bash
 source "$BATS_ROOT/lib/bats-core/tracing.bash"
 

--- a/test.bats
+++ b/test.bats
@@ -1,7 +1,0 @@
-teardown() {
-	false
-}
-
-@test test {
-	false
-}

--- a/test/warnings.bats
+++ b/test/warnings.bats
@@ -51,7 +51,7 @@ setup() {
     [ "${lines[1]}" == "ok 1 Trigger BW02" ]
     [ "${lines[2]}" == "The following warnings were encountered during tests:" ]
     [ "${lines[3]}" == "BW02: Using flags on \`run\` requires at least BATS_VERSION=1.5.0. Use \`bats_require_minimum_version 1.5.0\` to fix this message." ]
-    [[ "${lines[4]}" == "      (from function \`bats_warn_minimum_guaranteed_version' in file ${RELATIVE_BATS_ROOT}lib/bats-core/warnings.bash, line 31,"* ]]
+    [[ "${lines[4]}" == "      (from function \`bats_warn_minimum_guaranteed_version' in file ${RELATIVE_BATS_ROOT}lib/bats-core/warnings.bash, line 33,"* ]]
     [[ "${lines[5]}" == "       from function \`run' in file ${RELATIVE_BATS_ROOT}lib/bats-core/test_functions.bash, line"* ]]
     [ "${lines[6]}" ==  "       in test file $RELATIVE_FIXTURE_ROOT/BW02.bats, line 2)" ]
 }


### PR DESCRIPTION
Add a `#!/usr/bin/env bash` shebang, similarly to all other scripts in `lib/bash-core`.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
