### PR TITLE
Remove obsolete 'version' from `docker-compose.yml`

### DIFF
--- a/docker-compose.override.dist
+++ b/docker-compose.override.dist
@@ -1,5 +1,4 @@
 # Copy this file to docker-compose.override.yml
-version: '3.6'
 services:
     bats:
         entrypoint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
     bats:
         build:


### PR DESCRIPTION
```
# docker compose build
WARN[0000] bats-core/docker-compose.yml: `version` is obsolete
```

More info: https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md


- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
