### PR TITLE
Minor fix in Tutorial documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 #### Documentation
 
 * fix typos and links (#596, #604)
+* fix redirection order of an example in the tutorial (#617)
 
 ## [1.7.0] - 2022-05-14
 
@@ -412,7 +413,16 @@ Changes:
 
 * Initial public release.
 
-[Unreleased]: https://github.com/bats-core/bats-core/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/bats-core/bats-core/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/bats-core/bats-core/compare/v1.6.1...v1.7.0
+[1.6.1]: https://github.com/bats-core/bats-core/compare/v1.6.0...v1.6.1
+[1.6.0]: https://github.com/bats-core/bats-core/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/bats-core/bats-core/compare/v1.4.1...v1.5.0
+[1.4.1]: https://github.com/bats-core/bats-core/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/bats-core/bats-core/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/bats-core/bats-core/compare/v1.2.1...v1.3.0
+[1.2.1]: https://github.com/bats-core/bats-core/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/bats-core/bats-core/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/bats-core/bats-core/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/bats-core/bats-core/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/bats-core/bats-core/compare/v1.0.0...v1.0.1

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -567,7 +567,7 @@ As an example, we want to add an echo server capability to our project. First, w
     setup_file() {
         load 'test_helper/common-setup'
         _common_setup
-        PORT=$(project.sh start-echo-server >/dev/null 2>&1)
+        PORT=$(project.sh start-echo-server 2>&1 >/dev/null)
         export PORT
     }
 


### PR DESCRIPTION
In addition to the issue mentioned in #562, 
the example needs the following correction for a successful test.

The order of redirection is essential here.
As **project.sh** redirects $PORT on STDERR.

Just a request to the maintainers.
If the maintainers are thinking of rewriting the whole example, 
I would request them to accept this PR and then work on it.
This will help me in having my first PR in bats-core.
Closed PRs don't look well on the GitHub profile.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
