### PR TITLE
Fix infinite wait when invoking "bats -j5" instead of "bats -j 5"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * `shfmt` all files and enforce via CI (#651)
 * avoid kernel warning flood/hang with CTRL+C on Bash 5.2 RC (#656)
+* Fix infinite wait with (invalid) `-j<n>` (without space) (#657)
 
 ## [1.8.0] - 2022-09-15
 

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -285,6 +285,11 @@ bats_read_tests_list_file() {
 bats_run_tests() {
   bats_exec_file_status=0
 
+  if [[ "$num_jobs" -lt 1 ]]; then
+    printf 'Invalid number of jobs: %s\n' "$num_jobs" >&2
+    exit 1
+  fi
+
   if [[ "$num_jobs" != 1 && "${BATS_NO_PARALLELIZE_WITHIN_FILE-False}" == False ]]; then
     export BATS_SEMAPHORE_NUMBER_OF_SLOTS="$num_jobs"
     bats_run_tests_in_parallel "$BATS_RUN_TMPDIR/parallel_output" || bats_exec_file_status=1

--- a/test/parallel.bats
+++ b/test/parallel.bats
@@ -5,6 +5,9 @@ bats_require_minimum_version 1.5.0
 load test_helper
 fixtures parallel
 
+# shellcheck disable=SC2034
+BATS_TEST_TIMEOUT=10 # only intended for the "short form ..."" test
+
 setup() {
   type -p parallel &>/dev/null || skip "--jobs requires GNU parallel"
   (type -p flock &>/dev/null || type -p shlock &>/dev/null) || skip "--jobs requires flock/shlock"
@@ -207,4 +210,11 @@ check_parallel_tests() { # <expected maximum parallelity>
 
 @test "BATS_NO_PARALLELIZE_WITHIN_FILE does not work from inside test function" {
   DISABLE_IN_TEST_FUNCTION=1 reentrant_run ! bats --jobs 2 "$FIXTURE_ROOT/must_not_parallelize_within_file.bats"
+}
+
+@test "Short form typo does not run endlessly" {
+  unset BATS_NO_PARALLELIZE_ACROSS_FILES
+  run bats -j2 "$FIXTURE_ROOT/../bats/passing.bats"
+  (( SECONDS < 5 ))
+  [ "${lines[1]}" = 'Invalid number of jobs: -2' ]
 }

--- a/test/timeout.bats
+++ b/test/timeout.bats
@@ -23,3 +23,7 @@ bats_require_minimum_version 1.5.0
   [ "${lines[3]}" == "#   \`sleep \"\${SLEEP?}\"' failed due to timeout" ]
   ((SECONDS < 10)) || false
 }
+
+@test "sleep in run" {
+    run sleep 10
+}


### PR DESCRIPTION
bats's option parser translates "-j5" to "-j -5". This caused a negative number of "slots" (threads) to be available and the test to silently hang forever. Not nice.

Add a $num_jobs sanity check to fail immediately like this:

```
Invalid number of jobs: -5
tests.bats
   bats warning: Executed 0 instead of expected 3 tests

3 tests, 0 failures, 3 not run
```

Non-numeric arguments (e.g.: -jf) evaluate to zero which also fails the check.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
