### PR TITLE
Update github runner images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
   linux:
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-18.04']
+        os: ['ubuntu-20.04', 'ubuntu-22.04']
         env_vars:
           - ''
           # allow for some parallelity without GNU parallel, since it is not installed by default
@@ -47,7 +47,7 @@ jobs:
   npm_on_linux:
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-18.04']
+        os: ['ubuntu-20.04', 'ubuntu-22.04']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -84,7 +84,7 @@ jobs:
   macos:
     strategy:
       matrix:
-        os: ['macos-10.15']
+        os: ['macos-11', 'macos-12']
         env_vars:
           - ''
           # allow for some parallelity without GNU parallel, since it is not installed by default
@@ -105,7 +105,7 @@ jobs:
   npm_on_macos:
     strategy:
       matrix:
-        os: ['macos-10.15']
+        os: ['macos-11', 'macos-12']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -152,7 +152,7 @@ jobs:
           time docker run -it -v $PWD:/opt/bats alpine sh -c "apk add bash ncurses; /opt/bats/bin/bats  --print-output-on-failure --tap /opt/bats/test"
 
   freebsd:
-    runs-on: macos-10.15
+    runs-on: macos-12
     strategy:
       matrix:
         packages:
@@ -160,7 +160,7 @@ jobs:
           - ""
     steps:
       - uses: actions/checkout@v2
-      - uses: vmactions/freebsd-vm@v0.1.5
+      - uses: vmactions/freebsd-vm@v0
         with:
           prepare: pkg install -y bash parallel ${{ matrix.packages }}
           run: |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * `teardown_file` errors don't swallow `setup_file` errors anymore, the behavior
   is more like `teardown`'s now (only `return`/last command can trigger `teardown`
    errors) (#623)
+* upgraded from deprecated CI envs for MacOS (10 -> 11,12) and Ubuntu 
+  (18.04 -> 22.04) (#630)
 
 #### Documentation
 


### PR DESCRIPTION
Github deprecated and will remove two runner images

macos-10.15 will be removed on 2022-08-30
macos-12 is available
https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

ubuntu-18.04 will be removed on 2022-12-01
ubuntu-22.04 is available
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
