### PR TITLE
test/parallel: add a test for negative jobs number arguments

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * add `${BATS_TEST_TAGS[@]}` for querying the tags during a test (#705)
 * print tags on failing tests (#705)
+* test for negative arguments to `--jobs` (#693)
+
 ### Fixed
 
 * fix `${BATS_TEST_NAMES[@]}` containing only `--tags` instead of test name since Bats v1.8.0 (#705)

--- a/test/parallel.bats
+++ b/test/parallel.bats
@@ -218,3 +218,10 @@ check_parallel_tests() { # <expected maximum parallelity>
   (( SECONDS < 5 ))
   [ "${lines[1]}" = 'Invalid number of jobs: -2' ]
 }
+
+@test "Negative jobs number does not run endlessly" {
+  unset BATS_NO_PARALLELIZE_ACROSS_FILES
+  run bats -j -3 "$FIXTURE_ROOT/../bats/passing.bats"
+  (( SECONDS < 5 ))
+  [ "${lines[1]}" = 'Invalid number of jobs: -3' ]
+}


### PR DESCRIPTION
Before commit 48b0d2650a96, -j2 and -j -2 both triggered an infinite loop. That commit fixed the infinite loop but -j2 and -j -2 are still parsed the same. In the corresponding code review #657 Martin expressed an intent to change the parser and parse these differently in the future.

In commit 0ec3619426f5 Martin added a "no infinite loop" test for "-j2". However this test will stop testing negative arguments when the parser changes (the test will also have to be adjusted when the parser changes).

Add one additional test with a "-j -3" argument that will test a negative argument forever.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
