### PR TITLE
Update Arch Linux package URL in installation.rst

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 #### Documentation
 
 * clarify docker usage (#741)
+* update Arch Linux package URL in installation.rst (#821)
 
 ## [1.10.0] - 2023-07-15
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,7 +7,7 @@ Linux: Distribition Package Manager
 
 Following Linux distributions provide Bats via their package manager:
 
-* Arch Linux: `community/bash-bats <https://archlinux.org/packages/community/any/bash-bats/>`__
+* Arch Linux: `extra/bash-bats <https://archlinux.org/packages/extra/any/bash-bats/>`__
 * Alpine Linux: `bats <https://pkgs.alpinelinux.org/package/edge/main/x86/bats>`__
 * Debian Linux: `shells/bats <https://packages.debian.org/search?keywords=bats>`__
 * Fedora Linux: `rpms/bats <https://src.fedoraproject.org/rpms/bats>`__


### PR DESCRIPTION
The old URL returns 404 now.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
