### PR TITLE
spelling: accessible, necessary, overridden, receive, re-enable, etc.

### DIFF
--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -80,7 +80,7 @@ internal use.
 If a test with the tag `bats:focus` is encountered in a test suite,
 all other tests will be filtered out and only those tagged with this tag will be executed.
 
-In focus mode, the exit code of successful runs will be overriden to 1 to prevent CI from silently running on a subset of tests due to an accidentally commited `bats:focus` tag.    
+In focus mode, the exit code of successful runs will be overridden to 1 to prevent CI from silently running on a subset of tests due to an accidentally committed `bats:focus` tag.    
 Should you require the true exit code, e.g. for a `git bisect` operation, you can disable this behavior by setting
 `BATS_NO_FAIL_FOCUS_RUN=1` when running `bats`, but make sure not to commit this to CI!
 

--- a/lib/bats-core/tracing.bash
+++ b/lib/bats-core/tracing.bash
@@ -158,7 +158,7 @@ bats_trim_filename() {
 }
 
 # normalize a windows path from e.g. C:/directory to /c/directory
-# The path must point to an existing/accessable directory, not a file!
+# The path must point to an existing/accessible directory, not a file!
 bats_normalize_windows_dir_path() { # <output-var> <path>
   local output_var="$1" path="$2"
   if [[ "$output_var" != NORMALIZED_INPUT ]]; then

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -89,7 +89,7 @@ bats_teardown_trap() {
 
   # `bats_teardown_trap` is always called with one parameter (BATS_TEARDOWN_STARTED)
   # The second parameter is optional and corresponds for to the killer pid
-  # that will be forwarded to the exit trap to kill it if necesary
+  # that will be forwarded to the exit trap to kill it if necessary
   local killer_pid=${2:-}
 
   # mark the start of this function to distinguish where skip is called
@@ -269,7 +269,7 @@ bats_start_timeout_countdown() { # <timeout>
   # Start another process to kill the children of this process
   (
     sleep "$timeout" &
-    # sleep won't recieve signals, so we use wait below
+    # sleep won't receive signals, so we use wait below
     # and kill sleep explicitly when signalled to do so
     # shellcheck disable=SC2064
     trap "kill $!; exit 0" ABRT

--- a/man/bats.7
+++ b/man/bats.7
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "BATS" "7" "November 2022" "bats-core" "Bash Automated Testing System"
+.TH "BATS" "7" "June 2023" "bats-core" "Bash Automated Testing System"
 .SH "NAME"
 \fBbats\fR \- Bats test file format
 .SH "DESCRIPTION"
@@ -60,9 +60,11 @@ Tag lists must be separated by commas and are allowed to contain whitespace\. Th
 Every tag starting with \fBbats:\fR (case insensitive!) is reserved for Bats\' internal use:
 .TP
 \fBbats:focus\fR
-If any test with the tag \fBbats:focus\fR is encountered in a test suite, only those tagged with this tag will be executed\. To prevent the CI from silently running on a subset of tests due to an accidentally commited \fBbats:focus\fR tag, the exit code of successful runs will be overriden to 1\.
+If any test with the tag \fBbats:focus\fR is encountered in a test suite, only those tagged with this tag will be executed\.
 .IP
-Should you require the true exit code, e\.g\. for a \fBgit bisect\fR operation, you can disable this behavior by setting \fBBATS_NO_FAIL_FOCUS_RUN=1\fR when running \fBbats\fR, but make sure to not commit this to CI!
+In focus mode, the exit code of successful runs will be overridden to 1 to prevent CI from silently running on a subset of tests due to an accidentally committed \fBbats:focus\fR tag\.
+.br
+Should you require the true exit code, e\.g\. for a \fBgit bisect\fR operation, you can disable this behavior by setting \fBBATS_NO_FAIL_FOCUS_RUN=1\fR when running \fBbats\fR, but make sure not to commit this to CI!
 .SH "THE RUN HELPER"
 Usage: run [OPTIONS] [\-\-]
 .P
@@ -226,6 +228,8 @@ There are several global variables you can use to introspect on Bats tests:
 \fB$BATS_RUN_TMPDIR\fR is the location to the temporary directory used by bats to store all its internal temporary files during the tests\. (default: \fB$BATS_TMPDIR/bats\-run\-$BATS_ROOT_PID\-XXXXXX\fR)
 .IP "\[ci]" 4
 \fB$BATS_FILE_EXTENSION\fR (default: \fBbats\fR) specifies the extension of test files that should be found when running a suite (via \fBbats [\-r] suite_folder/\fR)
+.IP "\[ci]" 4
+\fB$BATS_TEST_TAGS\fR the tags of the current test\.
 .IP "\[ci]" 4
 \fB$BATS_SUITE_TMPDIR\fR is a temporary directory common to all tests of a suite\. Could be used to create files required by multiple tests\.
 .IP "\[ci]" 4

--- a/man/bats.7.ronn
+++ b/man/bats.7.ronn
@@ -86,8 +86,8 @@ internal use:
 * `bats:focus`:
     If any test with the tag `bats:focus` is encountered in a test suite, only those tagged with this tag will be executed.
     
-    In focus mode, the exit code of successful runs will be overriden to 1 to prevent CI from silently running on a subset
-    of tests due to an accidentally commited `bats:focus` tag.    
+    In focus mode, the exit code of successful runs will be overridden to 1 to prevent CI from silently running on a subset
+    of tests due to an accidentally committed `bats:focus` tag.    
     Should you require the true exit code, e.g. for a `git bisect` operation, you can disable this behavior by setting
     `BATS_NO_FAIL_FOCUS_RUN=1` when running `bats`, but make sure not to commit this to CI!
 

--- a/test/parallel.bats
+++ b/test/parallel.bats
@@ -76,7 +76,7 @@ check_parallel_tests() { # <expected maximum parallelity>
   export PARALLELITY=12
 
   # file parallelization is needed for maximum parallelity!
-  # If we got over the skip (if no GNU parallel) in setup() we can reenable it safely!
+  # If we got over the skip (if no GNU parallel) in setup() we can re-enable it safely!
   unset BATS_NO_PARALLELIZE_ACROSS_FILES
   reentrant_run bash -c "bats --jobs $PARALLELITY \"${FIXTURE_ROOT}/suite/\" 2> >(grep -v '^parallel: Warning: ')"
 
@@ -104,7 +104,7 @@ check_parallel_tests() { # <expected maximum parallelity>
   export PARALLELITY=2
 
   # file parallelization is needed for this test!
-  # If we got over the skip (if no GNU parallel) in setup() we can reenable it safely!
+  # If we got over the skip (if no GNU parallel) in setup() we can re-enable it safely!
   unset BATS_NO_PARALLELIZE_ACROSS_FILES
   # run 4 files with parallelity of 2 -> serialize 2
   reentrant_run bats --jobs $PARALLELITY "$FIXTURE_ROOT/setup_file"

--- a/test/warnings.bats
+++ b/test/warnings.bats
@@ -22,7 +22,7 @@ setup() {
   [[ "$output" == "Invalid Bats warning number 'invalid-number'. It must be an integer between 1 and "* ]]
 }
 
-@test "BW01 is printed when \`run\`ing a (non-existant) command with exit code 127 without exit code check" {
+@test "BW01 is printed when \`run\`ing a (non-existent) command with exit code 127 without exit code check" {
   reentrant_run -0 bats "$FIXTURE_ROOT/BW01.bats"
   [ "${lines[0]}" == "1..1" ]
   [ "${lines[1]}" == "ok 1 Trigger BW01" ]
@@ -32,7 +32,7 @@ setup() {
   [ "${lines[5]}" == "       in test file $RELATIVE_FIXTURE_ROOT/BW01.bats, line 3)" ]
 }
 
-@test "BW01 is not printed when \`run\`ing a (non-existant) command with exit code 127 with exit code check" {
+@test "BW01 is not printed when \`run\`ing a (non-existent) command with exit code 127 with exit code check" {
   reentrant_run -0 bats "$FIXTURE_ROOT/BW01_check_exit_code_is_127.bats"
   [ "${lines[0]}" == "1..1" ]
   [ "${lines[1]}" == "ok 1 Don't trigger BW01 with checked exit code 127" ]


### PR DESCRIPTION
These were found by codespell when trying to run the Toolbx tests on Ubuntu 22.04 [1].

Toolbx requires Bats 1.7.0, while Ubuntu 22.04 only has 1.2.1. Downloading a newer Bats inside a sub-directory tricked Toolbx's own codespell tests to start complaining about spelling mistakes in Bats.

[1] https://github.com/containers/toolbox/pull/1319

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
