### PR TITLE
chore: Fix a typo in tutorial

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,7 +43,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 #### Documentation
 
-* fix typos, spelling and links (#596, #604, #619)
+* fix typos, spelling and links (#596, #604, #619, #627)
 * fix redirection order of an example in the tutorial (#617)
 
 ## [1.7.0] - 2022-05-14

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -257,7 +257,7 @@ This is a common mistake that can happen when our mind parses the file different
 `run` is just a function, so the pipe won't actually be forwarded into the function. Bash reads this as `(run project.sh) | grep Welcome`, 
 instead of our intended `run (project.sh | grep Welcome)`.
 
-Unfortunately, the latter is no valid bash syntax, so we have to work around it, e.g. by using a function:
+Unfortunately, the latter is not valid bash syntax, so we have to work around it, e.g. by using a function:
 
 .. code-block:: bash
 


### PR DESCRIPTION
The tutorial contains this text:

> Unfortunately, the latter is no valid bash syntax, [..]

Unfortunately, this is _not_ valid English syntax 😉. The text now
reads:

> Unfortunately, the latter is not valid bash syntax, [..]

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
