### PR TITLE
run: don't change the value of i

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ### Fixed
 
+* fix `run` with options overwriting the value of `i` (#726, #727)
 * fix `${BATS_TEST_NAMES[@]}` containing only `--tags` instead of test name since Bats v1.8.0 (#705)
 * fix `run --keep-empty-lines` counting trailing `\n` as (empty) new line (#711)
 

--- a/lib/bats-core/common.bash
+++ b/lib/bats-core/common.bash
@@ -39,6 +39,7 @@ bats_version_lt() { # <version1> <version2>
   IFS=. read -ra version1_parts <<<"$1"
   IFS=. read -ra version2_parts <<<"$2"
 
+  local -i i
   for i in {0..2}; do
     if ((version1_parts[i] < version2_parts[i])); then
       return 0
@@ -139,6 +140,7 @@ bats_all_in() { # <sorted-array> <sorted search values...>
 
   local -i haystack_index=0         # initialize only here to continue from last search position
   local search_value haystack_value # just to appease shellcheck
+  local -i i
   for ((i = 1; i <= $#; ++i)); do
     eval "local search_value=${!i}"
     for (( ; haystack_index < haystack_length; ++haystack_index)); do
@@ -168,6 +170,7 @@ bats_any_in() { # <sorted-array> <sorted search values>
 
   local -i haystack_index=0         # initialize only here to continue from last search position
   local search_value haystack_value # just to appease shellcheck
+  local -i i
   for ((i = 1; i <= $#; ++i)); do
     eval "local search_value=${!i}"
     for (( ; haystack_index < haystack_length; ++haystack_index)); do


### PR DESCRIPTION
I came across an interesting bug today. A very simple test code stopped working properly once I changed "run" followed by the $status check to "run !".

Fixes: https://github.com/bats-core/bats-core/issues/726 (see for a repro).

The fix is to always declare your variables.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
