### PR TITLE
List test names 508 701

### DIFF
--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -137,7 +137,7 @@ fi
 arguments=()
 
 # list of single char options that don't expect a value
-single_char_flags="hvcprtTx"
+single_char_flags="hvclLprtTx"
 
 # Unpack single-character options bundled together, e.g. -cr, -pr.
 for arg in "$@"; do

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -170,6 +170,7 @@ formatter=${BATS_FORMATTER:-'tap'}
 report_formatter=''
 recursive=
 setup_suite_file=''
+skip_formatter=
 export BATS_TEMPDIR_CLEANUP=1
 if [[ -z "${CI:-}" && -t 0 && -t 1 ]] && command -v tput >/dev/null; then
   formatter='pretty'
@@ -229,9 +230,11 @@ while [[ "$#" -ne 0 ]]; do
     ;;
   -l | --list)
     flags+=('-l')
+    skip_formatter=1
     ;;
   -L | --list-with-filename)
     flags+=('-L')
+    skip_formatter=1
     ;;
   -r | --recursive)
     recursive=1
@@ -513,7 +516,10 @@ bats_tee() { # <output-file> <command...>
   return $status
 }
 
-if [[ -n "$report_formatter" ]]; then
+# skip output formatting in case of we onyl print names (-l/-L)
+if [[ -n "$skip_formatter" ]]; then
+  exec bats-exec-suite "${flags[@]}" "${filenames[@]}"
+elif [[ -n "$report_formatter" ]]; then
   exec bats-exec-suite "${flags[@]}" "${filenames[@]}" |
     bats_tee "${BATS_REPORT_OUTPUT_DIR}/${BATS_REPORT_FILENAME}" "$interpolated_report_formatter" "${report_formatter_flags[@]}" |
     bats_test_count_validator |

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -64,6 +64,8 @@ HELP_TEXT_HEADER
   -h, --help                Display this help message
   -j, --jobs <jobs>         Number of parallel jobs (requires GNU parallel or shenwei356/rush)
   --parallel-binary-name    Name of parallel binary
+  -l, --list                list test names without running any tests
+  -L, --list-with-filename  Same as -l but print filenames, too
   --no-tempdir-cleanup      Preserve test output temporary directory
   --no-parallelize-across-files
                             Serialize test file execution instead of running
@@ -224,6 +226,12 @@ while [[ "$#" -ne 0 ]]; do
   --parallel-binary-name)
     shift
     flags+=('--parallel-binary-name' "$1")
+    ;;
+  -l | --list)
+    flags+=('-l')
+    ;;
+  -L | --list-with-filename)
+    flags+=('-L')
     ;;
   -r | --recursive)
     recursive=1

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -103,7 +103,7 @@ bats_run_setup_file() {
 
 bats_run_teardown_file() {
   local bats_teardown_file_status=0
-  # avoid running the therdown trap due to errors in teardown_file
+  # avoid running the teardown trap due to errors in teardown_file
   trap 'bats_file_exit_trap' EXIT
 
   # rely on bats_error_trap to catch failures

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -2,6 +2,7 @@
 set -e
 
 count_only_flag=''
+list_only_flag=0
 filter=''
 num_jobs=${BATS_NUMBER_OF_PARALLEL_JOBS:-1}
 parallel_binary_name=${BATS_PARALLEL_BINARY_NAME:-"parallel"}
@@ -39,6 +40,12 @@ while [[ "$#" -ne 0 ]]; do
   --parallel-binary-name)
     shift
     parallel_binary_name="$1"
+    ;;
+  -l)
+    list_only_flag=1
+    ;;
+  -L)
+    list_only_flag=2
     ;;
   -T)
     flags+=('-T')
@@ -309,6 +316,57 @@ fi
 
 if [[ -n "$count_only_flag" ]]; then
   printf '%d\n' "${test_count}"
+  exit
+fi
+
+bats_decode_test_name() {
+  local name="$1"
+  local length="${#name}"
+  name="${name#test_}"
+  local i=0
+  local result=''
+  local char=''
+  while (( i < length )); do
+    char="${name:$i:1}"
+    case $char in
+      '-')
+        (( i += 1 ))
+        if [[ "${name:$i:4}" == '2d5f' ]]; then
+          result+="_"
+          (( i += 4 ))
+        else
+          result+=$(printf "%b" "\x${name:$i:2}")
+          (( i += 2 ))
+        fi
+      ;;
+      '_')
+        result+=" "
+        (( i += 1 ))
+        ;;
+      *)
+        result+="$char"
+        (( i += 1 ))
+    ;;
+    esac
+  done
+  printf -v "$2" '%s' "$result"
+}
+
+if [[ "$list_only_flag" -gt 0 ]]; then
+  decoded_name=''
+  TEST_LINE_PATTERN="^(.*)\s+([^[:blank:]]+)$"
+  while read -r test_line; do
+    if [[ "$test_line" =~ $TEST_LINE_PATTERN ]]; then
+      filename="${BASH_REMATCH[1]}"
+      test_name="${BASH_REMATCH[2]}"
+      bats_decode_test_name "$test_name" 'decoded_name'
+      if [[ "$list_only_flag" -eq 1 ]]; then
+        printf "%s\n" "$decoded_name"
+      else
+        printf "%s : %s\n" "$filename" "$decoded_name"
+      fi
+    fi
+  done < "$TESTS_LIST_FILE"
   exit
 fi
 

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -316,7 +316,7 @@ fi
 
 if [[ -n "$count_only_flag" ]]; then
   printf '%d\n' "${test_count}"
-  [[ "$list_only_flag" -eq 0 ]] && exit
+  [[ "$list_only_flag" -eq 0 ]] && exit 0
 fi
 
 bats_decode_test_name() {

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -316,7 +316,7 @@ fi
 
 if [[ -n "$count_only_flag" ]]; then
   printf '%d\n' "${test_count}"
-  exit
+  [[ "$list_only_flag" -eq 0 ]] && exit
 fi
 
 bats_decode_test_name() {
@@ -353,6 +353,11 @@ bats_decode_test_name() {
 }
 
 if [[ "$list_only_flag" -gt 0 ]]; then
+  # No point on continuing if there's no test.
+  if [[ "${test_count}" -eq 0 ]]; then
+    exit 0
+  fi
+
   decoded_name=''
   TEST_LINE_PATTERN="^(.*)\s+([^[:blank:]]+)$"
   while read -r test_line; do
@@ -367,7 +372,7 @@ if [[ "$list_only_flag" -gt 0 ]]; then
       fi
     fi
   done < "$TESTS_LIST_FILE"
-  exit
+  exit 0
 fi
 
 if [[ -n "$bats_no_parallelize_across_files" ]] && [[ ! "$num_jobs" -gt 1 ]]; then
@@ -388,7 +393,7 @@ fi
 bats_exec_suite_status=0
 printf '1..%d\n' "${test_count}"
 
-# No point on continuing if there's no tests.
+# No point on continuing if there's no test.
 if [[ "${test_count}" == 0 ]]; then
   exit
 fi

--- a/man/bats.1
+++ b/man/bats.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "BATS" "1" "November 2022" "bats-core" "Bash Automated Testing System"
+.TH "BATS" "1" "June 2023" "bats-core" "Bash Automated Testing System"
 .SH "NAME"
 \fBbats\fR \- Bash Automated Testing System
 .SH "SYNOPSIS"
@@ -39,75 +39,69 @@ A query of \fB\-\-filter\-tags a,!b \-\-filter\-tags b,c\fR can be translated to
 .P
 An empty tag list matches tests without tags\.
 .SH "OPTIONS"
-.TP
-\fB\-c\fR, \fB\-\-count\fR
-Count the number of test cases without running any tests
-.TP
-\fB\-\-code\-quote\-style <style>\fR
-A two character string of code quote delimiters or \fBcustom\fR which requires setting \fB$BATS_BEGIN_CODE_QUOTE\fR and \fB$BATS_END_CODE_QUOTE\fR\. Can also be set via \fB$BATS_CODE_QUOTE_STYLE\fR\.
-.TP
-\fB\-f\fR, \fB\-\-filter <regex>\fR
-Filter test cases by names matching the regular expression
-.TP
-\fB\-F\fR, \fB\-\-formatter <type>\fR
-Switch between formatters: pretty (default), tap (default w/o term), tap13, junit, \fB/<absolute path to formatter>\fR
-.TP
-\fB\-\-filter\-status <status>\fR
-Only run tests with the given status in the last completed (no CTRL+C/SIGINT) run\. Valid \fIstatus\fR values are: failed \- runs tests that failed or were not present in the last run missed \- runs tests that were not present in the last run
-.TP
-\fB\-\-filter\-tags <comma\-separated\-tag\-list>\fR
-Only run tests that match all the tags in the list (\fB&&\fR)\. You can negate a tag via prepending \fB!\fR\. Specifying this flag multiple times allows for logical or (\fB||\fR): \fB\-\-filter\-tags A,B \-\-filter\-tags A,!C\fR matches tags \fB(A && B) || (A && !C)\fR
-.TP
-\fB\-\-gather\-test\-outputs\-in <directory>\fR
-Gather the output of failing \fIand\fR passing tests as files in directory
-.TP
-\fB\-h\fR, \fB\-\-help\fR
-Display this help message
-.TP
-\fB\-j\fR, \fB\-\-jobs <jobs>\fR
-Number of parallel jobs (requires GNU parallel)
-.TP
-\fB\-\-no\-tempdir\-cleanup\fR
-Preserve test output temporary directory
-.TP
-\fB\-\-no\-parallelize\-across\-files\fR
-Serialize test file execution instead of running them in parallel (requires \-\-jobs >1)
-.TP
-\fB\-\-no\-parallelize\-within\-files\fR
-Serialize test execution within files instead of running them in parallel (requires \-\-jobs >1)
-.TP
-\fB\-\-report\-formatter <type>\fR
-Switch between reporters (same options as \-\-formatter)
-.TP
-\fB\-o\fR, \fB\-\-output <dir>\fR
-Directory to write report files
-.TP
-\fB\-p\fR, \fB\-\-pretty\fR
-Shorthand for "\-\-formatter pretty"
-.TP
-\fB\-\-print\-output\-on\-failure\fR
-Automatically print the value of \fB$output\fR on failed tests
-.TP
-\fB\-r\fR, \fB\-\-recursive\fR
-Include tests in subdirectories
-.TP
-\fB\-\-show\-output\-of\-passing\-tests\fR
-Print output of passing tests
-.TP
-\fB\-t\fR, \fB\-\-tap\fR
-Shorthand for "\-\-formatter tap"
-.TP
-\fB\-T\fR, \fB\-\-timing\fR
-Add timing information to tests
-.TP
-\fB\-x\fR, \fB\-\-trace\fR
-Print test commands as they are executed (like \fBset \-x\fR)
-.TP
-\fB\-\-verbose\-run\fR
-Make \fBrun\fR print \fB$output\fR by default
-.TP
-\fB\-v\fR, \fB\-\-version\fR
-Display the version number
+.IP "\[ci]" 4
+\fB\-c\fR, \fB\-\-count\fR: Count the number of test cases without running any tests
+.IP "\[ci]" 4
+\fB\-\-code\-quote\-style <style>\fR: A two character string of code quote delimiters or \fBcustom\fR which requires setting \fB$BATS_BEGIN_CODE_QUOTE\fR and \fB$BATS_END_CODE_QUOTE\fR\. Can also be set via \fB$BATS_CODE_QUOTE_STYLE\fR\.
+.IP "\[ci]" 4
+\fB\-\-line\-reference\-format\fR Controls how file/line references e\.g\. in stack traces are printed:
+.IP "\[ci]" 4
+comma_line (default): a\.bats, line 1
+.IP "\[ci]" 4
+colon: a\.bats:1
+.IP "\[ci]" 4
+uri: file:///tests/a\.bats:1
+.IP "\[ci]" 4
+custom: provide your own via defining bats_format_file_line_reference_custom with parameters \fIfilename\fR \fIline\fR, store via \fBprintf \-v "$output"\fR
+.IP "" 0
+
+.IP "\[ci]" 4
+\fB\-f\fR, \fB\-\-filter <regex>\fR: Filter test cases by names matching the regular expression
+.IP "\[ci]" 4
+\fB\-F\fR, \fB\-\-formatter <type>\fR: Switch between formatters: pretty (default), tap (default w/o term), tap13, junit, \fB/<absolute path to formatter>\fR
+.IP "\[ci]" 4
+\fB\-\-filter\-status <status>\fR: Only run tests with the given status in the last completed (no CTRL+C/SIGINT) run\. Valid \fIstatus\fR values are: failed \- runs tests that failed or were not present in the last run missed \- runs tests that were not present in the last run
+.IP "\[ci]" 4
+\fB\-\-filter\-tags <comma\-separated\-tag\-list>\fR: Only run tests that match all the tags in the list (\fB&&\fR)\. You can negate a tag via prepending \fB!\fR\. Specifying this flag multiple times allows for logical or (\fB||\fR): \fB\-\-filter\-tags A,B \-\-filter\-tags A,!C\fR matches tags \fB(A && B) || (A && !C)\fR
+.IP "\[ci]" 4
+\fB\-\-gather\-test\-outputs\-in <directory>\fR: Gather the output of failing \fIand\fR passing tests as files in directory
+.IP "\[ci]" 4
+\fB\-h\fR, \fB\-\-help\fR: Display this help message
+.IP "\[ci]" 4
+\fB\-j\fR, \fB\-\-jobs <jobs>\fR: Number of parallel jobs (requires GNU parallel)
+.IP "\[ci]" 4
+\fB\-l\fR, \fB\-\-list\fR: list test names without running any tests
+.IP "\[ci]" 4
+\fB\-L\fR, \fB\-\-list\-with\-filename\fR: Same as "\-l" but print filenames, too
+.IP "\[ci]" 4
+\fB\-\-no\-tempdir\-cleanup\fR: Preserve test output temporary directory
+.IP "\[ci]" 4
+\fB\-\-no\-parallelize\-across\-files\fR: Serialize test file execution instead of running them in parallel (requires \-\-jobs >1)
+.IP "\[ci]" 4
+\fB\-\-no\-parallelize\-within\-files\fR: Serialize test execution within files instead of running them in parallel (requires \-\-jobs >1)
+.IP "\[ci]" 4
+\fB\-\-report\-formatter <type>\fR: Switch between reporters (same options as \-\-formatter)
+.IP "\[ci]" 4
+\fB\-o\fR, \fB\-\-output <dir>\fR: Directory to write report files
+.IP "\[ci]" 4
+\fB\-p\fR, \fB\-\-pretty\fR: Shorthand for "\-\-formatter pretty"
+.IP "\[ci]" 4
+\fB\-\-print\-output\-on\-failure\fR: Automatically print the value of \fB$output\fR on failed tests
+.IP "\[ci]" 4
+\fB\-r\fR, \fB\-\-recursive\fR: Include tests in subdirectories
+.IP "\[ci]" 4
+\fB\-\-show\-output\-of\-passing\-tests\fR: Print output of passing tests
+.IP "\[ci]" 4
+\fB\-t\fR, \fB\-\-tap\fR: Shorthand for "\-\-formatter tap"
+.IP "\[ci]" 4
+\fB\-T\fR, \fB\-\-timing\fR: Add timing information to tests
+.IP "\[ci]" 4
+\fB\-x\fR, \fB\-\-trace\fR: Print test commands as they are executed (like \fBset \-x\fR)
+.IP "\[ci]" 4
+\fB\-\-verbose\-run\fR: Make \fBrun\fR print \fB$output\fR by default
+.IP "\[ci]" 4
+\fB\-v\fR, \fB\-\-version\fR: Display the version number
+.IP "" 0
 .SH "OUTPUT"
 When you run Bats from a terminal, you\'ll see output as each test is performed, with a check\-mark next to the test\'s name if it passes or an "X" if it fails\.
 .IP "" 4

--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -80,8 +80,8 @@ OPTIONS
     Count the number of test cases without running any tests
   * `--code-quote-style <style>`:
     A two character string of code quote delimiters or `custom`
-    which requires setting `$BATS_BEGIN_CODE_QUOTE` and 
-    `$BATS_END_CODE_QUOTE`. 
+    which requires setting `$BATS_BEGIN_CODE_QUOTE` and
+    `$BATS_END_CODE_QUOTE`.
     Can also be set via `$BATS_CODE_QUOTE_STYLE`.
   * `--line-reference-format`
     Controls how file/line references e.g. in stack traces are printed:
@@ -101,7 +101,7 @@ OPTIONS
       failed - runs tests that failed or were not present in the last run
       missed - runs tests that were not present in the last run
   * `--filter-tags <comma-separated-tag-list>`:
-    Only run tests that match all the tags in the list (`&&`). You can negate a 
+    Only run tests that match all the tags in the list (`&&`). You can negate a
     tag via prepending `!`.
     Specifying this flag multiple times allows for logical or (`||`):
     `--filter-tags A,B --filter-tags A,!C` matches tags `(A && B) || (A && !C)`
@@ -111,6 +111,10 @@ OPTIONS
     Display this help message
   * `-j`, `--jobs <jobs>`:
     Number of parallel jobs (requires GNU parallel)
+  * `-l`, `--list`:
+    list test names without running any tests
+  * `-L`, `--list-with-filename`:
+    Same as "-l" but print filenames, too
   * `--no-tempdir-cleanup`:
     Preserve test output temporary directory
   * `--no-parallelize-across-files`:

--- a/test/fixtures/list_test_names/cryptic.bats
+++ b/test/fixtures/list_test_names/cryptic.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "nothing_special at-this-one" { true; }
+@test "don't fail on 'single' or "Double" quotes" { true; }
+@test "handles braces < [ } ({[]}) )(" { true; }
+@test "handles `backticks`" { true; }
+@test "handles \backslash incl sequences \n \r \t" { true; }

--- a/test/fixtures/list_test_names/decode.bats
+++ b/test/fixtures/list_test_names/decode.bats
@@ -69,6 +69,7 @@ bats_decode_test_name() {
 @test "decode" {
   BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
   local count=0
+  local encoded decoded
   while read -r line; do
     if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
       (( count += 1 ))
@@ -78,5 +79,5 @@ bats_decode_test_name() {
       bats_decode_test_name "$encoded" 'decoded'
       [[ "$name" == "$decoded" ]]
     fi
-  done < <(find $BATS_ROOT/test/fixtures/list_test_names -type f -name '*.bats' -print0 | xargs -0 grep -h '^@test')
+  done < <(find "$BATS_ROOT"/test/fixtures/list_test_names -type f -name '*.bats' -print0 | xargs -0 grep -h '^@test')
 }

--- a/test/fixtures/list_test_names/decode.bats
+++ b/test/fixtures/list_test_names/decode.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+bats_encode_test_name() {
+  local name="$1"
+  local result='test_'
+  local hex_code
+
+  if [[ ! "$name" =~ [^[:alnum:]\ _-] ]]; then
+    name="${name//_/-5f}"
+    name="${name//-/-2d}"
+    name="${name// /_}"
+    result+="$name"
+  else
+    local length="${#name}"
+    local char i
+
+    for ((i = 0; i < length; i++)); do
+      char="${name:$i:1}"
+      if [[ "$char" == ' ' ]]; then
+        result+='_'
+      elif [[ "$char" =~ [[:alnum:]] ]]; then
+        result+="$char"
+      else
+        printf -v 'hex_code' -- '-%02x' \'"$char"
+        result+="$hex_code"
+      fi
+    done
+  fi
+
+  printf -v "$2" '%s' "$result"
+}
+
+bats_decode_test_name() {
+  local name="$1"
+  local length="${#name}"
+  name="${name#test_}"
+  local i=0
+  local result=''
+  local char=''
+  while (( i < length )); do
+    char="${name:$i:1}"
+    case $char in
+      '-')
+        (( i += 1 ))
+        if [[ "${name:$i:4}" == '2d5f' ]]; then
+          result+="_"
+          (( i += 4 ))
+        else
+          result+=$(printf "%b" "\x${name:$i:2}")
+          (( i += 2 ))
+        fi
+      ;;
+      '_')
+        result+=" "
+        (( i += 1 ))
+        ;;
+      *)
+        result+="$char"
+        (( i += 1 ))
+    ;;
+    esac
+  done
+  printf -v "$2" '%s' "$result"
+}
+
+# bats test_tags=bats:slow
+@test "decode" {
+  BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
+  local count=0
+  while read -r line; do
+    if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
+      (( count += 1 ))
+      name="${BASH_REMATCH[1]#[\'\"]}"
+      name="${name%[\'\"]}"
+      bats_encode_test_name "$name" 'encoded'
+      bats_decode_test_name "$encoded" 'decoded'
+      [[ "$name" == "$decoded" ]]
+    fi
+  done < <(find $BATS_ROOT/test/fixtures/list_test_names -type f -name '*.bats' -print0 | xargs -0 grep -h '^@test')
+}

--- a/test/fixtures/list_test_names/empty.bats
+++ b/test/fixtures/list_test_names/empty.bats
@@ -1,0 +1,4 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+

--- a/test/fixtures/list_test_names/file_first.bats
+++ b/test/fixtures/list_test_names/file_first.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "First One" { true; }
+@test 'First Two' { true; }
+@test "First Three failed" { false; }
+# bats test_tags=first:test
+@test "First Four test_tag" { true; }
+# bats test_tags=first:test,tag:failed
+@test "First Five test_tag failed" { false; }

--- a/test/fixtures/list_test_names/file_second.bats
+++ b/test/fixtures/list_test_names/file_second.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+# bats file_tags=second:file
+
+@test "Second One" { true; }
+@test "Second Two" { true; }
+@test "Second Three failed" { false; }
+# bats test_tags=second:test
+@test "Second Four test_tag" { true; }
+# bats test_tags=second:test
+@test "Second Five test_tag failed" { false; }

--- a/test/list_test_names.bats
+++ b/test/list_test_names.bats
@@ -118,3 +118,25 @@ setup() {
   [[ "${#lines[@]}" -eq 1 ]]
   [[ "${lines[0]}" == "First Five test_tag failed" ]]
 }
+
+# should have status 0 but validator.bash fails on empty output
+@test "don't' print anything if no tests are found" {
+  run -1 bin/bats -l "$FIXTURE_ROOT"/empty.bats
+  [[ "${#lines[@]}" -eq 0 ]]
+  [[ "$output" -eq "" ]]
+}
+
+# should have status 1 but validator.bash fails on empty output
+@test "don't' print anything if all tests are filtered out" {
+  run -1 bin/bats -l --filter 'Oops' "$FIXTURE_ROOT"/file*
+  [[ "${#lines[@]}" -eq 0 ]]
+  [[ "$output" -eq "" ]]
+}
+
+@test "print test count and names if -c and -l are given" {
+  run -0 bin/bats -lc --filter 'One' "$FIXTURE_ROOT"/file*
+  [[ "${#lines[@]}" -eq 3 ]]
+  [[ "${lines[0]}" == "2" ]]
+  [[ "${lines[1]}" == "First One" ]]
+  [[ "${lines[2]}" == "Second One" ]]
+}

--- a/test/list_test_names.bats
+++ b/test/list_test_names.bats
@@ -119,16 +119,14 @@ setup() {
   [[ "${lines[0]}" == "First Five test_tag failed" ]]
 }
 
-# should have status 0 but validator.bash fails on empty output
 @test "don't' print anything if no tests are found" {
-  run -1 bin/bats -l "$FIXTURE_ROOT"/empty.bats
+  run -0 bin/bats -l "$FIXTURE_ROOT"/empty.bats
   [[ "${#lines[@]}" -eq 0 ]]
   [[ "$output" -eq "" ]]
 }
 
-# should have status 1 but validator.bash fails on empty output
 @test "don't' print anything if all tests are filtered out" {
-  run -1 bin/bats -l --filter 'Oops' "$FIXTURE_ROOT"/file*
+  run -0 bin/bats -l --filter 'Oops' "$FIXTURE_ROOT"/file*
   [[ "${#lines[@]}" -eq 0 ]]
   [[ "$output" -eq "" ]]
 }

--- a/test/list_test_names.bats
+++ b/test/list_test_names.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.9.0
+
+setup() {
+  load test_helper
+  fixtures list_test_names
+}
+
+@test "list test names can decode test names" {
+  run -0 bin/bats -l "$FIXTURE_ROOT"/decode.bats
+}
+
+@test "list test can print cryptic test names" {
+  run -0 bin/bats -l "$FIXTURE_ROOT"/cryptic.bats
+  [[ "${#lines[@]}" -eq 5 ]]
+  [[ "${lines[0]}" == "nothing_special at-this-one" ]]
+  [[ "${lines[1]}" == "don't fail on 'single' or \"Double\" quotes" ]]
+  [[ "${lines[2]}" == "handles braces < [ } ({[]}) )(" ]]
+  [[ "${lines[3]}" == 'handles `backticks`' ]]
+  [[ "${lines[4]}" == 'handles \backslash incl sequences \n \r \t' ]]
+}
+
+@test "list all tests (-l | --list)" {
+  run -0 bin/bats -l "$FIXTURE_ROOT"/file*
+  [[ "${#lines[@]}" -eq 10 ]]
+  [[ "${lines[0]}" == "First One" ]]
+  [[ "${lines[1]}" == "First Two" ]]
+  [[ "${lines[2]}" == "First Three failed" ]]
+  [[ "${lines[3]}" == "First Four test_tag" ]]
+  [[ "${lines[4]}" == "First Five test_tag failed" ]]
+  [[ "${lines[5]}" == "Second One" ]]
+  [[ "${lines[6]}" == "Second Two" ]]
+  [[ "${lines[7]}" == "Second Three failed" ]]
+  [[ "${lines[8]}" == "Second Four test_tag" ]]
+  [[ "${lines[9]}" == "Second Five test_tag failed" ]]
+}
+
+@test "list all tests (-L | --list-with-filename)" {
+  run -0 bin/bats -L "$FIXTURE_ROOT"/file*
+  [[ "${#lines[@]}" -eq 10 ]]
+  [[ "${lines[0]}" == "$FIXTURE_ROOT/file_first.bats : First One" ]]
+  [[ "${lines[1]}" == "$FIXTURE_ROOT/file_first.bats : First Two" ]]
+  [[ "${lines[2]}" == "$FIXTURE_ROOT/file_first.bats : First Three failed" ]]
+  [[ "${lines[3]}" == "$FIXTURE_ROOT/file_first.bats : First Four test_tag" ]]
+  [[ "${lines[4]}" == "$FIXTURE_ROOT/file_first.bats : First Five test_tag failed" ]]
+  [[ "${lines[5]}" == "$FIXTURE_ROOT/file_second.bats : Second One" ]]
+  [[ "${lines[6]}" == "$FIXTURE_ROOT/file_second.bats : Second Two" ]]
+  [[ "${lines[7]}" == "$FIXTURE_ROOT/file_second.bats : Second Three failed" ]]
+  [[ "${lines[8]}" == "$FIXTURE_ROOT/file_second.bats : Second Four test_tag" ]]
+  [[ "${lines[9]}" == "$FIXTURE_ROOT/file_second.bats : Second Five test_tag failed" ]]
+}
+
+@test "list filtered 'First' tests" {
+  run -0 bin/bats -l --filter 'First' "$FIXTURE_ROOT"/file*
+  [[ "${#lines[@]}" -eq 5 ]]
+  [[ "${lines[0]}" == "First One" ]]
+  [[ "${lines[1]}" == "First Two" ]]
+  [[ "${lines[2]}" == "First Three failed" ]]
+  [[ "${lines[3]}" == "First Four test_tag" ]]
+  [[ "${lines[4]}" == "First Five test_tag failed" ]]
+}
+
+@test "list filtered 'One' tests" {
+  run -0 bin/bats -l --filter 'One' "$FIXTURE_ROOT"/file*
+  [[ "${#lines[@]}" -eq 2 ]]
+  [[ "${lines[0]}" == "First One" ]]
+  [[ "${lines[1]}" == "Second One" ]]
+}
+
+@test "list file_tagged tests" {
+  run -0 bin/bats -l --filter-tags second:file "$FIXTURE_ROOT"/file*
+  [[ "${#lines[@]}" -eq 5 ]]
+  [[ "${lines[0]}" == "Second One" ]]
+  [[ "${lines[1]}" == "Second Two" ]]
+  [[ "${lines[2]}" == "Second Three failed" ]]
+  [[ "${lines[3]}" == "Second Four test_tag" ]]
+  [[ "${lines[4]}" == "Second Five test_tag failed" ]]
+}
+
+@test "list --filter failed tests" {
+  run -1 bin/bats "$FIXTURE_ROOT/file_first.bats"
+  [[ "${#lines[@]}" -eq 11 ]]
+  [[ "${lines[0]}" == "1..5" ]]
+  [[ "${lines[1]}" == "ok 1 First One" ]]
+  [[ "${lines[2]}" == "ok 2 First Two" ]]
+  [[ "${lines[3]}" == "not ok 3 First Three failed" ]]
+  [[ "${lines[4]}" == "# (in test file test/fixtures/list_test_names/file_first.bats, line 5)" ]]
+  [[ "${lines[5]}" == "#   \`@test \"First Three failed\" { false; }' failed" ]]
+  [[ "${lines[6]}" == "ok 4 First Four test_tag" ]]
+  [[ "${lines[7]}" == "not ok 5 First Five test_tag failed" ]]
+  [[ "${lines[8]}" == "# tags: first:test tag:failed" ]]
+  [[ "${lines[9]}" == "# (in test file test/fixtures/list_test_names/file_first.bats, line 9)" ]]
+  [[ "${lines[10]}" == "#   \`@test \"First Five test_tag failed\" { false; }' failed" ]]
+  # now rerun with -l to list failed tests
+  run -0 bin/bats -l --filter failed "$FIXTURE_ROOT/file_first.bats"
+  [[ "${#lines[@]}" -eq 2 ]]
+  [[ "${lines[0]}" == "First Three failed" ]]
+  [[ "${lines[1]}" == "First Five test_tag failed" ]]
+}
+@test "list '--filter failed --filter-tags' tests" {
+  run -1 bin/bats "$FIXTURE_ROOT/file_first.bats"
+  [[ "${#lines[@]}" -eq 11 ]]
+  [[ "${lines[0]}" == "1..5" ]]
+  [[ "${lines[1]}" == "ok 1 First One" ]]
+  [[ "${lines[2]}" == "ok 2 First Two" ]]
+  [[ "${lines[3]}" == "not ok 3 First Three failed" ]]
+  [[ "${lines[4]}" == "# (in test file test/fixtures/list_test_names/file_first.bats, line 5)" ]]
+  [[ "${lines[5]}" == "#   \`@test \"First Three failed\" { false; }' failed" ]]
+  [[ "${lines[6]}" == "ok 4 First Four test_tag" ]]
+  [[ "${lines[7]}" == "not ok 5 First Five test_tag failed" ]]
+  [[ "${lines[8]}" == "# tags: first:test tag:failed" ]]
+  [[ "${lines[9]}" == "# (in test file test/fixtures/list_test_names/file_first.bats, line 9)" ]]
+  [[ "${lines[10]}" == "#   \`@test \"First Five test_tag failed\" { false; }' failed" ]]
+  # now rerun with -l to list failed, tagged tests
+  run -0 bin/bats -l --filter failed --filter-tags tag:failed "$FIXTURE_ROOT/file_first.bats"
+  [[ "${#lines[@]}" -eq 1 ]]
+  [[ "${lines[0]}" == "First Five test_tag failed" ]]
+}

--- a/test/list_test_names.bats
+++ b/test/list_test_names.bats
@@ -17,6 +17,7 @@ setup() {
   [[ "${lines[0]}" == "nothing_special at-this-one" ]]
   [[ "${lines[1]}" == "don't fail on 'single' or \"Double\" quotes" ]]
   [[ "${lines[2]}" == "handles braces < [ } ({[]}) )(" ]]
+  # shellcheck disable=SC2016
   [[ "${lines[3]}" == 'handles `backticks`' ]]
   [[ "${lines[4]}" == 'handles \backslash incl sequences \n \r \t' ]]
 }


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

Hi all,

I digged into that ones and hope I have found a valuable implementation providing a list in _bats processing order_ with or without filenames:

Close #508 and close #701

Hope you find it valuable. And in case there's something to add or change please let me now.

### Switches
  * `-l`, `--list`:
    list test names without running any tests
  * `-L`, `--list-with-filename`:
    Same as "-l" but print filenames, too

### Output

```bash
$ bin/bats test/fixtures/list_test_names/cryptic.bats -F tap
1..5
ok 1 nothing_special at-this-one
ok 2 don't fail on 'single' or Double quotes
ok 3 handles braces < [ } ({[]}) )(
ok 4 handles 
ok 5 handles \backslash incl sequences \n \r \t

5 tests, 0 failures

$ bin/bats test/fixtures/list_test_names/cryptic.bats -l
nothing_special at-this-one
don't fail on 'single' or "Double" quotes
handles braces < [ } ({[]}) )(
handles `backticks`
handles \backslash incl sequences \n \r \t

$ bin/bats test/fixtures/list_test_names/cryptic.bats -L
test/fixtures/list_test_names/cryptic.bats : nothing_special at-this-one
test/fixtures/list_test_names/cryptic.bats : don't fail on 'single' or "Double" quotes
test/fixtures/list_test_names/cryptic.bats : handles braces < [ } ({[]}) )(
test/fixtures/list_test_names/cryptic.bats : handles `backticks`
test/fixtures/list_test_names/cryptic.bats : handles \backslash incl sequences \n \r \t
```

### Implementation

looks like the only place where we have the original test name available is in bats-preprocess and so it would be extracted from there. Either by:

- creating a new intermediate file with mapping from encoded name to original name
- passing the original name via bats_test_function (additional argument)
- inject a special comment (# bats_test_name <original name>

all these will lead to maintenance of a separate list, keeping in sync when (tag) filtering tests, processing .....
Additionally original names can contain arbitrary characters which will break simple parsing or passing as arguments (Example: `@test "Don't find in empty array" {` even `@test " some "Quotes" inside"` will be a valid test name)

So I thought about decoding the name in case a list-only is requested and implemented the functionality with it.

It needs **no modification** to  the data structures or operating logic, but just add the new command line options and a section in bats-exec-suite to handle printing the list of names. I placed it where `-c` already is evaluated, that's after _gathering_ and _filtering_ (both tags and text) .

the bats _test suite_ is running fine and I added some tests and updated the manpage.

### Suggestion: 

- maybe the functions `bats_encode_test_name` (in `bats-preprocess`) and `bats_decode_test_name` (new in `bats-exec-suite`) could be externalized to `common.bash` or ...
- maybe a nice addition would be to print the line number when using `-L`
  ```bash
  test/fixtures/list_test_names/cryptic.bats [178]: nothing_special at-this-one
  test/fixtures/list_test_names/cryptic.bats [1356]: don't fail on 'single' or "Double" quotes
  ```
