### PR TITLE
Update FAQ about setup and teardown for all tests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * clarify docker usage (#741)
 * update Arch Linux package URL in installation.rst (#821)
 * rename bash-bats to bats for Arch Linux in installation.rst (#836)
+* fix FAQ entry about setup-/teardown_suite, as they are available now (#861)
 
 ## [1.10.0] - 2023-07-15
 

--- a/docs/list-links.py
+++ b/docs/list-links.py
@@ -1,0 +1,4 @@
+import pickle
+with open("build/doctrees/environment.pickle", "rb") as f:
+    dat = pickle.load(f)
+print(dat.domaindata['std']['labels'])

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,8 @@ release = '1'
 # ones.
 extensions = [
     'recommonmark',
-    'sphinxcontrib.programoutput'
+    'sphinxcontrib.programoutput',
+    'sphinx.ext.autosectionlabel'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -167,4 +167,6 @@ There is also `BATS_TEST_SKIPPED` which will be non-empty (contains the skip mes
 How can I setup/cleanup before/after all tests?
 -----------------------------------------------
 
-Currently, this is not supported. Please contribute your usecase to issue `#39 <https://github.com/bats-core/bats-core/issues/39>`_.
+Setup/cleanup before/after all tests can be achieved using the special `setup-suite` and `teardown-suite` functions.
+These functions must be placed into a dedicated `setup_suite.bash` file next to your `.bats` files. 
+For more information check out the `setup` and `teardown` section under `Writing Tests`.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -169,4 +169,4 @@ How can I setup/cleanup before/after all tests?
 
 Setup/cleanup before/after all tests can be achieved using the special `setup_suite` and `teardown_suite` functions.
 These functions must be placed into a dedicated `setup_suite.bash` file next to your `.bats` files. 
-For more information check out the :ref:`setup and teardown section <writing-tests:setup and teardown Pre- and post-test hooks>`.
+For more information check out the :ref:`setup and teardown section <setup and teardown: pre- and post-test hooks>`.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -169,4 +169,4 @@ How can I setup/cleanup before/after all tests?
 
 Setup/cleanup before/after all tests can be achieved using the special `setup_suite` and `teardown_suite` functions.
 These functions must be placed into a dedicated `setup_suite.bash` file next to your `.bats` files. 
-For more information check out the `setup` and `teardown` section under `Writing Tests`.
+For more information check out the :ref:`setup and teardown section <writing-tests:setup and teardown Pre- and post-test hooks>`.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -167,6 +167,6 @@ There is also `BATS_TEST_SKIPPED` which will be non-empty (contains the skip mes
 How can I setup/cleanup before/after all tests?
 -----------------------------------------------
 
-Setup/cleanup before/after all tests can be achieved using the special `setup-suite` and `teardown-suite` functions.
+Setup/cleanup before/after all tests can be achieved using the special `setup_suite` and `teardown_suite` functions.
 These functions must be placed into a dedicated `setup_suite.bash` file next to your `.bats` files. 
 For more information check out the `setup` and `teardown` section under `Writing Tests`.

--- a/docs/source/warnings/BW02.rst
+++ b/docs/source/warnings/BW02.rst
@@ -5,8 +5,8 @@ Using a feature that is only available starting with a certain version can be a 
 In most cases, running this code in older versions will generate an error due to a missing command.
 However, in cases like `run`'s where old version simply take all parameters as command to execute, the failure can be silent.
 
-How to fix
-----------
+How to fix BW02
+---------------
 
 When you encounter this warning, you can simply guard your code with `bats_require_minimum_version <version>` as the message says.
 For example, consider the following code:

--- a/docs/source/warnings/BW03.rst
+++ b/docs/source/warnings/BW03.rst
@@ -4,8 +4,8 @@ BW03: `setup_suite` is visible to test file '<path>', but was not executed. It b
 In contrast to the other setup functions, `setup_suite` must not be defined in `*.bats` files but in `setup_suite.bash`.
 When a file is executed and sees `setup_suite` defined but not run before the tests, this warning will be printed.
 
-How to fix
-----------
+How to fix BW03
+---------------
 
 The fix depends on your actual intention. There are basically two cases:
 


### PR DESCRIPTION
According to https://bats-core.readthedocs.io/en/stable/writing-tests.html#setup-and-teardown-pre-and-post-test-hooks the old FAQ answer is out of date. 

I hope this one better represents the current state.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
