### PR TITLE
Fix docker: bats not found

### DIFF
--- a/.github/workflows/release_dockerhub.yml
+++ b/.github/workflows/release_dockerhub.yml
@@ -13,26 +13,36 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v2
+
         - id: version
           run: |
             EXPECTED_VERSION=${{ github.event.inputs.version }}
             TAG_VERSION=${GITHUB_REF#refs/tags/v} # refs/tags/v1.2.3 -> 1.2.3
             echo ::set-output name=version::${EXPECTED_VERSION:-$TAG_VERSION}
-        -
-          name: Set up QEMU
+        - name: Set up QEMU
           uses: docker/setup-qemu-action@v1
-        -
-          name: Login to DockerHub
+
+
+        - name: Login to DockerHub
           uses: docker/login-action@v1 
           with:
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
-        -
-          name: Set up Docker Buildx
+
+        - name: Set up Docker Buildx
           id: buildx
           uses: docker/setup-buildx-action@v1
+
         - uses: docker/build-push-action@v2
           with:
             platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
             tags: ${{ secrets.DOCKER_USERNAME }}/bats:${{ steps.version.outputs.version }},${{ secrets.DOCKER_USERNAME }}/bats:latest
             push: true
+
+        - uses: docker/build-push-action@v2
+          with:
+            platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+            tags: ${{ secrets.DOCKER_USERNAME }}/bats:${{ steps.version.outputs.version }}-no-faccessat2,${{ secrets.DOCKER_USERNAME }}/bats:latest-no-faccessat2
+            push: true
+            build-args:
+              - bashver: 5.1.4

--- a/.github/workflows/release_dockerhub.yml
+++ b/.github/workflows/release_dockerhub.yml
@@ -44,5 +44,4 @@ jobs:
             platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
             tags: ${{ secrets.DOCKER_USERNAME }}/bats:${{ steps.version.outputs.version }}-no-faccessat2,${{ secrets.DOCKER_USERNAME }}/bats:latest-no-faccessat2
             push: true
-            build-args:
-              - bashver: 5.1.4
+            build-args: bashver=5.1.4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * running only tests that failed in the last run via `--filter-status failed` (#483)
 * variable `BATS_TEST_RETRIES` that specifies how often a test should be
   reattempted before it is considered failed (#618)
+* Docker tags `latest-no-faccessat2` and `<bats-version\>-no-faccessat2` for
+  avoiding `bash: bats: No such file or directory` on `docker<20.10` (or
+  `runc<v1.0.0-rc93`) (#622)
 
 #### Documentation
 


### PR DESCRIPTION
Fixes #551 (and possibly #564) by adding two docker images with the -no-faccessat2 tag that rely on bash:5.1.4 as base image, which does not use that syscall.

Read [chilversc's comment](https://github.com/bats-core/bats-core/issues/564#issuecomment-1193011159) for more details about this.