### PR TITLE
Fix BATS_TEST_NAMES contains "--tags"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+* add `${BATS_TEST_TAGS[@]}` for querying the tags during a test (#705)
+* print tags on failing tests (#705)
+### Fixed
+
+* fix `${BATS_TEST_NAMES[@]}` containing only `--tags` instead of test name since Bats v1.8.0 (#705)
+
 ## [1.9.0] - 2023-02-12
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 [kac]: https://keepachangelog.com/en/1.0.0/
 [semver]: https://semver.org/
 
+## [Unreleased]
+
 ## [1.9.0] - 2023-02-12
 
 ### Added

--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -582,6 +582,7 @@ There are several global variables you can use to introspect on Bats tests:
   is `setup_file()`.
 - `$BATS_TEST_NUMBER` is the (1-based) index of the current test case in the test file.
 - `$BATS_SUITE_TEST_NUMBER` is the (1-based) index of the current test case in the test suite (over all files).
+- `$BATS_TEST_TAGS` the tags of the current test.
 - `$BATS_TMPDIR` is the base temporary directory used by bats to create its
    temporary files / directories.
    (default: `$TMPDIR`. If `$TMPDIR` is not set, `/tmp` is used.)

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -355,7 +355,8 @@ bats_test_function() {
   local test_name="$1"
   BATS_TEST_NAMES+=("$test_name")
   if [[ "$test_name" == "$BATS_TEST_NAME" ]]; then
-    BATS_TEST_TAGS=("${tags[@]}")
+    # shellcheck disable=SC2034
+    readonly BATS_TEST_TAGS=("${tags[@]}")
   fi
 }
 

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -347,6 +347,9 @@ bats_test_begin() {
 }
 
 bats_test_function() {
+  if [[ "$1" == --tags ]]; then
+    shift 2
+  fi
   local test_name="$1"
   BATS_TEST_NAMES+=("$test_name")
 }

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -356,7 +356,7 @@ bats_test_function() {
   BATS_TEST_NAMES+=("$test_name")
   if [[ "$test_name" == "$BATS_TEST_NAME" ]]; then
     # shellcheck disable=SC2034
-    readonly BATS_TEST_TAGS=("${tags[@]}")
+    BATS_TEST_TAGS=("${tags[@]+${tags[@]}}")
   fi
 }
 

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -347,11 +347,16 @@ bats_test_begin() {
 }
 
 bats_test_function() {
+  local tags=()
   if [[ "$1" == --tags ]]; then
+    IFS=',' read -ra tags <<<"$2"
     shift 2
   fi
   local test_name="$1"
   BATS_TEST_NAMES+=("$test_name")
+  if [[ "$test_name" == "$BATS_TEST_NAME" ]]; then
+    BATS_TEST_TAGS=("${tags[@]}")
+  fi
 }
 
 # decides whether a failed test should be run again

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -157,6 +157,11 @@ bats_exit_trap() {
       rm -r "$BATS_TEST_TMPDIR" # clean up for retry
     else
       printf 'not ok %d %s%s\n' "$BATS_SUITE_TEST_NUMBER" "${BATS_TEST_NAME_PREFIX:-}${BATS_TEST_DESCRIPTION}${BATS_TEST_TIME}" "$exit_metadata" >&3
+      if (( ${#BATS_TEST_TAGS[@]} > 0 )); then
+        printf '# tags:'
+        printf ' %s' "${BATS_TEST_TAGS[@]}"
+        printf '\n'
+      fi >&3
       local stack_trace
       bats_get_failure_stack_trace stack_trace
       bats_print_stack_trace "${stack_trace[@]}" >&3

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -347,4 +347,5 @@ exec 3<&1
 bats_create_test_tmpdirs
 # Run the given test.
 bats_evaluate_preprocessed_source
+readonly BATS_TEST_TAGS
 bats_perform_test

--- a/man/bats.7.ronn
+++ b/man/bats.7.ronn
@@ -317,6 +317,7 @@ in the test file.
 * `$BATS_FILE_EXTENSION` (default: `bats`) specifies the extension of
 test files that should be found when running a suite (via
 `bats [-r] suite_folder/`)
+* `$BATS_TEST_TAGS` the tags of the current test.
 * `$BATS_SUITE_TMPDIR` is a temporary directory common to all tests of a suite.
   Could be used to create files required by multiple tests.
 * `$BATS_FILE_TMPDIR` is a temporary directory common to all tests of a test file.

--- a/test/fixtures/bats/BATS_variables_dont_contain_double_slashes.bats
+++ b/test/fixtures/bats/BATS_variables_dont_contain_double_slashes.bats
@@ -1,6 +1,6 @@
 @test "BATS_* variables don't contain double slashes" {
   for var_name in ${!BATS_@}; do
-    local var_value="${!var_name}"
+    local var_value="${!var_name-}"
     if [[ "$var_value" == *'//'* ]]; then
 
       echo "$var_name contains // ${#var_value}: ${var_value}" && false

--- a/test/fixtures/suite/test_number/file2.bats
+++ b/test/fixtures/suite/test_number/file2.bats
@@ -18,6 +18,6 @@
 }
 
 @test "BATS_TEST_NAMES is per file" {
-  echo "${#BATS_TEST_NAMES[@]}"
-  [[ "${#BATS_TEST_NAMES[@]}" == 4 ]]
+  echo "${#BATS_TEST_NAMES[@]} ${BATS_TEST_NAMES[0]}"
+  [ "${BATS_TEST_NAMES[0]}" == test_first_test_in_file_2 ]
 }

--- a/test/fixtures/suite/test_number/file2.bats
+++ b/test/fixtures/suite/test_number/file2.bats
@@ -2,22 +2,23 @@
 
 @test "first test in file 2" {
   echo "BATS_TEST_NUMBER=$BATS_TEST_NUMBER"
-  [[ "$BATS_TEST_NUMBER" == 1 ]]
+  [ "$BATS_TEST_NUMBER" -eq 1 ]
   echo "BATS_SUITE_TEST_NUMBER=$BATS_SUITE_TEST_NUMBER"
-  [[ "$BATS_SUITE_TEST_NUMBER" == 4 ]]
+  [ "$BATS_SUITE_TEST_NUMBER" -eq 4 ]
 }
 
 @test "second test in file 2" {
-  [[ "$BATS_TEST_NUMBER" == 2 ]]
-  [[ "$BATS_SUITE_TEST_NUMBER" == 5 ]]
+  [ "$BATS_TEST_NUMBER" -eq 2 ]
+  [ "$BATS_SUITE_TEST_NUMBER" -eq 5 ]
 }
 
 @test "second test in file 3" {
-  [[ "$BATS_TEST_NUMBER" == 3 ]]
-  [[ "$BATS_SUITE_TEST_NUMBER" == 6 ]]
+  [ "$BATS_TEST_NUMBER" -eq 3 ]
+  [ "$BATS_SUITE_TEST_NUMBER" -eq 6 ]
 }
 
 @test "BATS_TEST_NAMES is per file" {
   echo "${#BATS_TEST_NAMES[@]} ${BATS_TEST_NAMES[0]}"
+  [ "${#BATS_TEST_NAMES[@]}" -eq 4 ]
   [ "${BATS_TEST_NAMES[0]}" == test_first_test_in_file_2 ]
 }

--- a/test/fixtures/tagging/BATS_TEST_TAGS.bats
+++ b/test/fixtures/tagging/BATS_TEST_TAGS.bats
@@ -1,0 +1,26 @@
+setup() {
+    declare -p BATS_TEST_TAGS
+}
+
+@test "no tags" {
+    [ ${#BATS_TEST_TAGS[@]} -eq 0 ]
+}
+
+# bats test_tags=test_tag
+@test "only test tags" {
+    [ ${#BATS_TEST_TAGS[@]} -eq 1 ]
+    [ "${BATS_TEST_TAGS[0]}" == test_tag ]
+}
+
+# bats file_tags=file_tag
+@test "only file tags" {
+    [ ${#BATS_TEST_TAGS[@]} -eq 1 ]
+    [ "${BATS_TEST_TAGS[0]}" == file_tag ]
+}
+
+# bats test_tags=test_tag
+@test "test and file tags" {
+    [ ${#BATS_TEST_TAGS[@]} -eq 2 ]
+    [ "${BATS_TEST_TAGS[0]}" == file_tag ]
+    [ "${BATS_TEST_TAGS[1]}" == test_tag ]
+}

--- a/test/fixtures/tagging/print_tags_on_error.bats
+++ b/test/fixtures/tagging/print_tags_on_error.bats
@@ -1,0 +1,5 @@
+# bats file_tags=file_tag
+# bats test_tags=test_tag
+@test error {
+    false
+}

--- a/test/tagging.bats
+++ b/test/tagging.bats
@@ -77,3 +77,9 @@ setup() {
 @test "BATS_TEST_TAGS are set correctly" {
   run -0 bats "$FIXTURE_ROOT/BATS_TEST_TAGS.bats"
 }
+
+@test "Print tags on error" {
+  run -1 bats "$FIXTURE_ROOT/print_tags_on_error.bats"
+
+  [ "${lines[2]}" = '# tags: file_tag test_tag' ]
+}

--- a/test/tagging.bats
+++ b/test/tagging.bats
@@ -73,3 +73,7 @@ setup() {
   [ "${lines[2]}" = 'ok 2 Only test tags' ]
   [ "${#lines[@]}" -eq 3 ]
 }
+
+@test "BATS_TEST_TAGS are set correctly" {
+  run -0 bats "$FIXTURE_ROOT/BATS_TEST_TAGS.bats"
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -45,7 +45,7 @@ execute_with_unset_bats_vars() { # <command to execute...>
   "$@"
 }
 
-REENTRANT_RUN_PRESERVE+=(BATS_ROOT)
+REENTRANT_RUN_PRESERVE+=(BATS_ROOT BATS_TEST_TAGS)
 
 # call run with all BATS_* variables purged from the environment
 reentrant_run() { # <same args as run>


### PR DESCRIPTION
Fixes #700, fixes #689

* fix BATS_TEST_NAMES containing `--tag` since v1.8.0
* add BATS_TEST_TAGS
* print BATS_TEST_TAGS on error, if the test has tags