### PR TITLE
WIP: Export and document two new envariables to tests:

### DIFF
--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -640,6 +640,15 @@ There are several global variables you can use to introspect on Bats tests:
   is `setup_file()`.
 - `$BATS_TEST_NUMBER` is the (1-based) index of the current test case in the test file.
 - `$BATS_SUITE_TEST_NUMBER` is the (1-based) index of the current test case in the test suite (over all files).
+- `$BATS_JOBSLOT` is the unique job slot number for a given test, an integer
+  between 1 and `$BATS_JOBSLOTS` inclusive. No two tests will ever run
+  concurrently with the same slot number.
+- `$BATS_JOBSLOTS` is the maximum number of concurrent test jobs. This is not
+  necessarily the same as the value of the `-j` option! When running with
+  `--no-parallelize-across-files` or `--no-parallelize-within-files`, this
+  will be the same as `-j`. When running without either option (default),
+  it will be `-j` _squared_ because Bats uses its own algorithm to
+  run same-file tests.
 - `$BATS_TEST_TAGS` the tags of the current test.
 - `$BATS_TMPDIR` is the base temporary directory used by bats to create its
    temporary files / directories.

--- a/lib/bats-core/semaphore.bash
+++ b/lib/bats-core/semaphore.bash
@@ -54,7 +54,14 @@ bats_semaphore_run() {
 bats_semaphore_release_wrapper() {
   local output_dir="$1"
   local semaphore_name="$2"
-  shift 2 # all other parameters will be use for the command to execute
+  shift 2 # all other parameters will be used for the command to execute
+
+  # not to be confused with GNU parallel's PARALLEL_JOBSLOT
+  export BATS_JOBSLOT="$semaphore_name"
+  # if also running under GNU parallel, we can have n^2 slots.
+  if [[ -n "$PARALLEL_JOBSLOT" ]]; then
+    BATS_JOBSLOT=$(( (PARALLEL_JOBSLOT - 1) * BATS_SEMAPHORE_NUMBER_OF_SLOTS + semaphore_name ))
+  fi
 
   # shellcheck disable=SC2064 # we want to expand the semaphore_name right now!
   trap "status=$?; bats_semaphore_release_slot '$semaphore_name'; exit $status" EXIT

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -319,6 +319,10 @@ bats_run_tests() {
 
   if [[ "$num_jobs" != 1 && "${BATS_NO_PARALLELIZE_WITHIN_FILE-False}" == False ]]; then
     export BATS_SEMAPHORE_NUMBER_OF_SLOTS="$num_jobs"
+    export BATS_JOBSLOTS="$num_jobs"
+    if [[ -z "${bats_no_parallelize_across_files}" ]]; then
+      BATS_JOBSLOTS=$((BATS_JOBSLOTS ** 2))
+    fi
     bats_run_tests_in_parallel "$BATS_RUN_TMPDIR/parallel_output" || bats_exec_file_status=1
   else
     local test_number_in_suite=$BATS_FILE_FIRST_TEST_NUMBER_IN_SUITE \

--- a/test/parallel.bats
+++ b/test/parallel.bats
@@ -218,3 +218,18 @@ check_parallel_tests() { # <expected maximum parallelity>
   (( SECONDS < 5 ))
   [ "${lines[1]}" = 'Invalid number of jobs: -3' ]
 }
+
+@test "BATS_JOBSLOTS and JOBSLOT" {
+  if [[ "${BATS_NUMBER_OF_PARALLEL_JOBS:-1}" -gt 1 ]]; then
+    if [[ -z "${BATS_NO_PARALLELIZE_ACROSS_FILES:-}" ]]; then
+      [ "$BATS_JOBSLOTS" -eq "$BATS_NUMBER_OF_PARALLEL_JOBS" ]
+    elif [[ -z "${BATS_NO_PARALLELIZE_WITHIN_FILES:-}" ]]; then
+      [ "$BATS_JOBSLOTS" -eq "$BATS_NUMBER_OF_PARALLEL_JOBS" ]
+    else
+      [ "$BATS_JOBSLOTS" -eq $((BATS_NUMBER_OF_PARALLEL_JOBS ** 2)) ]
+    fi
+    [ "$BATS_JOBSLOT" -le "$BATS_JOBSLOTS" ]
+  else
+    [ -z "$BATS_JOBSLOTS" ]
+  fi
+}


### PR DESCRIPTION
  - BATS_JOBSLOTS - total number of parallel job slots
  - BATS_JOBSLOT  - number (1-based) of this task's slot

Reason this is needed: allocating ports on a host. Need something like `port=$((rand * BATS_JOBSLOTS + BATS_JOBSLOT))`

Similar to #255 but takes within-file parallel into consideration. There may be (probably are) better ways to do this.

Tests are not passing; I'm at diminishing returns. Help welcome.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
