### PR TITLE
Stricter `parallel` Exists Check

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ### Fixed
 
+* explicitly check for GNU parallel (#691)
+
 #### Documentation
 
 * improved clarity of section about output in free code (#671)

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -97,7 +97,7 @@ while [[ "$#" -ne 0 ]]; do
 done
 
 if [[ "$num_jobs" != 1 ]]; then
-  if ! type -p parallel >/dev/null && [[ -z "$bats_no_parallelize_across_files" ]]; then
+  if ! type -p parallel >/dev/null && parallel --version &>/dev/null && [[ -z "$bats_no_parallelize_across_files" ]]; then
     abort "Cannot execute \"${num_jobs}\" jobs without GNU parallel"
     exit 1
   fi

--- a/test/parallel.bats
+++ b/test/parallel.bats
@@ -9,7 +9,7 @@ fixtures parallel
 BATS_TEST_TIMEOUT=10 # only intended for the "short form ..."" test
 
 setup() {
-  type -p parallel &>/dev/null || skip "--jobs requires GNU parallel"
+  (type -p parallel &>/dev/null && parallel --version &>/dev/null) || skip "--jobs requires GNU parallel"
   (type -p flock &>/dev/null || type -p shlock &>/dev/null) || skip "--jobs requires flock/shlock"
 }
 


### PR DESCRIPTION
There are 2 common implementations of `parallel`: GNU parallel (https://www.gnu.org/software/parallel/) and moreutils' parallel (https://manpages.debian.org/testing/moreutils/parallel.1.en.html, https://linux.die.net/man/1/parallel).

The former is much more feature rich and is the actual intended dependency of parallel tests in bats.

The latter is far more common on many operating systems (including Ubuntu).

Currently, when the `parallel.bats` file runs, it checks to see if `parallel` is available and will skip the test if not. Unfortunately, this only checks that there is _a_ `parallel` command available -- not necessarily the correct one. If moreutils parallel is installed, the skip will not occur and the test will later fail in "libexec/bats-core/bats-exec-suite", when trying to run `parallel --keep-order --jobs ...` -- these CLI args are unknown to moreutils `parallel`.

This PR improves the check such that not _any_ `parallel` command will work. This check is extended by checking that the `parallel` command supports `--version`, which distinguishes between GNU parallel (supported) and moreutils parallel (unsupported).

Fixes https://github.com/bats-core/bats-core/issues/672.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
