### PR TITLE
Fix further unbound variable errors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * fix unset variable in `bats-formatter-junit` when `setup_file` fails (#632)
 * unify error behavior of `teardown`/`teardown_file`/`teardown_suite` functions:
   only fail via return code, not via ERREXIT (#633)
+* fix unbound variable errors with `set -u` on `setup_suite` failures (#643)
 
 #### Documentation
 

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -122,8 +122,7 @@ bats_load_library_safe() { # <slug>
 
   # Check for library load paths in BATS_TEST_DIRNAME and BATS_LIB_PATH
   if [[ ${slug:0:1} != / ]]; then
-    find_in_bats_lib_path library_path "$slug"
-    if [[ -z "$library_path" ]]; then
+    if ! find_in_bats_lib_path library_path "$slug"; then
       printf "Could not find library '%s' relative to test file or in BATS_LIB_PATH\n" "$slug" >&2
       return 1
     fi

--- a/lib/bats-core/tracing.bash
+++ b/lib/bats-core/tracing.bash
@@ -17,7 +17,7 @@ bats_capture_stack_trace() {
 		funcname="${FUNCNAME[$i]}"
 		BATS_DEBUG_LAST_STACK_TRACE+=("${BASH_LINENO[$((i-1))]} $funcname $test_file")
 		case "$funcname" in
-		"$BATS_TEST_NAME" | setup | teardown | setup_file | teardown_file | setup_suite | teardown_suite)
+		"${BATS_TEST_NAME-}" | setup | teardown | setup_file | teardown_file | setup_suite | teardown_suite)
 			break
 			;;
 		esac
@@ -64,7 +64,7 @@ bats_print_stack_trace() {
 
 		local fn
 		bats_frame_function "$frame" 'fn'
-		if [[ "$fn" != "$BATS_TEST_NAME" ]] && 
+		if [[ "$fn" != "${BATS_TEST_NAME-}" ]] && 
 			# don't print "from function `source'"",
 			# when failing in free code during `source $test_file` from bats-exec-file
 			! [[ "$fn" == 'source' &&  $index -eq $count ]]; then 
@@ -128,7 +128,7 @@ bats_frame_filename() {
 	local __bff_filename="${1#* }"
 	__bff_filename="${__bff_filename#* }"
 
-	if [[ "$__bff_filename" == "$BATS_TEST_SOURCE" ]]; then
+	if [[ "$__bff_filename" == "${BATS_TEST_SOURCE-}" ]]; then
 		__bff_filename="$BATS_TEST_FILENAME"
 	fi
 	printf -v "$2" '%s' "$__bff_filename"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -33,7 +33,6 @@ setup() {
 }
 
 @test "invalid filename prints an error" {
-  whereis bats
   reentrant_run bats nonexistent
   [ $status -eq 1 ]
   [ "$(expr "$output" : ".*does not exist")" -ne 0 ]

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -3,74 +3,76 @@
 setup() {
   load test_helper
   fixtures bats
+  REENTRANT_RUN_PRESERVE+=(BATS_LIBEXEC)
 }
 
 @test "no arguments prints message and usage instructions" {
-  run bats
+  reentrant_run bats
   [ $status -eq 1 ]
   [ "${lines[0]}" == 'Error: Must specify at least one <test>' ]
   [ "${lines[1]%% *}" == 'Usage:' ]
 }
 
 @test "invalid option prints message and usage instructions" {
-  run bats --invalid-option
+  reentrant_run bats --invalid-option
   [ $status -eq 1 ]
   [ "${lines[0]}" == "Error: Bad command line option '--invalid-option'" ]
   [ "${lines[1]%% *}" == 'Usage:' ]
 }
 
 @test "-v and --version print version number" {
-  run bats -v
+  reentrant_run bats -v
   [ $status -eq 0 ]
   [ "$(expr "$output" : "Bats [0-9][0-9.]*")" -ne 0 ]
 }
 
 @test "-h and --help print help" {
-  run bats -h
+  reentrant_run bats -h
   [ $status -eq 0 ]
   [ "${#lines[@]}" -gt 3 ]
 }
 
 @test "invalid filename prints an error" {
-  run bats nonexistent
+  whereis bats
+  reentrant_run bats nonexistent
   [ $status -eq 1 ]
   [ "$(expr "$output" : ".*does not exist")" -ne 0 ]
 }
 
 @test "empty test file runs zero tests" {
-  run bats "$FIXTURE_ROOT/empty.bats"
+  reentrant_run bats "$FIXTURE_ROOT/empty.bats"
   [ $status -eq 0 ]
   [ "$output" = "1..0" ]
 }
 
 @test "one passing test" {
-  run bats "$FIXTURE_ROOT/passing.bats"
+  reentrant_run bats "$FIXTURE_ROOT/passing.bats"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..1" ]
   [ "${lines[1]}" = "ok 1 a passing test" ]
 }
 
 @test "summary passing tests" {
-  run filter_control_sequences bats -p "$FIXTURE_ROOT/passing.bats"
+  reentrant_run filter_control_sequences bats -p "$FIXTURE_ROOT/passing.bats"
   echo "$output"
   [ $status -eq 0 ]
   [ "${lines[2]}" = "1 test, 0 failures" ]
 }
 
 @test "summary passing and skipping tests" {
-  run filter_control_sequences bats -p "$FIXTURE_ROOT/passing_and_skipping.bats"
+  reentrant_run filter_control_sequences bats -p "$FIXTURE_ROOT/passing_and_skipping.bats"
   [ $status -eq 0 ]
   [ "${lines[4]}" = "3 tests, 0 failures, 2 skipped" ]
 }
 
 @test "summary passing and failing tests" {
-  run filter_control_sequences bats -p "$FIXTURE_ROOT/failing_and_passing.bats"
+  reentrant_run filter_control_sequences bats -p "$FIXTURE_ROOT/failing_and_passing.bats"
   [ $status -eq 0 ]
   [ "${lines[5]}" = "2 tests, 1 failure" ]
 }
 
 @test "summary passing, failing and skipping tests" {
-  run filter_control_sequences bats -p "$FIXTURE_ROOT/passing_failing_and_skipping.bats"
+  reentrant_run filter_control_sequences bats -p "$FIXTURE_ROOT/passing_failing_and_skipping.bats"
   [ $status -eq 0 ]
   [ "${lines[6]}" = "3 tests, 1 failure, 1 skipped" ]
 }
@@ -83,7 +85,7 @@ setup() {
 }
 
 @test "one failing test" {
-  run bats "$FIXTURE_ROOT/failing.bats"
+  reentrant_run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
   [ "${lines[0]}" = '1..1' ]
   [ "${lines[1]}" = 'not ok 1 a failing test' ]
@@ -92,7 +94,7 @@ setup() {
 }
 
 @test "one failing and one passing test" {
-  run bats "$FIXTURE_ROOT/failing_and_passing.bats"
+  reentrant_run bats "$FIXTURE_ROOT/failing_and_passing.bats"
   [ $status -eq 1 ]
   [ "${lines[0]}" = '1..2' ]
   [ "${lines[1]}" = 'not ok 1 a failing test' ]
@@ -102,13 +104,13 @@ setup() {
 }
 
 @test "failing test with significant status" {
-  STATUS=2 run bats "$FIXTURE_ROOT/failing.bats"
+  STATUS=2 reentrant_run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
   [ "${lines[3]}" = "#   \`eval \"( exit \${STATUS:-1} )\"' failed with status 2" ]
 }
 
 @test "failing helper function logs the test case's line number" {
-  run bats "$FIXTURE_ROOT/failing_helper.bats"
+  reentrant_run bats "$FIXTURE_ROOT/failing_helper.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'not ok 1 failing helper function' ]
   [ "${lines[2]}" = "# (from function \`failing_helper' in file $RELATIVE_FIXTURE_ROOT/test_helper.bash, line 6," ]
@@ -117,7 +119,7 @@ setup() {
 }
 
 @test "failing bash condition logs correct line number" {
-  run bats "$FIXTURE_ROOT/failing_with_bash_cond.bats"
+  reentrant_run bats "$FIXTURE_ROOT/failing_with_bash_cond.bats"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 4 ]
   [ "${lines[1]}" = 'not ok 1 a failing test' ]
@@ -126,7 +128,7 @@ setup() {
 }
 
 @test "failing bash expression logs correct line number" {
-  run bats "$FIXTURE_ROOT/failing_with_bash_expression.bats"
+  reentrant_run bats "$FIXTURE_ROOT/failing_with_bash_expression.bats"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 4 ]
   [ "${lines[1]}" = 'not ok 1 a failing test' ]
@@ -135,7 +137,7 @@ setup() {
 }
 
 @test "failing negated command logs correct line number" {
-  run bats "$FIXTURE_ROOT/failing_with_negated_command.bats"
+  reentrant_run bats "$FIXTURE_ROOT/failing_with_negated_command.bats"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 4 ]
   [ "${lines[1]}" = 'not ok 1 a failing test' ]
@@ -144,32 +146,38 @@ setup() {
 }
 
 @test "test environments are isolated" {
-  run bats "$FIXTURE_ROOT/environment.bats"
+  reentrant_run bats "$FIXTURE_ROOT/environment.bats"
   [ $status -eq 0 ]
 }
 
 @test "setup is run once before each test" {
   unset BATS_NUMBER_OF_PARALLEL_JOBS BATS_NO_PARALLELIZE_ACROSS_FILES
+
   # shellcheck disable=SC2031,SC2030
   export BATS_TEST_SUITE_TMPDIR="${BATS_TEST_TMPDIR}"
-  run bats "$FIXTURE_ROOT/setup.bats"
+  REENTRANT_RUN_PRESERVE+=(BATS_TEST_SUITE_TMPDIR)
+
+  reentrant_run bats "$FIXTURE_ROOT/setup.bats"
   [ $status -eq 0 ]
-  run cat "$BATS_TEST_SUITE_TMPDIR/setup.log"
+  reentrant_run cat "$BATS_TEST_SUITE_TMPDIR/setup.log"
   [ ${#lines[@]} -eq 3 ]
 }
 
 @test "teardown is run once after each test, even if it fails" {
   unset BATS_NUMBER_OF_PARALLEL_JOBS BATS_NO_PARALLELIZE_ACROSS_FILES
+
   # shellcheck disable=SC2031,SC2030
   export BATS_TEST_SUITE_TMPDIR="${BATS_TEST_TMPDIR}"
-  run bats "$FIXTURE_ROOT/teardown.bats"
+  REENTRANT_RUN_PRESERVE+=(BATS_TEST_SUITE_TMPDIR)
+
+  reentrant_run bats "$FIXTURE_ROOT/teardown.bats"
   [ $status -eq 1 ]
-  run cat "$BATS_TEST_SUITE_TMPDIR/teardown.log"
+  reentrant_run cat "$BATS_TEST_SUITE_TMPDIR/teardown.log"
   [ ${#lines[@]} -eq 3 ]
 }
 
 @test "setup failure" {
-  run bats "$FIXTURE_ROOT/failing_setup.bats"
+  reentrant_run bats "$FIXTURE_ROOT/failing_setup.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'not ok 1 truth' ]
   [ "${lines[2]}" = "# (from function \`setup' in test file $RELATIVE_FIXTURE_ROOT/failing_setup.bats, line 2)" ]
@@ -177,7 +185,7 @@ setup() {
 }
 
 @test "passing test with teardown failure" {
-  PASS=1 run bats "$FIXTURE_ROOT/failing_teardown.bats"
+  PASS=1 reentrant_run bats "$FIXTURE_ROOT/failing_teardown.bats"
   [ $status -eq 1 ]
   echo "$output"
   [ "${lines[1]}" = 'not ok 1 truth' ]
@@ -186,7 +194,7 @@ setup() {
 }
 
 @test "failing test with teardown failure" {
-  PASS=0 run bats "$FIXTURE_ROOT/failing_teardown.bats"
+  PASS=0 reentrant_run bats "$FIXTURE_ROOT/failing_teardown.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" =  'not ok 1 truth' ]
   [ "${lines[2]}" =  "# (in test file $RELATIVE_FIXTURE_ROOT/failing_teardown.bats, line 6)" ]
@@ -194,20 +202,20 @@ setup() {
 }
 
 @test "teardown failure with significant status" {
-  PASS=1 STATUS=2 run bats "$FIXTURE_ROOT/failing_teardown.bats"
+  PASS=1 STATUS=2 reentrant_run bats "$FIXTURE_ROOT/failing_teardown.bats"
   [ $status -eq 1 ]
   [ "${lines[3]}" = "#   \`eval \"( exit \${STATUS:-1} )\"' failed with status 2" ]
 }
 
 @test "failing test file outside of BATS_CWD" {
   cd "${BATS_TEST_TMPDIR}"
-  run bats "$FIXTURE_ROOT/failing.bats"
+  reentrant_run bats "$FIXTURE_ROOT/failing.bats"
   [ $status -eq 1 ]
   [ "${lines[2]}" = "# (in test file $FIXTURE_ROOT/failing.bats, line 4)" ]
 }
 
 @test "output is discarded for passing tests and printed for failing tests" {
-  run bats "$FIXTURE_ROOT/output.bats"
+  reentrant_run bats "$FIXTURE_ROOT/output.bats"
   [ $status -eq 1 ]
   [ "${lines[6]}"  = '# failure stdout 1' ]
   [ "${lines[7]}"  = '# failure stdout 2' ]
@@ -215,34 +223,34 @@ setup() {
 }
 
 @test "-c prints the number of tests" {
-  run bats -c "$FIXTURE_ROOT/empty.bats"
+  reentrant_run bats -c "$FIXTURE_ROOT/empty.bats"
   [ $status -eq 0 ]
   [ "$output" = 0 ]
 
-  run bats -c "$FIXTURE_ROOT/output.bats"
+  reentrant_run bats -c "$FIXTURE_ROOT/output.bats"
   [ $status -eq 0 ]
   [ "$output" = 4 ]
 }
 
 @test "dash-e is not mangled on beginning of line" {
-  run bats "$FIXTURE_ROOT/intact.bats"
+  reentrant_run bats "$FIXTURE_ROOT/intact.bats"
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 dash-e on beginning of line" ]
 }
 
 @test "dos line endings are stripped before testing" {
-  run bats "$FIXTURE_ROOT/dos_line_no_shellcheck.bats"
+  reentrant_run bats "$FIXTURE_ROOT/dos_line_no_shellcheck.bats"
   [ $status -eq 0 ]
 }
 
 @test "test file without trailing newline" {
-  run bats "$FIXTURE_ROOT/without_trailing_newline.bats"
+  reentrant_run bats "$FIXTURE_ROOT/without_trailing_newline.bats"
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 truth" ]
 }
 
 @test "skipped tests" {
-  run bats "$FIXTURE_ROOT/skipped.bats"
+  reentrant_run bats "$FIXTURE_ROOT/skipped.bats"
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 a skipped test # skip" ]
   [ "${lines[2]}" = "ok 2 a skipped test with a reason # skip a reason" ]
@@ -250,7 +258,7 @@ setup() {
 
 @test "extended syntax" {
   emulate_bats_env
-  run bats-exec-suite -x "$FIXTURE_ROOT/failing_and_passing.bats"
+  reentrant_run bats-exec-suite -x "$FIXTURE_ROOT/failing_and_passing.bats"
   echo "$output"
   [ $status -eq 1 ]
   [ "${lines[1]}" = "suite $FIXTURE_ROOT/failing_and_passing.bats" ]
@@ -261,7 +269,7 @@ setup() {
 }
 
 @test "timing syntax" {
-  run bats -T "$FIXTURE_ROOT/failing_and_passing.bats"
+  reentrant_run bats -T "$FIXTURE_ROOT/failing_and_passing.bats"
   echo "$output"
   [ $status -eq 1 ]
   regex='not ok 1 a failing test in [0-9]+ms'
@@ -272,7 +280,7 @@ setup() {
 
 @test "extended timing syntax" {
   emulate_bats_env
-  run bats-exec-suite -x -T "$FIXTURE_ROOT/failing_and_passing.bats"
+  reentrant_run bats-exec-suite -x -T "$FIXTURE_ROOT/failing_and_passing.bats"
   echo "$output"
   [ $status -eq 1 ]
   regex="not ok 1 a failing test in [0-9]+ms"
@@ -285,7 +293,7 @@ setup() {
 
 @test "time is greater than 0ms for long test" {
   emulate_bats_env
-  run bats-exec-suite -x -T "$FIXTURE_ROOT/run_long_command.bats"
+  reentrant_run bats-exec-suite -x -T "$FIXTURE_ROOT/run_long_command.bats"
   echo "$output"
   [ $status -eq 0 ]
   regex="ok 1 run long command in [1-9][0-9]*ms"
@@ -293,7 +301,7 @@ setup() {
 }
 
 @test "single-line tests" {
-  run bats "$FIXTURE_ROOT/single_line_no_shellcheck.bats"
+  reentrant_run bats "$FIXTURE_ROOT/single_line_no_shellcheck.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" =  'ok 1 empty' ]
   [ "${lines[2]}" =  'ok 2 passing' ]
@@ -304,19 +312,19 @@ setup() {
 }
 
 @test "testing IFS not modified by run" {
-  run bats "$FIXTURE_ROOT/loop_keep_IFS.bats"
+  reentrant_run bats "$FIXTURE_ROOT/loop_keep_IFS.bats"
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 loop_func" ]
 }
 
 @test "expand variables in test name" {
-  SUITE='test/suite' run bats "$FIXTURE_ROOT/expand_var_in_test_name.bats"
+  SUITE='test/suite' reentrant_run bats "$FIXTURE_ROOT/expand_var_in_test_name.bats"
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 test/suite: test with variable in name" ]
 }
 
 @test "handle quoted and unquoted test names" {
-  run bats "$FIXTURE_ROOT/quoted_and_unquoted_test_names_no_shellcheck.bats"
+  reentrant_run bats "$FIXTURE_ROOT/quoted_and_unquoted_test_names_no_shellcheck.bats"
   [ $status -eq 0 ]
   [ "${lines[1]}" = "ok 1 single-quoted name" ]
   [ "${lines[2]}" = "ok 2 double-quoted name" ]
@@ -379,7 +387,7 @@ END_OF_ERR_MSG
 }
 
 @test "parse @test lines with various whitespace combinations" {
-  run bats "$FIXTURE_ROOT/whitespace_no_shellcheck.bats"
+  reentrant_run bats "$FIXTURE_ROOT/whitespace_no_shellcheck.bats"
   [ $status -eq 0 ]
   [ "${lines[1]}" = 'ok 1 no extra whitespace' ]
   [ "${lines[2]}" = 'ok 2 tab at beginning of line' ]
@@ -395,7 +403,7 @@ END_OF_ERR_MSG
 }
 
 @test "duplicate tests error and generate a warning on stderr" {
-  run bats --tap "$FIXTURE_ROOT/duplicate-tests_no_shellcheck.bats"
+  reentrant_run bats --tap "$FIXTURE_ROOT/duplicate-tests_no_shellcheck.bats"
   [ $status -eq 1 ]
 
   local expected='Error: Duplicate test name(s) in file '
@@ -410,7 +418,7 @@ END_OF_ERR_MSG
 }
 
 @test "sourcing a nonexistent file in setup produces error output" {
-  run bats "$FIXTURE_ROOT/source_nonexistent_file_in_setup.bats"
+  reentrant_run bats "$FIXTURE_ROOT/source_nonexistent_file_in_setup.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'not ok 1 sourcing nonexistent file fails in setup' ]
   [ "${lines[2]}" = "# (from function \`setup' in test file $RELATIVE_FIXTURE_ROOT/source_nonexistent_file_in_setup.bats, line 3)" ]
@@ -418,7 +426,7 @@ END_OF_ERR_MSG
 }
 
 @test "referencing unset parameter in setup produces error output" {
-  run bats "$FIXTURE_ROOT/reference_unset_parameter_in_setup.bats"
+  reentrant_run bats "$FIXTURE_ROOT/reference_unset_parameter_in_setup.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'not ok 1 referencing unset parameter fails in setup' ]
   [ "${lines[2]}" = "# (from function \`setup' in test file $RELATIVE_FIXTURE_ROOT/reference_unset_parameter_in_setup.bats, line 4)" ]
@@ -426,7 +434,7 @@ END_OF_ERR_MSG
 }
 
 @test "sourcing a nonexistent file in test produces error output" {
-  run bats "$FIXTURE_ROOT/source_nonexistent_file.bats"
+  reentrant_run bats "$FIXTURE_ROOT/source_nonexistent_file.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'not ok 1 sourcing nonexistent file fails' ]
   [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/source_nonexistent_file.bats, line 3)" ]
@@ -434,7 +442,7 @@ END_OF_ERR_MSG
 }
 
 @test "referencing unset parameter in test produces error output" {
-  run bats "$FIXTURE_ROOT/reference_unset_parameter.bats"
+  reentrant_run bats "$FIXTURE_ROOT/reference_unset_parameter.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'not ok 1 referencing unset parameter fails' ]
   [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/reference_unset_parameter.bats, line 4)" ]
@@ -442,7 +450,7 @@ END_OF_ERR_MSG
 }
 
 @test "sourcing a nonexistent file in teardown produces error output" {
-  run bats "$FIXTURE_ROOT/source_nonexistent_file_in_teardown.bats"
+  reentrant_run bats "$FIXTURE_ROOT/source_nonexistent_file_in_teardown.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'not ok 1 sourcing nonexistent file fails in teardown' ]
   [ "${lines[2]}" = "# (from function \`teardown' in test file $RELATIVE_FIXTURE_ROOT/source_nonexistent_file_in_teardown.bats, line 3)" ]
@@ -450,7 +458,7 @@ END_OF_ERR_MSG
 }
 
 @test "referencing unset parameter in teardown produces error output" {
-  run bats "$FIXTURE_ROOT/reference_unset_parameter_in_teardown.bats"
+  reentrant_run bats "$FIXTURE_ROOT/reference_unset_parameter_in_teardown.bats"
   [ $status -eq 1 ]
   [ "${lines[1]}" = 'not ok 1 referencing unset parameter fails in teardown' ]
   [ "${lines[2]}" = "# (from function \`teardown' in test file $RELATIVE_FIXTURE_ROOT/reference_unset_parameter_in_teardown.bats, line 4)" ]
@@ -460,7 +468,7 @@ END_OF_ERR_MSG
 @test "execute exported function without breaking failing test output" {
   exported_function() { return 0; }
   export -f exported_function
-  run bats "$FIXTURE_ROOT/exported_function.bats"
+  reentrant_run bats "$FIXTURE_ROOT/exported_function.bats"
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..1" ]
   [ "${lines[1]}" = "not ok 1 failing test" ]
@@ -470,7 +478,7 @@ END_OF_ERR_MSG
 }
 
 @test "output printed even when no final newline" {
-  run bats "$FIXTURE_ROOT/no-final-newline.bats"
+  reentrant_run bats "$FIXTURE_ROOT/no-final-newline.bats"
   printf 'num lines: %d\n' "${#lines[@]}" >&2
   printf 'LINE: %s\n' "${lines[@]}" >&2
   [ "$status" -eq 1 ]
@@ -488,7 +496,7 @@ END_OF_ERR_MSG
 }
 
 @test "run tests which consume stdin (see #197)" {
-  run bats "$FIXTURE_ROOT/read_from_stdin.bats"
+  reentrant_run bats "$FIXTURE_ROOT/read_from_stdin.bats"
   [ "$status" -eq 0 ]
   [[ "${lines[0]}" == "1..3" ]]
   [[ "${lines[1]}" == "ok 1 test 1" ]]
@@ -497,7 +505,7 @@ END_OF_ERR_MSG
 }
 
 @test "report correct line on unset variables" {
-  LANG=C run bats "$FIXTURE_ROOT/unbound_variable.bats"
+  LANG=C reentrant_run bats "$FIXTURE_ROOT/unbound_variable.bats"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 9 ]
   [ "${lines[1]}" = 'not ok 1 access unbound variable' ]
@@ -513,7 +521,7 @@ END_OF_ERR_MSG
 }
 
 @test "report correct line on external function calls" {
-  run bats "$FIXTURE_ROOT/external_function_calls.bats"
+  reentrant_run bats "$FIXTURE_ROOT/external_function_calls.bats"
   [ "$status" -eq 1 ]
 
   expectedNumberOfTests=12
@@ -550,25 +558,25 @@ END_OF_ERR_MSG
   # shellcheck source=lib/bats-core/validator.bash
   source "$BATS_ROOT/lib/bats-core/validator.bash"
   export -f bats_test_count_validator
-  run bash -c "echo $'1..1\n' | bats_test_count_validator"
+  reentrant_run bash -c "echo $'1..1\n' | bats_test_count_validator"
   [[ $status -ne 0 ]]
 
-  run bash -c "echo $'1..1\nok 1\nok 2' | bats_test_count_validator"
+  reentrant_run bash -c "echo $'1..1\nok 1\nok 2' | bats_test_count_validator"
   [[ $status -ne 0 ]]
 
-  run bash -c "echo $'1..1\nok 1' | bats_test_count_validator"
+  reentrant_run bash -c "echo $'1..1\nok 1' | bats_test_count_validator"
   [[ $status -eq 0 ]]
 }
 
 @test "running the same file twice runs its tests twice without errors" {
-  run bats "$FIXTURE_ROOT/passing.bats" "$FIXTURE_ROOT/passing.bats"
+  reentrant_run bats "$FIXTURE_ROOT/passing.bats" "$FIXTURE_ROOT/passing.bats"
   echo "$output"
   [[ $status -eq 0 ]]
   [[ "${lines[0]}" == "1..2" ]] # got 2x1 tests
 }
 
 @test "Don't use unbound variables inside bats (issue #340)" {
-  run bats "$FIXTURE_ROOT/set_-eu_in_setup_and_teardown.bats"
+  reentrant_run bats "$FIXTURE_ROOT/set_-eu_in_setup_and_teardown.bats"
   echo "$output"
   [[ "${lines[0]}" == "1..4" ]]
   [[ "${lines[1]}" == "ok 1 skipped test # skip" ]]
@@ -590,7 +598,7 @@ END_OF_ERR_MSG
 @test "each file is evaluated n+1 times" {
   # shellcheck disable=SC2031,SC2030
   export TEMPFILE="$BATS_TEST_TMPDIR/$BATS_TEST_NAME.log"
-  run bats "$FIXTURE_ROOT/evaluation_count/"
+  reentrant_run bats "$FIXTURE_ROOT/evaluation_count/"
 
   cat "$TEMPFILE"
 
@@ -630,7 +638,7 @@ END_OF_ERR_MSG
 }
 
 @test "test comment style" {
-  run bats "$FIXTURE_ROOT/comment_style.bats"
+  reentrant_run bats "$FIXTURE_ROOT/comment_style.bats"
   [ $status -eq 0 ]
   [ "${lines[0]}" = '1..6' ]
   [ "${lines[1]}" = 'ok 1 should_be_found' ]
@@ -642,7 +650,7 @@ END_OF_ERR_MSG
 }
 
 @test "test works even if PATH is reset" {
-  run bats "$FIXTURE_ROOT/update_path_env.bats"
+  reentrant_run bats "$FIXTURE_ROOT/update_path_env.bats"
   [ "$status" -eq 1 ]
   [ "${lines[4]}" = "# /usr/local/bin:/usr/bin:/bin" ]
 }
@@ -650,7 +658,7 @@ END_OF_ERR_MSG
 @test "Test nounset does not trip up bats' internals (see #385)" {
   # don't export nounset within this file or we might trip up the testsuite itself,
   # getting bad diagnostics
-  run bash -c "set -o nounset; export SHELLOPTS; bats --tap '$FIXTURE_ROOT/passing.bats'"
+  reentrant_run bash -c "set -o nounset; export SHELLOPTS; bats --tap '$FIXTURE_ROOT/passing.bats'"
   echo "$output"
   [ "${lines[0]}" = "1..1" ]
   [ "${lines[1]}" = "ok 1 a passing test" ]
@@ -677,7 +685,7 @@ END_OF_ERR_MSG
 @test "run should exit if tmpdir exist" {
   local dir
   dir=$(mktemp -d "${BATS_RUN_TMPDIR}/BATS_RUN_TMPDIR_TEST.XXXXXX")
-  run bats --tempdir "${dir}" "$FIXTURE_ROOT/passing.bats"
+  reentrant_run bats --tempdir "${dir}" "$FIXTURE_ROOT/passing.bats"
   [ "$status" -eq 1 ]
   [ "${lines[0]}" == "Error: BATS_RUN_TMPDIR (${dir}) already exists" ]
   [ "${lines[1]}" == "Reusing old run directories can lead to unexpected results ... aborting!" ]
@@ -686,7 +694,7 @@ END_OF_ERR_MSG
 @test "run should exit if TMPDIR can't be created" {
   local dir
   dir=$(mktemp "${BATS_RUN_TMPDIR}/BATS_RUN_TMPDIR_TEST.XXXXXX")
-  run bats --tempdir "${dir}" "$FIXTURE_ROOT/passing.bats"
+  reentrant_run bats --tempdir "${dir}" "$FIXTURE_ROOT/passing.bats"
   [ "$status" -eq 1 ]
   [ "${lines[1]}" == "Error: Failed to create BATS_RUN_TMPDIR (${dir})" ]
 }
@@ -695,7 +703,7 @@ END_OF_ERR_MSG
   # shellcheck disable=SC2031,SC2030
   export TMPDIR
   TMPDIR=$(mktemp -u "${BATS_RUN_TMPDIR}/donotexist.XXXXXX")
-  run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
+  reentrant_run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
   echo "$output"
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = "Error: BATS_TMPDIR (${TMPDIR}) does not exist or is not a directory" ]
@@ -703,24 +711,24 @@ END_OF_ERR_MSG
 
 @test "Setting BATS_TMPDIR is ignored" {
   unset TMPDIR # ensure we don't have a predefined value
-  expected="/tmp" run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
+  expected="/tmp" reentrant_run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
   echo "$output"
   [ "$status" -eq 0 ]
-  BATS_TMPDIR="${BATS_RUN_TMPDIR}" expected="/tmp" run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
+  BATS_TMPDIR="${BATS_RUN_TMPDIR}" expected="/tmp" reentrant_run bats "$FIXTURE_ROOT/BATS_TMPDIR.bats"
   [ "$status" -eq 0 ]
 }
 
 @test "Parallel mode works on MacOS with over subscription (issue #433)" {
   type -p parallel &>/dev/null || skip "--jobs requires GNU parallel"
   (type -p flock &>/dev/null || type -p shlock &>/dev/null) || skip "--jobs requires flock/shlock"
-  run bats -j 2 "$FIXTURE_ROOT/issue-433"
+  reentrant_run bats -j 2 "$FIXTURE_ROOT/issue-433"
 
   [ "$status" -eq 0 ]
   [[ "$output" != *"No such file or directory"* ]] || exit 1 # ensure failures are detected with old bash
 }
 
 @test "Failure in free code (see #399)" {
-  run bats --tap "$FIXTURE_ROOT/failure_in_free_code.bats"
+  reentrant_run bats --tap "$FIXTURE_ROOT/failure_in_free_code.bats"
   echo "$output"
   [ "$status" -ne 0 ]
   [ "${lines[0]}" == 1..1 ]
@@ -992,7 +1000,7 @@ END_OF_ERR_MSG
 }
 
 @test "--print-output-on-failure works as expected" {
-  run bats --print-output-on-failure --show-output-of-passing-tests "$FIXTURE_ROOT/print_output_on_failure.bats"
+  reentrant_run bats --print-output-on-failure --show-output-of-passing-tests "$FIXTURE_ROOT/print_output_on_failure.bats"
   [ "${lines[0]}" == '1..3' ]
   [ "${lines[1]}" == 'ok 1 no failure prints no output' ]
   # ^ no output despite --show-output-of-passing-tests, because there is no failure
@@ -1008,7 +1016,7 @@ END_OF_ERR_MSG
 }
 
 @test "--print-output-on-failure also shows stderr (for run --separate-stderr)" {
-  run bats --print-output-on-failure --show-output-of-passing-tests "$FIXTURE_ROOT/print_output_on_failure_with_stderr.bats"
+  reentrant_run bats --print-output-on-failure --show-output-of-passing-tests "$FIXTURE_ROOT/print_output_on_failure_with_stderr.bats"
   [ "${lines[0]}" == '1..3' ]
   [ "${lines[1]}" == 'ok 1 no failure prints no output' ]
   # ^ no output despite --show-output-of-passing-tests, because there is no failure
@@ -1027,7 +1035,7 @@ END_OF_ERR_MSG
 
 @test "--show-output-of-passing-tests works as expected" {
   bats_require_minimum_version 1.5.0
-  run -0 bats --show-output-of-passing-tests "$FIXTURE_ROOT/show-output-of-passing-tests.bats"
+  reentrant_run -0 bats --show-output-of-passing-tests "$FIXTURE_ROOT/show-output-of-passing-tests.bats"
   [ "${lines[0]}" == '1..1' ]
   [ "${lines[1]}" == 'ok 1 test' ]
   [ "${lines[2]}" == '# output' ]
@@ -1036,7 +1044,7 @@ END_OF_ERR_MSG
 
 @test "--verbose-run prints output" {
   bats_require_minimum_version 1.5.0
-  run -1 bats --verbose-run "$FIXTURE_ROOT/verbose-run.bats"
+  reentrant_run -1 bats --verbose-run "$FIXTURE_ROOT/verbose-run.bats"
   [ "${lines[0]}" == '1..1' ]
   [ "${lines[1]}" == 'not ok 1 test' ]
   [ "${lines[2]}" == "# (in test file $RELATIVE_FIXTURE_ROOT/verbose-run.bats, line 3)" ]
@@ -1047,7 +1055,7 @@ END_OF_ERR_MSG
 
 @test "BATS_VERBOSE_RUN=1 also prints output" {
   bats_require_minimum_version 1.5.0
-  run -1 env BATS_VERBOSE_RUN=1 bats "$FIXTURE_ROOT/verbose-run.bats"
+  reentrant_run -1 env BATS_VERBOSE_RUN=1 bats "$FIXTURE_ROOT/verbose-run.bats"
   [ "${lines[0]}" == '1..1' ]
   [ "${lines[1]}" == 'not ok 1 test' ]
   [ "${lines[2]}" == "# (in test file $RELATIVE_FIXTURE_ROOT/verbose-run.bats, line 3)" ]
@@ -1058,7 +1066,7 @@ END_OF_ERR_MSG
 
 @test "--gather-test-outputs-in gathers outputs of all tests (even succeeding!)" {
   local OUTPUT_DIR="$BATS_TEST_TMPDIR/logs"
-  run bats --verbose-run --gather-test-outputs-in "$OUTPUT_DIR" "$FIXTURE_ROOT/print_output_on_failure.bats"
+  reentrant_run bats --verbose-run --gather-test-outputs-in "$OUTPUT_DIR" "$FIXTURE_ROOT/print_output_on_failure.bats"
 
   [ -d "$OUTPUT_DIR" ] # will be generated!
 
@@ -1082,13 +1090,13 @@ END_OF_ERR_MSG
 
   # anything existing, even if empty, 'hidden', etc. should cause failure
   mkdir "$OUTPUT_DIR" && touch "$OUTPUT_DIR/.oops"
-  run -1 bats --verbose-run --gather-test-outputs-in "$OUTPUT_DIR" "$FIXTURE_ROOT/passing.bats"
+  reentrant_run -1 bats --verbose-run --gather-test-outputs-in "$OUTPUT_DIR" "$FIXTURE_ROOT/passing.bats"
   [ "${lines[0]}" == "Error: Directory '$OUTPUT_DIR' must be empty for --gather-test-outputs-in" ]
 
   # empty directory is just fine
   rm "$OUTPUT_DIR/.oops" && rmdir "$OUTPUT_DIR" # avoiding rm -fr to avoid goofs
   mkdir "$OUTPUT_DIR"
-  run -0 bats --verbose-run --gather-test-outputs-in "$OUTPUT_DIR" "$FIXTURE_ROOT/passing.bats"
+  reentrant_run -0 bats --verbose-run --gather-test-outputs-in "$OUTPUT_DIR" "$FIXTURE_ROOT/passing.bats"
   [ "$(find "$OUTPUT_DIR" -type f | wc -l)" -eq 1 ]
 }
 
@@ -1104,7 +1112,7 @@ END_OF_ERR_MSG
   fi
 
   bats_require_minimum_version 1.5.0
-  run ! bats --jobs 2 "$FIXTURE_ROOT/parallel.bats"
+  reentrant_run ! bats --jobs 2 "$FIXTURE_ROOT/parallel.bats"
   [ "${lines[0]}" == "ERROR: flock/shlock is required for parallelization within files!" ]
   [ "${#lines[@]}" -eq 1 ]
 }
@@ -1115,7 +1123,9 @@ END_OF_ERR_MSG
 
 @test "BATS_CODE_QUOTE_STYLE works with any two characters (even unicode)" {
   bats_require_minimum_version 1.5.0
-  BATS_CODE_QUOTE_STYLE='``' run -1 bats --tap "${FIXTURE_ROOT}/failing.bats"
+
+  REENTRANT_RUN_PRESERVE+=(BATS_CODE_QUOTE_STYLE)
+  BATS_CODE_QUOTE_STYLE='``' reentrant_run -1 bats --tap "${FIXTURE_ROOT}/failing.bats"
   # shellcheck disable=SC2016
   [ "${lines[3]}" == '#   `eval "( exit ${STATUS:-1} )"` failed' ]
 
@@ -1127,7 +1137,7 @@ END_OF_ERR_MSG
   fi
 
   bats_require_minimum_version 1.5.0
-  run -1 bats --tap "${FIXTURE_ROOT}/failing.bats"
+  reentrant_run -1 bats --tap "${FIXTURE_ROOT}/failing.bats"
   # shellcheck disable=SC2016
   [ "${lines[3]}" == '#   😁eval "( exit ${STATUS:-1} )"😂 failed' ]
 }
@@ -1138,27 +1148,32 @@ END_OF_ERR_MSG
 
   bats_require_minimum_version 1.5.0
 
-  BATS_CODE_QUOTE_STYLE=custom run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
+  REENTRANT_RUN_PRESERVE+=(BATS_CODE_QUOTE_STYLE)
+  BATS_CODE_QUOTE_STYLE=custom reentrant_run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
   [ "${lines[0]}" == 'ERROR: BATS_CODE_QUOTE_STYLE=custom requires BATS_BEGIN_CODE_QUOTE and BATS_END_CODE_QUOTE to be set' ]
 
+  REENTRANT_RUN_PRESERVE+=(BATS_BEGIN_CODE_QUOTE BATS_END_CODE_QUOTE)
   # shellcheck disable=SC2016
   BATS_CODE_QUOTE_STYLE=custom \
   BATS_BEGIN_CODE_QUOTE='$(' \
   BATS_END_CODE_QUOTE=')' \
-    run -1 bats --tap "${FIXTURE_ROOT}/failing.bats"
+    reentrant_run -1 bats --tap "${FIXTURE_ROOT}/failing.bats"
   # shellcheck disable=SC2016
   [ "${lines[3]}" == '#   $(eval "( exit ${STATUS:-1} )") failed' ]
 }
 
 @test "Warn about invalid BATS_CODE_QUOTE_STYLE" {
   bats_require_minimum_version 1.5.0
-  BATS_CODE_QUOTE_STYLE='' run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
+
+  REENTRANT_RUN_PRESERVE+=(BATS_CODE_QUOTE_STYLE)
+
+  BATS_CODE_QUOTE_STYLE='' reentrant_run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
   [ "${lines[0]}" == 'ERROR: Unknown BATS_CODE_QUOTE_STYLE: ' ]
 
-  BATS_CODE_QUOTE_STYLE='1' run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
+  BATS_CODE_QUOTE_STYLE='1' reentrant_run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
   [ "${lines[0]}" == 'ERROR: Unknown BATS_CODE_QUOTE_STYLE: 1' ]
 
-  BATS_CODE_QUOTE_STYLE='three' run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
+  BATS_CODE_QUOTE_STYLE='three' reentrant_run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
   [ "${lines[0]}" == 'ERROR: Unknown BATS_CODE_QUOTE_STYLE: three' ]
 }
 
@@ -1200,7 +1215,7 @@ END_OF_ERR_MSG
   local BATS_DECLARED_VARIABLES_FILE="${BATS_TEST_TMPDIR}/variables.log"
   bats_require_minimum_version 1.5.0
   # now capture bats @test environment
-  run -0 env -i PATH="$PATH" BATS_DECLARED_VARIABLES_FILE="$BATS_DECLARED_VARIABLES_FILE"  bash "${BATS_ROOT}/bin/bats" "${FIXTURE_ROOT}/issue-519.bats"
+  reentrant_run -0 env -i PATH="$PATH" BATS_DECLARED_VARIABLES_FILE="$BATS_DECLARED_VARIABLES_FILE"  bash "${BATS_ROOT}/bin/bats" "${FIXTURE_ROOT}/issue-519.bats"
   # use function to allow failing via !, run is a bit unwieldy with the pipe and subshells
   check_no_new_variables() {
     # -23 -> only look at additions on the bats list
@@ -1215,7 +1230,7 @@ END_OF_ERR_MSG
     SECONDS=0
     export LOG_FILE="$BATS_TEST_TMPDIR/fds.log"
     bats_require_minimum_version 1.5.0
-    run -0 bats --show-output-of-passing-tests --tap "${FIXTURE_ROOT}/issue-205.bats"
+    reentrant_run -0 bats --show-output-of-passing-tests --tap "${FIXTURE_ROOT}/issue-205.bats"
     echo "Whole suite took: $SECONDS seconds"
     FDS_LOG=$(<"$LOG_FILE")
     echo "$FDS_LOG"
@@ -1225,32 +1240,33 @@ END_OF_ERR_MSG
 }
 
 @test "Allow for prefixing tests' names with BATS_TEST_NAME_PREFIX" {
-  BATS_TEST_NAME_PREFIX='PREFIX: ' run bats "${FIXTURE_ROOT}/passing.bats"
+  REENTRANT_RUN_PRESERVE+=(BATS_TEST_NAME_PREFIX)
+  BATS_TEST_NAME_PREFIX='PREFIX: ' reentrant_run bats "${FIXTURE_ROOT}/passing.bats"
   [ "${lines[1]}" == "ok 1 PREFIX: a passing test" ]
 }
 
 @test "Setting status in teardown* does not override exit code (see issue #575)" {
   bats_require_minimum_version 1.5.0
-  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=0 run -0 bats "$FIXTURE_ROOT/teardown_override_status.bats"
-  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=0 run -1 bats "$FIXTURE_ROOT/teardown_override_status.bats"
-  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=1 STATUS=0 run -1 bats "$FIXTURE_ROOT/teardown_override_status.bats"
-  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=1 STATUS=0 run -1 bats "$FIXTURE_ROOT/teardown_override_status.bats"
-  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=1 run -0 bats "$FIXTURE_ROOT/teardown_override_status.bats"
-  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=1 run -1 bats "$FIXTURE_ROOT/teardown_override_status.bats"
+  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=0 reentrant_run -0 bats "$FIXTURE_ROOT/teardown_override_status.bats"
+  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=0 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_override_status.bats"
+  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=1 STATUS=0 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_override_status.bats"
+  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=1 STATUS=0 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_override_status.bats"
+  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=1 reentrant_run -0 bats "$FIXTURE_ROOT/teardown_override_status.bats"
+  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=1 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_override_status.bats"
 
-  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=0 run -0 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
-  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=0 run -1 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
-  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=1 STATUS=0 run -1 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
-  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=1 STATUS=0 run -1 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
-  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=1 run -0 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
-  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=1 run -1 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
+  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=0 reentrant_run -0 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
+  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=0 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
+  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=1 STATUS=0 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
+  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=1 STATUS=0 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
+  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=1 reentrant_run -0 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
+  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=1 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_file_override_status.bats"
 
-  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=0 run -0 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
-  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=0 run -1 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
-  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=1 STATUS=0 run -1 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
-  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=1 STATUS=0 run -1 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
-  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=1 run -0 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
-  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=1 run -1 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
+  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=0 reentrant_run -0 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
+  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=0 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
+  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=1 STATUS=0 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
+  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=1 STATUS=0 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
+  TEARDOWN_RETURN_CODE=0 TEST_RETURN_CODE=0 STATUS=1 reentrant_run -0 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
+  TEARDOWN_RETURN_CODE=1 TEST_RETURN_CODE=0 STATUS=1 reentrant_run -1 bats "$FIXTURE_ROOT/teardown_suite_override_status/"
 }
 
 @test "BATS_* variables don't contain double slashes" {
@@ -1259,7 +1275,7 @@ END_OF_ERR_MSG
 
 @test "Without .bats/run-logs --filter-status failed returns an error" {
   bats_require_minimum_version 1.5.0
-  run -1 bats --filter-status failed "$FIXTURE_ROOT/passing_and_failing.bats"
+  reentrant_run -1 bats --filter-status failed "$FIXTURE_ROOT/passing_and_failing.bats"
   [[ "${lines[0]}" == "Error: --filter-status needs '"*".bats/run-logs/' to save failed tests. Please create this folder, add it to .gitignore and try again." ]] || false
 }
 
@@ -1268,13 +1284,13 @@ END_OF_ERR_MSG
   cp "$FIXTURE_ROOT/many_passing_and_one_failing.bats" .
   mkdir -p .bats/run-logs
   bats_require_minimum_version 1.5.0
-  run -1 bats --filter-status failed "many_passing_and_one_failing.bats"
+  reentrant_run -1 bats --filter-status failed "many_passing_and_one_failing.bats"
   # without previous recording, all tests should be run
   [ "${lines[0]}" == 'No recording of previous runs found. Running all tests!' ]
   [ "${lines[1]}" == '1..4' ]
   [ "$(grep -c 'not ok' <<< "$output")" -eq 1 ]
 
-  run -1 bats --tap --filter-status failed "many_passing_and_one_failing.bats"
+  reentrant_run -1 bats --tap --filter-status failed "many_passing_and_one_failing.bats"
   # now we should only run the failing test
   [ "${lines[0]}" == 1..1 ]
   [ "${lines[1]}" == "not ok 1 a failing test" ]
@@ -1284,7 +1300,7 @@ END_OF_ERR_MSG
 
   find .bats/run-logs/ -type f -print -exec cat {} \;
 
-  run -1 bats --tap --filter-status failed "many_passing_and_one_failing.bats"
+  reentrant_run -1 bats --tap --filter-status failed "many_passing_and_one_failing.bats"
   # now we should only run the failing test
   [ "${lines[0]}" == 1..2 ]
   [ "${lines[1]}" == "not ok 1 a failing test" ]
@@ -1296,13 +1312,13 @@ END_OF_ERR_MSG
   cp "$FIXTURE_ROOT/many_passing_and_one_failing.bats" .
   mkdir -p .bats/run-logs
   bats_require_minimum_version 1.5.0
-  run -1 bats --filter-status passed "many_passing_and_one_failing.bats"
+  reentrant_run -1 bats --filter-status passed "many_passing_and_one_failing.bats"
   # without previous recording, all tests should be run
   [ "${lines[0]}" == 'No recording of previous runs found. Running all tests!' ]
   [ "${lines[1]}" == '1..4' ]
   [ "$(grep -c 'not ok' <<< "$output")" -eq 1 ]
 
-  run -0 bats --tap --filter-status passed "many_passing_and_one_failing.bats"
+  reentrant_run -0 bats --tap --filter-status passed "many_passing_and_one_failing.bats"
   # now we should only run the passed tests
   [ "${lines[0]}" == 1..3 ]
   [ "$(grep -c 'not ok' <<< "$output")" -eq 0 ]
@@ -1310,7 +1326,7 @@ END_OF_ERR_MSG
   # add a new test that was missed before
   echo $'@test missed { :; }' >> "many_passing_and_one_failing.bats"
 
-  run -0 bats --tap --filter-status passed "many_passing_and_one_failing.bats"
+  reentrant_run -0 bats --tap --filter-status passed "many_passing_and_one_failing.bats"
   # now we should only run the passed and missed tests
   [ "${lines[0]}" == 1..4 ]
   [ "$(grep -c 'not ok' <<< "$output")" -eq 0 ]
@@ -1322,7 +1338,7 @@ END_OF_ERR_MSG
   cp "$FIXTURE_ROOT/many_passing_and_one_failing.bats" .
   mkdir -p .bats/run-logs
   bats_require_minimum_version 1.5.0
-  run -1 bats --filter-status missed "many_passing_and_one_failing.bats"
+  reentrant_run -1 bats --filter-status missed "many_passing_and_one_failing.bats"
   # without previous recording, all tests should be run
   [ "${lines[0]}" == 'No recording of previous runs found. Running all tests!' ]
   [ "${lines[1]}" == '1..4' ]
@@ -1331,7 +1347,7 @@ END_OF_ERR_MSG
   # add a new test that was missed before
   echo $'@test missed { :; }' >> "many_passing_and_one_failing.bats"
 
-  run -0 bats --tap --filter-status missed "many_passing_and_one_failing.bats"
+  reentrant_run -0 bats --tap --filter-status missed "many_passing_and_one_failing.bats"
   # now we should only run the missed test
   [ "${lines[0]}" == 1..1 ]
   [ "${lines[1]}" == "ok 1 missed" ]
@@ -1345,9 +1361,9 @@ END_OF_ERR_MSG
   mkdir -p .bats/run-logs
   bats_require_minimum_version 1.5.0
   # have no failing tests
-  run -0 bats --filter-status failed "passing.bats"
+  reentrant_run -0 bats --filter-status failed "passing.bats"
   # try to run the empty list of failing tests
-  run -0 bats --filter-status failed "passing.bats"
+  reentrant_run -0 bats --filter-status failed "passing.bats"
   [ "${lines[0]}" == "There where no failed tests in the last recorded run." ]
   [ "${lines[1]}" == "1..0" ]
   [ "${#lines[@]}" -eq 2 ]
@@ -1369,10 +1385,10 @@ enforce_own_process_group() {
 
   bats_require_minimum_version 1.5.0
   # don't hang yet, so we get a useful rerun file
-  run -1 env DONT_ABORT=1 bats "sigint_in_failing_test.bats"
+  reentrant_run -1 env DONT_ABORT=1 bats "sigint_in_failing_test.bats"
 
   # check that we have exactly one log
-  run find .bats/run-logs -name '*.log'
+  reentrant_run find .bats/run-logs -name '*.log'
   [[ "${lines[0]}" == *.log ]] || false
   [ ${#lines[@]} -eq 1 ]
 
@@ -1381,17 +1397,17 @@ enforce_own_process_group() {
   sleep 1 # ensure we would get different timestamps for each run
 
   # now rerun but abort midrun
-  run -1 enforce_own_process_group bats --rerun-failed "sigint_in_failing_test.bats"
+  reentrant_run -1 enforce_own_process_group bats --rerun-failed "sigint_in_failing_test.bats"
 
   # should not have produced a new log
-  run find .bats/run-logs -name '*.log'
+  reentrant_run find .bats/run-logs -name '*.log'
   [ "$first_run_logs" == "$output" ]
 }
 
 @test "BATS_TEST_RETRIES allows for retrying tests" {
   export LOG="$BATS_TEST_TMPDIR/call.log"
   bats_require_minimum_version 1.5.0
-  run ! bats "$FIXTURE_ROOT/retry.bats"
+  reentrant_run ! bats "$FIXTURE_ROOT/retry.bats"
   [ "${lines[0]}" == '1..3' ]
   [ "${lines[1]}" == 'not ok 1 Fail all' ]
   [ "${lines[4]}" == 'ok 2 Fail once' ]

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -154,6 +154,7 @@ setup() {
 
   # shellcheck disable=SC2031,SC2030
   export BATS_TEST_SUITE_TMPDIR="${BATS_TEST_TMPDIR}"
+  # shellcheck disable=SC2030
   REENTRANT_RUN_PRESERVE+=(BATS_TEST_SUITE_TMPDIR)
 
   reentrant_run bats "$FIXTURE_ROOT/setup.bats"
@@ -167,6 +168,7 @@ setup() {
 
   # shellcheck disable=SC2031,SC2030
   export BATS_TEST_SUITE_TMPDIR="${BATS_TEST_TMPDIR}"
+  # shellcheck disable=SC2030,SC2031
   REENTRANT_RUN_PRESERVE+=(BATS_TEST_SUITE_TMPDIR)
 
   reentrant_run bats "$FIXTURE_ROOT/teardown.bats"
@@ -1123,6 +1125,7 @@ END_OF_ERR_MSG
 @test "BATS_CODE_QUOTE_STYLE works with any two characters (even unicode)" {
   bats_require_minimum_version 1.5.0
 
+  # shellcheck disable=SC2030,SC2031
   REENTRANT_RUN_PRESERVE+=(BATS_CODE_QUOTE_STYLE)
   BATS_CODE_QUOTE_STYLE='``' reentrant_run -1 bats --tap "${FIXTURE_ROOT}/failing.bats"
   # shellcheck disable=SC2016
@@ -1147,6 +1150,7 @@ END_OF_ERR_MSG
 
   bats_require_minimum_version 1.5.0
 
+  # shellcheck disable=SC2030,SC2031
   REENTRANT_RUN_PRESERVE+=(BATS_CODE_QUOTE_STYLE)
   BATS_CODE_QUOTE_STYLE=custom reentrant_run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
   [ "${lines[0]}" == 'ERROR: BATS_CODE_QUOTE_STYLE=custom requires BATS_BEGIN_CODE_QUOTE and BATS_END_CODE_QUOTE to be set' ]
@@ -1164,6 +1168,7 @@ END_OF_ERR_MSG
 @test "Warn about invalid BATS_CODE_QUOTE_STYLE" {
   bats_require_minimum_version 1.5.0
 
+  # shellcheck disable=SC2030,SC2031
   REENTRANT_RUN_PRESERVE+=(BATS_CODE_QUOTE_STYLE)
 
   BATS_CODE_QUOTE_STYLE='' reentrant_run -1 bats --tap "${FIXTURE_ROOT}/passing.bats"
@@ -1239,6 +1244,7 @@ END_OF_ERR_MSG
 }
 
 @test "Allow for prefixing tests' names with BATS_TEST_NAME_PREFIX" {
+  # shellcheck disable=SC2030,SC2031
   REENTRANT_RUN_PRESERVE+=(BATS_TEST_NAME_PREFIX)
   BATS_TEST_NAME_PREFIX='PREFIX: ' reentrant_run bats "${FIXTURE_ROOT}/passing.bats"
   [ "${lines[1]}" == "ok 1 PREFIX: a passing test" ]

--- a/test/formatter.bats
+++ b/test/formatter.bats
@@ -6,7 +6,7 @@ setup() {
 }
 
 @test "tap passing and skipping tests" {
-  run filter_control_sequences bats --formatter tap "$FIXTURE_ROOT/passing_and_skipping.bats"
+  reentrant_run filter_control_sequences bats --formatter tap "$FIXTURE_ROOT/passing_and_skipping.bats"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..3" ]
   [ "${lines[1]}" = "ok 1 a passing test" ]
@@ -15,7 +15,7 @@ setup() {
 }
 
 @test "tap passing, failing and skipping tests" {
-  run filter_control_sequences bats --formatter tap "$FIXTURE_ROOT/passing_failing_and_skipping.bats"
+  reentrant_run filter_control_sequences bats --formatter tap "$FIXTURE_ROOT/passing_failing_and_skipping.bats"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..3" ]
   [ "${lines[1]}" = "ok 1 a passing test" ]
@@ -24,7 +24,7 @@ setup() {
 }
 
 @test "skipped test with parens (pretty formatter)" {
-  run bats --pretty "$FIXTURE_ROOT/skipped_with_parens.bats"
+  reentrant_run bats --pretty "$FIXTURE_ROOT/skipped_with_parens.bats"
   [ $status -eq 0 ]
 
   # Some systems (Alpine, for example) seem to emit an extra whitespace into
@@ -34,11 +34,11 @@ setup() {
 }
 
 @test "pretty and tap formats" {
-  run bats --formatter tap "$FIXTURE_ROOT/passing.bats"
+  reentrant_run bats --formatter tap "$FIXTURE_ROOT/passing.bats"
   tap_output="$output"
   [ $status -eq 0 ]
 
-  run bats --pretty "$FIXTURE_ROOT/passing.bats"
+  reentrant_run bats --pretty "$FIXTURE_ROOT/passing.bats"
   pretty_output="$output"
   [ $status -eq 0 ]
 
@@ -46,7 +46,7 @@ setup() {
 }
 
 @test "pretty formatter bails on invalid tap" {
-  run bats-format-pretty < <(printf "This isn't TAP!\nGood day to you\n")
+  reentrant_run bats-format-pretty < <(printf "This isn't TAP!\nGood day to you\n")
   [ $status -eq 0 ]
   [ "${lines[0]}" = "This isn't TAP!" ]
   [ "${lines[1]}" = "Good day to you" ]
@@ -82,13 +82,13 @@ EOF
 
 @test "absolute paths load external formatters" {
     bats_require_minimum_version 1.5.0
-    run -0 bats "$FIXTURE_ROOT/passing.bats"  --formatter "$FIXTURE_ROOT/dummy-formatter"
+    reentrant_run -0 bats "$FIXTURE_ROOT/passing.bats"  --formatter "$FIXTURE_ROOT/dummy-formatter"
     [ "$output" = "Dummy Formatter!" ]
 }
 
 @test "specifying nonexistent external formatter is an error" {
   bats_require_minimum_version 1.5.0
-  run -1 bats "$FIXTURE_ROOT/passing.bats"  --formatter "$FIXTURE_ROOT/non-existing-file"
+  reentrant_run -1 bats "$FIXTURE_ROOT/passing.bats"  --formatter "$FIXTURE_ROOT/non-existing-file"
   [ "$output" = "ERROR: Formatter '$FIXTURE_ROOT/non-existing-file' is not readable!" ]
 }
 
@@ -96,6 +96,6 @@ EOF
   bats_require_minimum_version 1.5.0
   local non_executable="$BATS_TEST_TMPDIR/non-executable"
   touch "$non_executable"
-  run -1 bats "$FIXTURE_ROOT/passing.bats"  --formatter "$non_executable"
+  reentrant_run -1 bats "$FIXTURE_ROOT/passing.bats"  --formatter "$non_executable"
   [ "$output" = "ERROR: Formatter '$non_executable' is not executable!" ]
 }

--- a/test/install.bats
+++ b/test/install.bats
@@ -32,7 +32,7 @@ setup() {
   [ -f "$INSTALL_DIR/share/man/man1/bats.1" ]
   [ -f "$INSTALL_DIR/share/man/man7/bats.7" ]
 
-  run "$INSTALL_DIR/bin/bats" -v
+  reentrant_run "$INSTALL_DIR/bin/bats" -v
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
 
@@ -78,7 +78,7 @@ setup() {
   [ -f "$INSTALL_DIR/share/man/man1/bats.1" ]
   [ -f "$INSTALL_DIR/share/man/man7/bats.7" ]
 
-  run "$INSTALL_DIR/bin/bats" -v
+  reentrant_run "$INSTALL_DIR/bin/bats" -v
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
 
@@ -141,7 +141,7 @@ setup() {
     './bats "$@"' >"$bats_symlink"
   chmod 700 "$bats_symlink"
 
-  run "$bats_symlink" -v
+  reentrant_run "$bats_symlink" -v
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
 }

--- a/test/junit-formatter.bats
+++ b/test/junit-formatter.bats
@@ -8,7 +8,7 @@ TIMESTAMP_REGEX='[0-9]+-[0-1][0-9]-[0-3][0-9]T[0-2][0-9]:[0-5][0-9]:[0-5][0-9]'
 TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 
 @test "junit formatter with skipped test does not fail" {
-  run bats --formatter junit "$FIXTURE_ROOT/skipped.bats"
+  reentrant_run bats --formatter junit "$FIXTURE_ROOT/skipped.bats"
   echo "$output"
   [[ $status -eq 0 ]]
   [[ "${lines[0]}" == '<?xml version="1.0" encoding="UTF-8"?>' ]]
@@ -50,7 +50,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
       TEST_FILE_PATH="$FIXTURE_ROOT/$TEST_FILE_NAME"
     ;;
   esac
-  run bats --formatter junit "$TEST_FILE_PATH"
+  reentrant_run bats --formatter junit "$TEST_FILE_PATH"
 
   echo "$output"
   [[ "${lines[2]}" == "<testsuite name=\"$ESCAPED_TEST_FILE_NAME\" tests=\"3\" failures=\"1\" errors=\"0\" skipped=\"1\" time=\""*"\" timestamp=\""*"\" hostname=\""*"\">" ]]
@@ -63,7 +63,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 }
 
 @test "junit formatter: test suites" {
-  run bats --formatter junit "$FIXTURE_ROOT/suite/"
+  reentrant_run bats --formatter junit "$FIXTURE_ROOT/suite/"
   echo "$output"
 
   [[ "${lines[0]}" == '<?xml version="1.0" encoding="UTF-8"?>' ]]
@@ -79,7 +79,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 
 @test "junit formatter: test suites relative path" {
   cd "$FIXTURE_ROOT"
-  run bats --formatter junit "suite/"
+  reentrant_run bats --formatter junit "suite/"
   echo "$output"
 
   [[ "${lines[0]}" == '<?xml version="1.0" encoding="UTF-8"?>' ]]
@@ -94,7 +94,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 }
 
 @test "junit formatter: files with the same name are distinguishable" {
-  run bats --formatter junit -r "$FIXTURE_ROOT/duplicate/"
+  reentrant_run bats --formatter junit -r "$FIXTURE_ROOT/duplicate/"
   echo "$output"
 
   [[ "${lines[2]}" == *"<testsuite name=\"first/file1.bats\""* ]]
@@ -103,7 +103,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 
 @test "junit formatter as report formatter creates report.xml" {
   cd "$BATS_TEST_TMPDIR" # don't litter sources with output files
-  run bats --report-formatter junit "$FIXTURE_ROOT/suite/"
+  reentrant_run bats --report-formatter junit "$FIXTURE_ROOT/suite/"
   echo "$output"
   [[ -e "report.xml" ]]
   run cat "report.xml"
@@ -113,7 +113,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 }
 
 @test "junit does not mark tests with FD 3 output as failed (issue #360)" {
-  run bats --formatter junit "$FIXTURE_ROOT/issue_360.bats"
+  reentrant_run bats --formatter junit "$FIXTURE_ROOT/issue_360.bats"
 
   echo "$output"
 
@@ -141,7 +141,7 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 
 @test "junit does not mark tests with FD 3 output in teardown_file as failed (issue #531)" {
   bats_require_minimum_version 1.5.0
-  run -0 bats --formatter junit "$FIXTURE_ROOT/issue_531.bats"
+  reentrant_run -0 bats --formatter junit "$FIXTURE_ROOT/issue_531.bats"
 
   [[ "${lines[2]}" == '<testsuite name="issue_531.bats" '*'>' ]]
   [[ "${lines[3]}" == '    <testcase classname="issue_531.bats" '*'>' ]]
@@ -155,6 +155,6 @@ TESTSUITES_REGEX="<testsuites time=\"$FLOAT_REGEX\">"
 @test "don't choke on setup_file errors" {
   bats_require_minimum_version 1.5.0
   local stderr='' # silence shellcheck
-  run -1 --separate-stderr bats --formatter junit "$FIXTURE_ROOT/../file_setup_teardown/setup_file_failed.bats"
+  reentrant_run -1 --separate-stderr bats --formatter junit "$FIXTURE_ROOT/../file_setup_teardown/setup_file_failed.bats"
   [ "${stderr}" == "" ]
 }

--- a/test/pretty-formatter.bats
+++ b/test/pretty-formatter.bats
@@ -27,7 +27,7 @@ HERE
 
 @test "pretty formatter summary is colorized red on failure" {
   bats_require_minimum_version 1.5.0
-  run -1 bats --pretty "$FIXTURE_ROOT/failing.bats"
+  reentrant_run -1 bats --pretty "$FIXTURE_ROOT/failing.bats"
   
   [ "${lines[4]}" == $'\033[0m\033[31;1m' ] # TODO: avoid checking for the leading reset too
   [ "${lines[5]}" == '1 test, 1 failure' ]
@@ -36,7 +36,7 @@ HERE
 
 @test "pretty formatter summary is colorized green on success" {
   bats_require_minimum_version 1.5.0
-  run -0 bats --pretty "$FIXTURE_ROOT/passing.bats"
+  reentrant_run -0 bats --pretty "$FIXTURE_ROOT/passing.bats"
 
   [ "${lines[2]}" == $'\033[0m\033[32;1m' ] # TODO: avoid checking for the leading reset too
   [ "${lines[3]}" == '1 test, 0 failures' ]

--- a/test/root.bats
+++ b/test/root.bats
@@ -36,7 +36,7 @@ setup() {
 }
 
 @test "#113: set BATS_ROOT when /bin is a symlink to /usr/bin" {
-  run "$BATS_TEST_TMPDIR/bin/bats" -v
+  reentrant_run "$BATS_TEST_TMPDIR/bin/bats" -v
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
 }
@@ -68,7 +68,7 @@ setup() {
 
   # shellcheck disable=SC2103,SC2164
   cd - >/dev/null
-  run "$BATS_TEST_TMPDIR/bin/foo" -v
+  reentrant_run "$BATS_TEST_TMPDIR/bin/foo" -v
   echo "$output"
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
@@ -76,7 +76,7 @@ setup() {
 
 @test "set BATS_ROOT when calling from same dir" {
   cd "$BATS_TEST_TMPDIR"
-  run ./bin/bats -v
+  reentrant_run ./bin/bats -v
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
 }
@@ -85,7 +85,7 @@ setup() {
   cd /tmp
   # shellcheck disable=SC2031,SC2030
   PATH="$PATH:$BATS_TEST_TMPDIR/bin"
-  run bats -v
+  reentrant_run bats -v
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
 }
@@ -94,7 +94,7 @@ setup() {
   cd /tmp
   # shellcheck disable=SC2031,SC2030
   PATH="$PATH:$BATS_TEST_TMPDIR/bin"
-  run bash bats -v
+  reentrant_run bash bats -v
   [ "$status" -eq 0 ]
   [ "${output%% *}" == 'Bats' ]
 }

--- a/test/run.bats
+++ b/test/run.bats
@@ -87,7 +87,7 @@ print-stderr-stdout() {
 }
 
 @test "run exit code check output " {
-  run ! bats --tap "${FIXTURE_ROOT}/failing.bats"
+  reentrant_run ! bats --tap "${FIXTURE_ROOT}/failing.bats"
   echo "$output"
   [ "${lines[0]}" == 1..5 ]
   [ "${lines[1]}" == "not ok 1 run -0 false" ]
@@ -108,7 +108,7 @@ print-stderr-stdout() {
 }
 
 @test "run invalid exit code check error message" {
-  run ! bats --tap "${FIXTURE_ROOT}/invalid.bats"
+  reentrant_run ! bats --tap "${FIXTURE_ROOT}/invalid.bats"
   echo "$output"
   [ "${lines[0]}" == 1..2 ]
   [ "${lines[1]}" == "not ok 1 run '-4evah' echo hi" ]

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -1,31 +1,34 @@
-load test_helper
-fixtures suite
+setup() {
+  load test_helper
+  fixtures suite
+  REENTRANT_RUN_PRESERVE+=(BATS_LIBEXEC)
+}
 
 @test "running a suite with no test files" {
-  run bats "$FIXTURE_ROOT/empty"
+  reentrant_run bats "$FIXTURE_ROOT/empty"
   [ $status -eq 0 ]
   [ "$output" = "1..0" ]
 }
 
 @test "running a suite with one test file" {
-  run bats "$FIXTURE_ROOT/single"
+  reentrant_run bats "$FIXTURE_ROOT/single"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..1" ]
   [ "${lines[1]}" = "ok 1 a passing test" ]
 }
 
 @test "counting tests in a suite" {
-  run bats -c "$FIXTURE_ROOT/single"
+  reentrant_run bats -c "$FIXTURE_ROOT/single"
   [ $status -eq 0 ]
   [ "$output" -eq 1 ]
 
-  run bats -c "$FIXTURE_ROOT/multiple"
+  reentrant_run bats -c "$FIXTURE_ROOT/multiple"
   [ $status -eq 0 ]
   [ "$output" -eq 3 ]
 }
 
 @test "aggregated output of multiple tests in a suite" {
-  run bats "$FIXTURE_ROOT/multiple"
+  reentrant_run bats "$FIXTURE_ROOT/multiple"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..3" ]
   echo "$output" | grep "^ok . truth"
@@ -34,14 +37,14 @@ fixtures suite
 }
 
 @test "a failing test in a suite results in an error exit code" {
-  FLUNK=1 run bats "$FIXTURE_ROOT/multiple"
+  FLUNK=1 reentrant_run bats "$FIXTURE_ROOT/multiple"
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..3" ]
   echo "$output" | grep "^not ok . quasi-truth"
 }
 
 @test "running an ad-hoc suite by specifying multiple test files" {
-  run bats "$FIXTURE_ROOT/multiple/a.bats" "$FIXTURE_ROOT/multiple/b.bats"
+  reentrant_run bats "$FIXTURE_ROOT/multiple/a.bats" "$FIXTURE_ROOT/multiple/b.bats"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..3" ]
   echo "$output" | grep "^ok . truth"
@@ -51,7 +54,7 @@ fixtures suite
 
 @test "extended syntax in suite" {
   emulate_bats_env
-  FLUNK=1 run bats-exec-suite -x "$FIXTURE_ROOT/multiple/"*.bats
+  FLUNK=1 reentrant_run bats-exec-suite -x "$FIXTURE_ROOT/multiple/"*.bats
   echo "output: $output"
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..3" ]
@@ -67,7 +70,7 @@ fixtures suite
 
 @test "timing syntax in suite" {
   emulate_bats_env
-  FLUNK=1 run bats-exec-suite -T "$FIXTURE_ROOT/multiple/"*.bats
+  FLUNK=1 reentrant_run bats-exec-suite -T "$FIXTURE_ROOT/multiple/"*.bats
   echo "$output"
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..3" ]
@@ -81,7 +84,7 @@ fixtures suite
 
 @test "extended timing syntax in suite" {
   emulate_bats_env
-  FLUNK=1 run bats-exec-suite -x -T "$FIXTURE_ROOT/multiple/"*.bats
+  FLUNK=1 reentrant_run bats-exec-suite -x -T "$FIXTURE_ROOT/multiple/"*.bats
   echo "$output"
   [ $status -eq 1 ]
   [ "${lines[0]}" = "1..3" ]
@@ -99,7 +102,7 @@ fixtures suite
 }
 
 @test "recursive support (short option)" {
-  run bats -r "${FIXTURE_ROOT}/recursive"
+  reentrant_run bats -r "${FIXTURE_ROOT}/recursive"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..2" ]
   [ "${lines[1]}" = "ok 1 another passing test" ]
@@ -107,7 +110,7 @@ fixtures suite
 }
 
 @test "recursive support (long option)" {
-  run bats --recursive "${FIXTURE_ROOT}/recursive"
+  reentrant_run bats --recursive "${FIXTURE_ROOT}/recursive"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..2" ]
   [ "${lines[1]}" = "ok 1 another passing test" ]
@@ -119,7 +122,7 @@ fixtures suite
     skip "symbolic links aren't functional on OSTYPE=$OSTYPE"
   fi
 
-  run bats -r "${FIXTURE_ROOT}/recursive_with_symlinks"
+  reentrant_run bats -r "${FIXTURE_ROOT}/recursive_with_symlinks"
   [ $status -eq 0 ]
   [ "${lines[0]}" = "1..2" ]
   [ "${lines[1]}" = "ok 1 another passing test" ]
@@ -127,7 +130,7 @@ fixtures suite
 }
 
 @test "run entire suite when --filter isn't set" {
-  run bats "${FIXTURE_ROOT}/filter"
+  reentrant_run bats "${FIXTURE_ROOT}/filter"
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = '1..9' ]
   [ "${lines[1]}" = 'ok 1 foo in a' ]
@@ -142,7 +145,7 @@ fixtures suite
 }
 
 @test "use --filter to run subset of test cases from across the suite" {
-  run bats -f 'ba[rz]' "${FIXTURE_ROOT}/filter"
+  reentrant_run bats -f 'ba[rz]' "${FIXTURE_ROOT}/filter"
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = '1..4' ]
   [ "${lines[1]}" = 'ok 1 --bar in a' ]
@@ -152,13 +155,13 @@ fixtures suite
 
   local prev_output="$output"
 
-  run bats --filter 'ba[rz]' "${FIXTURE_ROOT}/filter"
+  reentrant_run bats --filter 'ba[rz]' "${FIXTURE_ROOT}/filter"
   [ "$status" -eq 0 ]
   [ "$output" = "$prev_output" ]
 }
 
 @test "--filter can handle regular expressions that contain [_- ]" {
-  run bats -f '--ba[rz][ _]in' "${FIXTURE_ROOT}/filter"
+  reentrant_run bats -f '--ba[rz][ _]in' "${FIXTURE_ROOT}/filter"
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = '1..2' ]
   [ "${lines[1]}" = 'ok 1 --bar in a' ]
@@ -166,7 +169,7 @@ fixtures suite
 }
 
 @test "--filter can handle regular expressions that start with ^" {
-  run bats -f '^ba[rz]' "${FIXTURE_ROOT}/filter"
+  reentrant_run bats -f '^ba[rz]' "${FIXTURE_ROOT}/filter"
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = '1..2' ]
   [ "${lines[1]}" = 'ok 1 baz in a' ]
@@ -178,13 +181,14 @@ fixtures suite
 }
 
 @test "BATS_TEST_NUMBER starts at 1 in each individual test file" {
-  run bats "${FIXTURE_ROOT}/test_number"
+  reentrant_run bats "${FIXTURE_ROOT}/test_number"
   echo "$output"
   [ "$status" -eq 0 ]
 }
 
 @test "Override BATS_FILE_EXTENSION with suite" {
-  BATS_FILE_EXTENSION="test" run bats "${FIXTURE_ROOT}/override_BATS_FILE_EXTENSION"
+  REENTRANT_RUN_PRESERVE+=(BATS_FILE_EXTENSION)
+  BATS_FILE_EXTENSION="test" reentrant_run bats "${FIXTURE_ROOT}/override_BATS_FILE_EXTENSION"
   echo "$output"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 2 ]
@@ -193,7 +197,8 @@ fixtures suite
 }
 
 @test "Override BATS_FILE_EXTENSION with suite recursive" {
-  BATS_FILE_EXTENSION="other_extension" run bats -r "${FIXTURE_ROOT}/override_BATS_FILE_EXTENSION"
+  REENTRANT_RUN_PRESERVE+=(BATS_FILE_EXTENSION)
+  BATS_FILE_EXTENSION="other_extension" reentrant_run bats -r "${FIXTURE_ROOT}/override_BATS_FILE_EXTENSION"
   echo "$output"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 2 ]

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -187,6 +187,7 @@ setup() {
 }
 
 @test "Override BATS_FILE_EXTENSION with suite" {
+  # shellcheck disable=SC2030
   REENTRANT_RUN_PRESERVE+=(BATS_FILE_EXTENSION)
   BATS_FILE_EXTENSION="test" reentrant_run bats "${FIXTURE_ROOT}/override_BATS_FILE_EXTENSION"
   echo "$output"
@@ -197,6 +198,7 @@ setup() {
 }
 
 @test "Override BATS_FILE_EXTENSION with suite recursive" {
+  # shellcheck disable=SC2030,SC2031
   REENTRANT_RUN_PRESERVE+=(BATS_FILE_EXTENSION)
   BATS_FILE_EXTENSION="other_extension" reentrant_run bats -r "${FIXTURE_ROOT}/override_BATS_FILE_EXTENSION"
   echo "$output"

--- a/test/suite_setup_teardown.bats
+++ b/test/suite_setup_teardown.bats
@@ -7,7 +7,7 @@ setup() {
 }
 
 @test "setup_suite.bash is picked up in toplevel folder of suite" {
-    run -0 bats -r "$FIXTURE_ROOT/pick_up_toplevel"
+    reentrant_run -0 bats -r "$FIXTURE_ROOT/pick_up_toplevel"
     run cat "$LOGFILE"
 
     [ "${lines[0]}" = "$FIXTURE_ROOT/pick_up_toplevel/setup_suite.bash setup_suite" ]
@@ -15,7 +15,7 @@ setup() {
 }
 
 @test "setup_suite.bash is picked up in folder of first test file" {
-    run -0 bats "$FIXTURE_ROOT/pick_up_toplevel/folder1/test.bats" "$FIXTURE_ROOT/pick_up_toplevel/folder2/test.bats"
+    reentrant_run -0 bats "$FIXTURE_ROOT/pick_up_toplevel/folder1/test.bats" "$FIXTURE_ROOT/pick_up_toplevel/folder2/test.bats"
     run cat "$LOGFILE"
 
     [ "${lines[0]}" = "$FIXTURE_ROOT/pick_up_toplevel/folder1/setup_suite.bash setup_suite" ]
@@ -23,14 +23,14 @@ setup() {
 }
 
 @test "setup_suite is not picked up from wrongly named file" {
-    run -0 bats "$FIXTURE_ROOT/non_default_name/"
+    reentrant_run -0 bats "$FIXTURE_ROOT/non_default_name/"
     run cat "$LOGFILE"
     [[ "${output}" != *"setup_suite"* ]] || false
     [[ "${output}" != *"teardown_suite"* ]] || false
 }
 
 @test "setup_suite is picked up from --setup-suite-file" {
-    run -0 bats "$FIXTURE_ROOT/non_default_name/" \
+    reentrant_run -0 bats "$FIXTURE_ROOT/non_default_name/" \
                 --setup-suite-file "$FIXTURE_ROOT/non_default_name/setup_suite_non_default.bash"
     run cat "$LOGFILE"
     [ "${lines[0]}" == "setup_suite non_default" ]
@@ -38,7 +38,7 @@ setup() {
 }
 
 @test "--setup-suite-file takes precedence over convention" {
-    run -0 bats "$FIXTURE_ROOT/default_name/" \
+    reentrant_run -0 bats "$FIXTURE_ROOT/default_name/" \
                 --setup-suite-file "$FIXTURE_ROOT/non_default_name/setup_suite_non_default.bash"
     run cat "$LOGFILE"
     [ "${lines[0]}" == "setup_suite non_default" ]
@@ -46,43 +46,43 @@ setup() {
 }
 
 @test "passing a nonexisting file to --setup-suite-file prints an error message" {
-    run -1 bats "$FIXTURE_ROOT/default_name/" \
+    reentrant_run -1 bats "$FIXTURE_ROOT/default_name/" \
                 --setup-suite-file "/non-existing/setup_suite.bash"
     [ "${lines[0]}" == "Error: --setup-suite-file /non-existing/setup_suite.bash does not exist!" ]
 }
 
 @test "setup_suite.bash without setup_suite() is an error" {
-    run ! bats "$FIXTURE_ROOT/no_setup_suite_function/"
+    reentrant_run ! bats "$FIXTURE_ROOT/no_setup_suite_function/"
     [ "${lines[1]}" == "$FIXTURE_ROOT/no_setup_suite_function/setup_suite.bash does not define \`setup_suite()\`" ]
 }
 
 @test "exported variables from setup_suite are visible in setup_file, setup and @test" {
     unset EXPORTED_VAR
-    EXPECTED_VALUE=exported_var run -0 bats "$FIXTURE_ROOT/exported_vars/"
+    EXPECTED_VALUE=exported_var reentrant_run -0 bats "$FIXTURE_ROOT/exported_vars/"
 }
 
 @test "syntax errors in setup_suite.bash are reported and lead to non zero exit code" {
-    LANG=C run ! bats --setup-suite-file "$FIXTURE_ROOT/syntax_error/setup_suite_no_shellcheck" "$FIXTURE_ROOT/syntax_error/"
+    LANG=C reentrant_run ! bats --setup-suite-file "$FIXTURE_ROOT/syntax_error/setup_suite_no_shellcheck" "$FIXTURE_ROOT/syntax_error/"
     [ "${lines[1]}" == "$FIXTURE_ROOT/syntax_error/setup_suite_no_shellcheck: line 2: syntax error: unexpected end of file" ]
 }
 
 @test "errors in setup_suite.bash's free code reported correctly" {
-    LANG=C run ! bats "$FIXTURE_ROOT/error_in_free_code/"
+    LANG=C reentrant_run ! bats "$FIXTURE_ROOT/error_in_free_code/"
     [ "${lines[1]}" == "$FIXTURE_ROOT/error_in_free_code/setup_suite.bash: line 1: call-to-undefined-command: command not found" ]
 }
 
 @test "errors in setup_suite reported correctly" {
-    LANG=C run ! bats "$FIXTURE_ROOT/error_in_setup_suite/"
+    LANG=C reentrant_run ! bats "$FIXTURE_ROOT/error_in_setup_suite/"
     [ "${lines[1]}" == "$FIXTURE_ROOT/error_in_setup_suite/setup_suite.bash: line 2: call-to-undefined-command: command not found" ]
 }
 
 @test "errors in teardown_suite reported correctly" {
-    LANG=C run ! bats "$FIXTURE_ROOT/error_in_teardown_suite/"
+    LANG=C reentrant_run ! bats "$FIXTURE_ROOT/error_in_teardown_suite/"
     [ "${lines[2]}" == "$FIXTURE_ROOT/error_in_teardown_suite/setup_suite.bash: line 6: call-to-undefined-command: command not found" ]
 }
 
 @test "failure in setup_suite skips further setup and suite but runs teardown_suite" {
-    run ! bats "$FIXTURE_ROOT/failure_in_setup_suite/"
+    reentrant_run ! bats "$FIXTURE_ROOT/failure_in_setup_suite/"
     [ "${lines[1]}" == "setup_suite before" ] # <- only setup_suite code before failure is run
     [ "${lines[2]}" == "teardown_suite" ] # <- teardown is run
     # get a nice error message
@@ -92,14 +92,14 @@ setup() {
 }
 
 @test "midway failure in teardown_suite does not fail test suite, remaining code is executed" {
-    run -0 bats "$FIXTURE_ROOT/failure_in_teardown_suite/"
+    reentrant_run -0 bats "$FIXTURE_ROOT/failure_in_teardown_suite/"
     [ "${lines[2]}" == "teardown_suite before" ]
     [ "${lines[3]}" == "teardown_suite after" ]
     [ "${#lines[@]}" -eq 4 ]
 }
 
 @test "nonzero return in teardown_suite does fails test suite" {
-    run -1 bats "$FIXTURE_ROOT/return_nonzero_in_teardown_suite/"
+    reentrant_run -1 bats "$FIXTURE_ROOT/return_nonzero_in_teardown_suite/"
     [ "${lines[2]}" == "teardown_suite before" ]
     [ "${lines[3]}" == "not ok 2 teardown_suite" ]
     [ "${lines[4]}" == "# (from function \`teardown_suite' in test file $RELATIVE_FIXTURE_ROOT/return_nonzero_in_teardown_suite/setup_suite.bash, line 7)" ]
@@ -109,7 +109,7 @@ setup() {
 }
 
 @test "stderr from setup/teardown_suite does not overtake stdout" {
-    run -0 --separate-stderr bats "$FIXTURE_ROOT/stderr_in_setup_teardown_suite/"
+    reentrant_run -0 --separate-stderr bats "$FIXTURE_ROOT/stderr_in_setup_teardown_suite/"
     [[ "$output" == *$'setup_suite stdout\nsetup_suite stderr'* ]] || false
     [[ "$output" == *$'teardown_suite stdout\nteardown_suite stderr'* ]] || false
 }

--- a/test/tap13-formatter.bats
+++ b/test/tap13-formatter.bats
@@ -2,7 +2,7 @@ load 'test_helper'
 fixtures bats # reuse bats fixtures
 
 @test "passing test" {
-    run bats --formatter tap13 "${FIXTURE_ROOT}/passing.bats"
+    reentrant_run bats --formatter tap13 "${FIXTURE_ROOT}/passing.bats"
     
     [ "${lines[0]}" == 'TAP version 13' ]
     [ "${lines[1]}" == '1..1' ]
@@ -11,7 +11,7 @@ fixtures bats # reuse bats fixtures
 }
 
 @test "failing test" {
-    run bats --formatter tap13 "${FIXTURE_ROOT}/failing.bats"
+    reentrant_run bats --formatter tap13 "${FIXTURE_ROOT}/failing.bats"
     
     [ "${lines[0]}" == 'TAP version 13' ]
     [ "${lines[1]}" == '1..1' ]
@@ -25,7 +25,7 @@ fixtures bats # reuse bats fixtures
 }
 
 @test "passing test with timing" {
-    run bats --formatter tap13 --timing "${FIXTURE_ROOT}/passing.bats"
+    reentrant_run bats --formatter tap13 --timing "${FIXTURE_ROOT}/passing.bats"
     
     [ "${lines[0]}" == 'TAP version 13' ]
     [ "${lines[1]}" == '1..1' ]
@@ -38,7 +38,7 @@ fixtures bats # reuse bats fixtures
 }
 
 @test "failing test with timing" {
-    run bats --formatter tap13 --timing "${FIXTURE_ROOT}/failing.bats"
+    reentrant_run bats --formatter tap13 --timing "${FIXTURE_ROOT}/failing.bats"
     
     [ "${lines[0]}" == 'TAP version 13' ]
     [ "${lines[1]}" == '1..1' ]

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -4,6 +4,7 @@ emulate_bats_env() {
   export BATS_ROOT_PID=$$
   export BATS_RUN_TMPDIR
   BATS_RUN_TMPDIR=$(mktemp -d "${BATS_RUN_TMPDIR}/emulated-tmpdir-${BATS_ROOT_PID}-XXXXXX")
+  REENTRANT_RUN_PRESERVE+=(BATS_CWD BATS_TEST_FILTER BATS_ROOT_PID BATS_RUN_TMPDIR)
 }
 
 fixtures() {
@@ -28,4 +29,41 @@ fi
 emit_debug_output() {
   # shellcheck disable=SC2154
   printf '%s\n' 'output:' "$output" >&2
+}
+
+execute_with_unset_bats_vars() { # <command to execute...>
+  for var_to_delete in "${!BATS_@}"; do
+    for var_to_exclude in "${REENTRANT_RUN_PRESERVE[@]-}"; do
+      # is this var excluded -> skip unset
+      if [[ $var_to_delete == "$var_to_exclude" ]]; then
+        continue 2
+      fi
+    done
+    unset "$var_to_delete"
+  done
+  "$@"
+}
+
+REENTRANT_RUN_PRESERVE+=(BATS_ROOT)
+
+# call run with all BATS_* variables purged from the environment
+reentrant_run() { # <same args as run>
+  # take up all args to run except the command,
+  # to avoid having to deal with empty arrays in Bash 3
+  local -a pre_command_args=()
+
+  # remove all flags to run to leave the command in $@
+  while [[ $1 == -* || $1 == ! ]]; do
+    pre_command_args+=("$1")
+    if [[ "$1" == -- ]]; then
+      shift
+      break
+    fi
+    shift
+  done
+
+  # put that here to ensure Bash 3 won't have to deal with empty pre_command_args
+  pre_command_args+=(execute_with_unset_bats_vars)
+
+  run "${pre_command_args[@]}" "$@"
 }

--- a/test/timeout.bats
+++ b/test/timeout.bats
@@ -6,7 +6,7 @@ bats_require_minimum_version 1.5.0
 @test "test faster than timeout" {
     SECONDS=0
     TIMEOUT=10
-    run -0 env BATS_TEST_TIMEOUT=$TIMEOUT SLEEP=1 bats -T "$FIXTURE_ROOT"
+    reentrant_run -0 env BATS_TEST_TIMEOUT=$TIMEOUT SLEEP=1 bats -T "$FIXTURE_ROOT"
     [ "${lines[0]}" == '1..1' ]
     [[ "${lines[1]}" == 'ok 1 my sleep 1 in '*'ms' ]] || false
     [ "${#lines[@]}" -eq 2 ]
@@ -16,7 +16,7 @@ bats_require_minimum_version 1.5.0
 
 @test "test longer than timeout" {
     SECONDS=0
-    run ! env BATS_TEST_TIMEOUT=1 SLEEP=10 bats -T "$FIXTURE_ROOT"
+    reentrant_run ! env BATS_TEST_TIMEOUT=1 SLEEP=10 bats -T "$FIXTURE_ROOT"
     [ "${lines[0]}" == '1..1' ]
     [[ "${lines[1]}" == 'not ok 1 my sleep 10 in '*'ms # timeout after 1s' ]] || false
     [ "${lines[2]}" == "# (in test file $RELATIVE_FIXTURE_ROOT/sleep2.bats, line 3)" ]

--- a/test/trace.bats
+++ b/test/trace.bats
@@ -6,7 +6,7 @@ setup() {
 }
 
 @test "no --trace doesn't show anything on failure" {
-  run -1 bats "$FIXTURE_ROOT/failing_complex.bats"
+  reentrant_run -1 bats "$FIXTURE_ROOT/failing_complex.bats"
   [ "${lines[0]}" = "1..1" ]
   [ "${lines[1]}" = "not ok 1 a complex failing test" ]
   [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/failing_complex.bats, line 4)" ]
@@ -16,7 +16,7 @@ setup() {
 }
 
 @test "--trace recurses into functions but not into run" {
-    run -1 bats --trace "$FIXTURE_ROOT/failing_recursive.bats"
+    reentrant_run -1 bats --trace "$FIXTURE_ROOT/failing_recursive.bats"
     
     [ "${lines[0]}" = '1..1' ]
     [ "${lines[1]}" = 'not ok 1 a recursive failing test' ]

--- a/test/warnings.bats
+++ b/test/warnings.bats
@@ -17,12 +17,13 @@ setup() {
 }
 
 @test "invalid warning is an error" {
-    run -1 bats_generate_warning invalid-number
+    REENTRANT_RUN_PRESERVE+=(BATS_WARNING_SHORT_DESCS)
+    reentrant_run -1 bats_generate_warning invalid-number
     [[ "$output" == "Invalid Bats warning number 'invalid-number'. It must be an integer between 1 and "* ]]
 }
 
 @test "BW01 is printed when \`run\`ing a (non-existant) command with exit code 127 without exit code check" {
-    run -0 bats "$FIXTURE_ROOT/BW01.bats"
+    reentrant_run -0 bats "$FIXTURE_ROOT/BW01.bats"
     [ "${lines[0]}" == "1..1" ]
     [ "${lines[1]}" == "ok 1 Trigger BW01" ]
     [ "${lines[2]}" == "The following warnings were encountered during tests:" ]
@@ -32,21 +33,21 @@ setup() {
 }
 
 @test "BW01 is not printed when \`run\`ing a (non-existant) command with exit code 127 with exit code check" {
-    run -0 bats "$FIXTURE_ROOT/BW01_check_exit_code_is_127.bats"
+    reentrant_run -0 bats "$FIXTURE_ROOT/BW01_check_exit_code_is_127.bats"
     [ "${lines[0]}" == "1..1" ]
     [ "${lines[1]}" == "ok 1 Don't trigger BW01 with checked exit code 127" ]
     [ "${#lines[@]}" -eq 2 ]
 }
 
 @test "BW01 is not printed when \`run\`ing a command with exit code !=127 without exit code check" {
-    run -0 bats "$FIXTURE_ROOT/BW01_no_exit_code_check_no_exit_code_127.bats"
+    reentrant_run -0 bats "$FIXTURE_ROOT/BW01_no_exit_code_check_no_exit_code_127.bats"
     [ "${lines[0]}" == "1..1" ]
     [ "${lines[1]}" == "ok 1 Don't trigger BW01 with exit code !=127 and no check" ]
     [ "${#lines[@]}" -eq 2 ]
 }
 
 @test "BW02 is printed when run uses parameters without guaranteed version >= 1.5.0" {
-    run -0 bats "$FIXTURE_ROOT/BW02.bats"
+    reentrant_run -0 bats "$FIXTURE_ROOT/BW02.bats"
     [ "${lines[0]}" == "1..1" ]
     [ "${lines[1]}" == "ok 1 Trigger BW02" ]
     [ "${lines[2]}" == "The following warnings were encountered during tests:" ]


### PR DESCRIPTION
Fixes #640. Try to make as many run calls as possible reentrant so that they don't hide unbound variable errors.