### PR TITLE
Fix a problem that `run` always fails with `IFS=_`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * fix unbound variable errors with `set -u` on `setup_suite` failures (#643)
 * fix `load` not being available in `setup_suite` (#644)
 * fix RPM spec, add regression test (#648)
+* fix handling of `IFS` by `run` (#650)
 
 #### Documentation
 

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -242,7 +242,12 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
 
   local origFlags="$-"
   set +eET
-  local origIFS="$IFS"
+  local origIFS="${IFS-}"
+  local origIFS_set="${IFS+set}"
+  local IFS="$origIFS"
+  if [[ ! $origIFS_set ]]; then
+    unset -v IFS
+  fi
   if [[ $keep_empty_lines ]]; then
     # 'output', 'status', 'lines' are global variables available to tests.
     # preserve trailing newlines by appending . and removing it later
@@ -265,7 +270,11 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
 
   # shellcheck disable=SC2034
   BATS_RUN_COMMAND="${*}"
-  IFS="$origIFS"
+  if [[ $origIFS_set ]]; then
+    IFS="$origIFS"
+  else
+    unset -v IFS
+  fi
   set "-$origFlags"
 
   if [[ ${BATS_VERBOSE_RUN:-} ]]; then

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -247,12 +247,12 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
     # 'output', 'status', 'lines' are global variables available to tests.
     # preserve trailing newlines by appending . and removing it later
     # shellcheck disable=SC2034
-    output="$($pre_command "$@"; status=$?; printf .; exit $status)" && status=0 || status=$?
+    output="$("$pre_command" "$@"; status=$?; printf .; exit $status)" && status=0 || status=$?
     output="${output%.}"
   else
     # 'output', 'status', 'lines' are global variables available to tests.
     # shellcheck disable=SC2034
-    output="$($pre_command "$@")" && status=0 || status=$?
+    output="$("$pre_command" "$@")" && status=0 || status=$?
   fi
 
   bats_separate_lines lines output

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -242,12 +242,6 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
 
   local origFlags="$-"
   set +eET
-  local origIFS="${IFS-}"
-  local origIFS_set="${IFS+set}"
-  local IFS="$origIFS"
-  if [[ ! $origIFS_set ]]; then
-    unset -v IFS
-  fi
   if [[ $keep_empty_lines ]]; then
     # 'output', 'status', 'lines' are global variables available to tests.
     # preserve trailing newlines by appending . and removing it later
@@ -270,11 +264,6 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
 
   # shellcheck disable=SC2034
   BATS_RUN_COMMAND="${*}"
-  if [[ $origIFS_set ]]; then
-    IFS="$origIFS"
-  else
-    unset -v IFS
-  fi
   set "-$origFlags"
 
   if [[ ${BATS_VERBOSE_RUN:-} ]]; then

--- a/test/pretty-formatter.bats
+++ b/test/pretty-formatter.bats
@@ -56,10 +56,10 @@ HERE
   }
   run format_example_stream
   # black text, green timing
-  [[ "${lines[1]}" == *$'\x1b[2G\x1b[1G ✓ test timing=1, timeout=0\x1b[32;22m [123]'* ]]
+  [[ "${lines[1]}" == *$'\x1b[2G\x1b[1G ✓ test timing=1, timeout=0\x1b[32;22m [123]'* ]] || false
   # red bold text, green timing
-  [[ "${lines[2]}" == *$'\x1b[2G\x1b[33;1m\x1b[1G ✗ test timing=1, timeout=1\x1b[32;22m [456 (timeout: 0s)]'* ]]
-  [[ "${lines[4]}" == *$'2 tests, 0 failures, 1 timed out in 0 seconds'* ]]
+  [[ "${lines[2]}" == *$'\x1b[2G\x1b[33;1m\x1b[1G ✗ test timing=1, timeout=1\x1b[32;22m [456 (timeout: 0s)]'* ]] || false
+  [[ "${lines[4]}" == *'2 tests, 0 failures, 1 timed out in '*' seconds' ]] || false
 
 format_example_stream() {
     bats-format-pretty  <<HERE

--- a/test/run.bats
+++ b/test/run.bats
@@ -120,3 +120,12 @@ print-stderr-stdout() {
   [ "${lines[7]}" == "#   \`run -256 echo hi' failed" ]
   [ "${lines[8]}" == "# Usage error: run: '-NNN': NNN must be <= 255 (got: 256)" ]
 }
+
+@test "run is not affected by IFS" {
+  IFS=_
+  run true
+  [ "$status" -eq 0 ]
+  IFS=0
+  run true
+  [ "$status" -eq 0 ]
+}

--- a/test/run.bats
+++ b/test/run.bats
@@ -129,3 +129,12 @@ print-stderr-stdout() {
   run true
   [ "$status" -eq 0 ]
 }
+
+@test "run does not change IFS" {
+  local IFS=_
+  run true
+  [ "$IFS" = _ ]
+  unset IFS
+  run true
+  [ "${IFS-(unset)}" = '(unset)' ]
+}


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

## Environment and steps to reproduce the issue

> **Bugs/usage issues**
> 1. State the version of Bash you're using bash --version

```bash
$ LANG=C bash --version
GNU bash, version 5.1.16(1)-release (x86_64-redhat-linux-gnu)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

> 2. State your operating system and its version

```bash
$ cat /etc/os-release
NAME="Fedora Linux"
VERSION="36 (Server Edition)"
ID=fedora
VERSION_ID=36
VERSION_CODENAME=""
PLATFORM_ID="platform:f36"
PRETTY_NAME="Fedora Linux 36 (Server Edition)"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:36"
HOME_URL="https://fedoraproject.org/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f36/system-administrators-guide/"
SUPPORT_URL="https://ask.fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=36
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=36
PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
VARIANT="Server Edition"
VARIANT_ID=server
```

> 3. Command line steps or code snippets that reproduce the issue


```bash
$ bats --version
Bats 1.7.0
$ cat test1.bats
@test "test something with a special IFS" {
  IFS=_
  run true
  [ "$status" -eq 0 ]
}
$ bats test1.bats
test1.bats
 ✗ test something with a special IFS
   (in test file test1.bats, line 4)
     `[ "$status" -eq 0 ]' failed
   Error: Test file "/home/murase/.mwg/git/bats-core/bats-core/t/merge" does not exist

1 test, 1 failure

$
```

> 4. Any apparently relevant information from the [Bash changelog](https://tiswww.case.edu/php/chet/bash/CHANGES)

I believe this is unrelated to any changes in Bash.

## Issues and fixes

I wanted to perform a test with a special value of `IFS` but noticed that `run` always fails with `IFS=_`. This is caused by [unquoted `$pre_command` in this line](https://github.com/bats-core/bats-core/blob/0e8d70b4faca091e34076b14ccc8be28c21f1b65/lib/bats-core/test_functions.bash#L250). The variable `pre_command` contains a function name including `_`, so the function name is split by `IFS=_` by word splitting. To fix the issue, we can just quote the function name by `" ... "`. See c8b5bba.

I also noticed that `run` tries to recover the original value of `IFS`, but this fails to restore the original state of `IFS` when `IFS` is in the unset state before the test. It should be noted that the empty IFS and the unset IFS have different meanings: e.g. word splitting is disabled by the empty IFS while word splitting is performed with the unset IFS as if it has the default value `$' \t\n'`. To fix the issue, we may just declare `IFS` locally in the function. We may also save and restore the set/unset state of `IFS` as well as its value in the function. See d62e928.



