### PR TITLE
CI: Upgrade freebsd action to v1.0.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -207,7 +207,7 @@ jobs:
           time ./bin/bats  --print-output-on-failure test/
 
   freebsd:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         packages:
@@ -215,7 +215,7 @@ jobs:
           - ""
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: vmactions/freebsd-vm@9991fc3550abdc19b61d50063c7eeb7713bc498f # v0.3.1
+      - uses: vmactions/freebsd-vm@35a5b20a98476a681c7576a344775be7e7f77f06 # v1.0.6
         with:
           prepare: pkg install -y bash parallel ${{ matrix.packages }}
           run: |


### PR DESCRIPTION
The old, Mac based, FreeBSD VM version was slow and unreliable.