### PR TITLE
Fix --gather-test-output-in fails on multiple / in test name

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * `install.sh` now works for deviating `lib/` dirs (like `lib32`,`lib64`) (#487)
 * catch unset `BATS_TEST_SOURCE` in `lib/bats-core/tracing.bash` so
   `set -u`/`set -o nounset` works as expected (#827)
+* fix `--gather-test-outputs-in` fails on tests with multiple `/` (#789)
 
 ### Changed
 

--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -204,7 +204,7 @@ bats_exit_trap() {
     if [[ -n "$should_retry" ]]; then
       try_suffix="-try$BATS_TEST_TRY_NUMBER"
     fi
-    cp "$BATS_OUT" "$BATS_GATHER_TEST_OUTPUTS_IN/$BATS_SUITE_TEST_NUMBER$try_suffix-${BATS_TEST_DESCRIPTION/\//%2F}.log"
+    cp "$BATS_OUT" "$BATS_GATHER_TEST_OUTPUTS_IN/$BATS_SUITE_TEST_NUMBER$try_suffix-${BATS_TEST_DESCRIPTION//\//%2F}.log"
   fi
   rm -f "$BATS_OUT"
   exit "$status"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1151,7 +1151,7 @@ END_OF_ERR_MSG
   bats_require_minimum_version 1.5.0
 
   reentrant_run -0 bats --gather-test-outputs-in "$OUTPUT_DIR" "$FIXTURE_ROOT/test_with_slash.bats"
-  [ -e "$OUTPUT_DIR/1-test with %2F in name.log" ]
+  [ -e "$OUTPUT_DIR/1-test with %2F in %2F name.log" ]
 }
 
 @test "Tell about missing flock and shlock" {

--- a/test/fixtures/bats/test_with_slash.bats
+++ b/test/fixtures/bats/test_with_slash.bats
@@ -1,3 +1,3 @@
-@test "test with / in name" {
+@test "test with / in / name" {
     true
 }


### PR DESCRIPTION
Expands on #735 which only fixed #688 for tests with a single slash

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
