### PR TITLE
Removed unused parameter

### DIFF
--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -373,7 +373,7 @@ fi
 # requires the test list to be read but not empty
 bats_create_file_tempdirs
 
-bats_preprocess_source "$filename"
+bats_preprocess_source # uses BATS_TEST_FILENAME
 
 trap bats_interrupt_trap INT
 bats_run_setup_file


### PR DESCRIPTION
Fallout from 3d7e49f642ab34b22c0068c43c8e671d0e03c84e

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
