### PR TITLE
Symlink bash location to /bin/bash in Docker images. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN apk add --no-cache parallel ncurses && \
     mkdir -p ~/.parallel && touch ~/.parallel/will-cite \
     && mkdir /code
 
+RUN ln -s "$(/usr/bin/env which bash)" "/bin/bash"
+
 RUN ln -s /opt/bats/bin/bats /usr/local/bin/bats
 COPY . /opt/bats/
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ### Added
 
+* make Dockerfile compatible with `#!/bin/bash` files (#967)
+
 #### Documentation
 
 * document `bats_pipe` function (#901)


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

Fixes #958 

# Problem outline
As it currently stands, you can not test source files which have `#!/bin/bash` at the top of them inside the bats docker image. This is because bash is not located here. 

I am aware that it is better practice to have `#!/usr/bin/env bash` as the shebang at the top of bash scripts - to make them more portable. 
However, the vast majority of bash code on GitHub uses /bin/bash (~8 million files). Which means, at them moment, they can't be tested inside the docker image provided by bats without changing their source code. 

# Summary of change
My proposed change is to symlink bash to the /bin/bash location - which means bats can be used (specifically the docker container running of the tests) can be used by a much wider group of source files. 

# Testing done

I've done some minimal testing. I've built the docker image using `docker build --build-arg bashver="5" --tag bats/bats:bash-pdruce .` and then I tested that I could access /bin/bash with the command `docker run -it --rm --entrypoint /bin/bash bats/bats:bash-pdruce`. 

This currently doesn't work for bats/bats:latest - `docker run -it --rm --entrypoint /bin/bash bats/bats:latest`
