### PR TITLE
typo in md: (text)[link] -> [text](link)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -101,7 +101,7 @@ To use it, run Bats with the `--formatter cat` option.
 
 ## Coding conventions
 
-Use (`shfmt`)[https://github.com/mvdan/sh#shfmt] and [ShellCheck](https://www.shellcheck.net/). The CI will enforce this.
+Use [`shfmt`](https://github.com/mvdan/sh#shfmt) and [ShellCheck](https://www.shellcheck.net/). The CI will enforce this.
 
 Use `snake_case` for all identifiers.
 


### PR DESCRIPTION
A typo in `CONTRIBUTING.md`:

```markdown
(text)[link]

should be

[text](link)
```

