### PR TITLE
Fix extra empty line with run --keep-empty-lines (fixes #708)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 ### Fixed
 
 * fix `${BATS_TEST_NAMES[@]}` containing only `--tags` instead of test name since Bats v1.8.0 (#705)
+* fix `run --keep-empty-lines` counting trailing `\n` as (empty) new line (#711)
 
 #### Documentation
 

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -163,14 +163,17 @@ bats_merge_stdout_and_stderr() {
 
 # write separate lines from <input-var> into <output-array>
 bats_separate_lines() { # <output-array> <input-var>
-  local output_array_name="$1"
-  local input_var_name="$2"
+  local -r output_array_name="$1"
+  local -r input_var_name="$2"
+  local input="${!input_var_name}"
   if [[ $keep_empty_lines ]]; then
     local bats_separate_lines_lines=()
-    if [[ -n "${!input_var_name}" ]]; then # avoid getting an empty line for empty input
+    if [[ -n "$input" ]]; then # avoid getting an empty line for empty input
+      # remove one trailing \n if it exists to compensate its addition by <<<
+      input=${input%$'\n'}
       while IFS= read -r line; do
         bats_separate_lines_lines+=("$line")
-      done <<<"${!input_var_name}"
+      done <<<"${input}"
     fi
     eval "${output_array_name}=(\"\${bats_separate_lines_lines[@]}\")"
   else

--- a/test/run.bats
+++ b/test/run.bats
@@ -19,21 +19,19 @@ bats_require_minimum_version 1.5.0
   [ ${#lines[@]} -eq 3 ]
 }
 
-@test "run --keep-empty-lines preserves trailing empty lines" {
+@test "run --keep-empty-lines does not count trailing newline as extra line (see #708)" {
   run --keep-empty-lines -- echo -n $'a\n'
   printf "'%s'\n" "${lines[@]}"
   [ "${lines[0]}" == a ]
-  [ "${lines[1]}" == '' ]
-  [ ${#lines[@]} -eq 2 ]
+  [ ${#lines[@]} -eq 1 ]
 }
 
-@test "run --keep-empty-lines preserves multiple trailing empty lines" {
+@test "run --keep-empty-lines preserves trailing empty line" {
   run --keep-empty-lines -- echo -n $'a\n\n'
   printf "'%s'\n" "${lines[@]}"
   [ "${lines[0]}" == a ]
   [ "${lines[1]}" == '' ]
-  [ "${lines[2]}" == '' ]
-  [ ${#lines[@]} -eq 3 ]
+  [ ${#lines[@]} -eq 2 ]
 }
 
 @test "run --keep-empty-lines preserves non-empty trailing line" {


### PR DESCRIPTION
Fixes #708 