### PR TITLE
catch unset BATS_TEST_SOURCE

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 ### Fixed
 
 * `install.sh` now works for deviating `lib/` dirs (like `lib32`,`lib64`) (#487)
+* catch unset `BATS_TEST_SOURCE` in `lib/bats-core/tracing.bash` so
+  `set -u`/`set -o nounset` works as expected (#827)
 
 ### Changed
 

--- a/lib/bats-core/tracing.bash
+++ b/lib/bats-core/tracing.bash
@@ -184,7 +184,7 @@ bats_emit_trace() {
       # avoid printing a function twice (at call site and at definition site)
       [[ $BASH_COMMAND != "$BATS_LAST_BASH_COMMAND" || ${BASH_LINENO[2]} != "$BATS_LAST_BASH_LINENO" || ${BASH_SOURCE[3]} != "$BATS_LAST_BASH_SOURCE" ]]; then
       local file="${BASH_SOURCE[2]}" # index 2: skip over bats_emit_trace and bats_debug_trap
-      if [[ $file == "${BATS_TEST_SOURCE}" ]]; then
+      if [[ $file == "${BATS_TEST_SOURCE:-}" ]]; then
         file="$BATS_TEST_FILENAME"
       fi
       local padding='$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$'


### PR DESCRIPTION
This allows `bats --trace` to be used with `set -u`.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
