### PR TITLE
Check Bash version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 [![Join the chat in bats-core/bats-core on gitter](https://badges.gitter.im/bats-core/bats-core.svg)][gitter]
 
-Bats is a [TAP](https://testanything.org/)-compliant testing framework for Bash.  It provides a simple
-way to verify that the UNIX programs you write behave as expected.
+Bats is a [TAP](https://testanything.org/)-compliant testing framework for Bash
+3.2 or above.  It provides a simple way to verify that the UNIX programs you
+write behave as expected.
 
 A Bats test file is a Bash script with special syntax for defining test cases.
 Under the hood, each test case is just a function with a description.

--- a/bin/bats
+++ b/bin/bats
@@ -2,6 +2,19 @@
 
 set -euo pipefail
 
+# Note: We first need to use POSIX's `[ ... ]' instead of Bash's `[[ ... ]]'
+# because this is the check for Bash, where the shell may not be Bash.  Once we
+# confirm that we are in Bash, we can use [[ ... ]] and (( ... )).  Note that
+# these [[ ... ]] and (( ... )) do not cause syntax errors in POSIX shells,
+# though they can be parsed differently.
+if [ -z "${BASH_VERSION-}" ] ||
+    [[ -z "${BASH_VERSINFO-}" ]] ||
+    ((BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 2)))
+then
+  printf 'bats: this program needs to be run by Bash >= 3.2\n' >&2
+  exit 1
+fi
+
 if command -v greadlink >/dev/null; then
   bats_readlinkf() {
     greadlink -f "$1"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * add security.md (#762)
 * add codespell CI checks (#720)
 * dynamic test registration via `bats_test_function` (#349)
+* add check that Bats is executed with Bash >= 3.2 (#873)
 
 ### Fixed
 


### PR DESCRIPTION
I here suggest including the check for the Bash version at the beginning of `bats`.

Using Bats, I would like to test if Bash frameworks would correctly work in different versions of Bash. I tried to run the test for the devel version of Bash, the latest release 5.2, down to Bash 3.0. However, the test fails because of syntax errors for Bash 3.0 and 3.1. It turned out that the failure is not caused by the Bash frameworks that are tested but by the `bats` test framework itself. I'd like to request Bats to check the Bash version first and output an error message if the minimum Bash version requirement by Bats is not satisfied.

I tried to find an explicit notice about the required Bash version, but I couldn't find any information. What is the minimum Bash version supported by Bats? I here assume it is 3.2 because Bats produce syntax errors in Bash 3.0 and 3.1, while some files seem to contain checks for 3.2 (e.g. in [`test/trace.bats`](https://github.com/bats-core/bats-core/blob/18eca2496cbd80ac97c73a70002e7ab4fb2179cf/test/trace.bats#L72)).

- [x] I have reviewed the [Contributor Guidelines][contributor].
  - The guideline says `[[ ... ]]` should be always used, but can I use `[ ... ]` for the very initial test for the shell? Relying on the Bash feature for the test of whether the Bash feature is available doesn't seem to make sense.
  - Also, the guideline says "*Always use [[ and ]] for evaluating variables*", but what "*evaluating variables*" means is unclear. I assume it considers just the two variations of `[[ ... ]]` and `[ ... ]`. However, technically, it might also exclude the uses of the arithmetic commands of the form `(( ... ))`. I used the arithmetic command in this PR because arithmetic commands seem to be already used in the codebase.
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it
  - Unrelated to this PR, but the "Current Maintainers" section seems outdated.

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
