### PR TITLE
Fix rpm build spec file to correctly build on Rocky Linux release 8.6

### DIFF
--- a/contrib/rpm/bats.spec
+++ b/contrib/rpm/bats.spec
@@ -39,9 +39,20 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/%{repo}
 %{_mandir}/man1/%{name}.1.gz
 %{_mandir}/man7/%{name}.7.gz
+/usr/lib/%{repo}/common.bash
+/usr/lib/%{repo}/formatter.bash
+/usr/lib/%{repo}/preprocessing.bash
+/usr/lib/%{repo}/semaphore.bash
+/usr/lib/%{repo}/test_functions.bash
+/usr/lib/%{repo}/tracing.bash
+/usr/lib/%{repo}/validator.bash
+/usr/lib/%{repo}/warnings.bash
 
 %changelog
-* Tue Jul 08 2018 mbland <mbland@acm.org> - 1.1.0-1
+* Wed Sep 07 2022 Marcel Hecko <marcel@blava.net> - 1.2.0-1
+- Fix and test RPM build on Rocky Linux release 8.6
+
+* Sun Jul 08 2018 mbland <mbland@acm.org> - 1.1.0-1
 - Increase version to match upstream release
 
 * Mon Jun 18 2018 pixdrift <support@pixeldrift.net> - 1.0.2-1


### PR DESCRIPTION
I have fixed the RPM build as I really need the RPM for my dev env. This has been fully tested on Rocky Linux 8.6, which should be binary compatible with RHEL8.6 and Alma Linux 8.6

The patch fixes the following errors:
```
[root@roxana-dev rpm]# rpmbuild -v -bb bats.spec
...
RPM build errors:
    bogus date in %changelog: Tue Jul 08 2018 mbland <mbland@acm.org> - 1.1.0-1
    Installed (but unpackaged) file(s) found:
   /usr/lib/bats-core/common.bash
   /usr/lib/bats-core/formatter.bash
   /usr/lib/bats-core/preprocessing.bash
   /usr/lib/bats-core/semaphore.bash
   /usr/lib/bats-core/test_functions.bash
   /usr/lib/bats-core/tracing.bash
   /usr/lib/bats-core/validator.bash
   /usr/lib/bats-core/warnings.bash
```

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
