### PR TITLE
Add variable to track bats call arguments

### DIFF
--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -112,6 +112,7 @@ BATS_LIBEXEC="$(
   pwd
 )"
 export BATS_LIBEXEC
+export BATS_ARGS="$@"
 export BATS_CWD="$PWD"
 export BATS_TEST_FILTER=
 export PATH="$BATS_LIBEXEC:$PATH"


### PR DESCRIPTION
- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

Having such a variable is useful for use cases where downstream functions can call bats with the original arguments, for example I am defining a setup-suite to automatically generate a coverage report and badge for bats, I can use this variable like:
```
coverage() {
    if which kcov; then
        echo "# generating coverage report using kcov" >&3
        # strip --setup-suite-file argument to prevent infinite loop condition
        kcov --include-path=$WORK_DIR $WORK_DIR/coverage bats ${BATS_ARGS%--setup-suite-file*}
        coverage_badge
    else
        echo "# unable to generate coverage report because kcov is not installed" >&3
    fi
}
```