### PR TITLE
feat(dependabot): group github actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
       - github-actions
       - dependencies
       - no changelog
+    groups:
+      actions-dependency:
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /


### PR DESCRIPTION
Right now the repo contains to many github actions dependencies PRs, with this config each of them will be grouped in a single PR so it will be much easier to test in one shot the updates and create less noise in the repo.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
