### PR TITLE
docs: Add external library link to `hyperupcall/bats-all`

### DIFF
--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -609,6 +609,7 @@ Bats supports loading external assertion libraries and helpers. Those under `bat
 
 and some external libraries, supported on a "best-effort" basis:
 
+- <https://github.com/hyperupcall/bats-all> - `git-subtree(1)`-managed aggregation of `bats-{support,assert,file}`
 - <https://github.com/ztombol/bats-docs> (still relevant? Requires review)
 - <https://github.com/grayhemp/bats-mock> (as per #147)
 - <https://github.com/jasonkarns/bats-mock> (how is this different from grayhemp/bats-mock?)


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

Looking at the [libraries and add-ons page](https://bats-core.readthedocs.io/en/stable/writing-tests.html#libraries-and-add-ons), I was thinking other people might find the [`bats-all`](https://github.com/hyperupcall/bats-all) repository (disclaimer: I maintain it) useful.

It's useful because it reduces the burden of adding any of the official Bats libraries to any project. Instead of managing 3 (usually) repositories with `git-submodule(1)` or `git-subtree(1)` (`npm` isn't appropriate for every project), now only one repository needs to be managed. It also contains a package definition for [Basalt](https://github.com/hyperupcall/basalt), the newest Bash package manager on the block (disclaimer: I've written and maintain Basalt). It also contains a (subshell-less) `load.bash` file so it shares the idioms of the core Bats libraries for familiarity.

I've maintained it since [October of 2021](https://github.com/hyperupcall/bats-all/releases/tag/v3.0.0) and it contains the official `bats-support`, `bats-assert`, and `bats-file` repositories managed with `git-subtree(1)`. I also dogfood the repository for many other Bash projects of mine.



[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
