### PR TITLE
docs: add doc for bats_pipe

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+#### Documentation
+
+* document `bats_pipe` function (#901)
+
 ### Fixed
 
 #### Documentation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,12 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+#### Documentation
+
+* fix hard-coded link to readthedocs (#901)
+
 ## [1.11.0] - 2024-03-24
 
 ### Added

--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -219,7 +219,7 @@ because
 
 will only fail the test if it is the last command and thereby determines the test function's exit code.
 This is due to Bash's decision to (counterintuitively?) not trigger `set -e` on `!` commands.
-(See also [the associated gotcha](https://bats-core.readthedocs.io/en/stable/gotchas.html#my-negated-statement-e-g-true-does-not-fail-the-test-even-when-it-should))
+(See also [the associated gotcha](gotchas.html#my-negated-statement-e-g-true-does-not-fail-the-test-even-when-it-should))
 
 
 ### `run` and pipes


### PR DESCRIPTION
Port the bats_pipe documentation from man/bats.7.ronn into the new docs.

Fix a link to be relative

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
