### PR TITLE
fix: use $BATS_LIBDIR instead of hardcoded lib in bats-gather-tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,6 +197,21 @@ jobs:
           docker run -it "bash:${{ matrix.version }}" --version
           time docker run -it ${{ matrix.env_vars }} "bats/bats:bash-${{ matrix.version }}"  --print-output-on-failure --tap /opt/bats/test
 
+  lib64-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Install in lib64
+        run: sudo ./install.sh /usr/ lib64
+      - name: Run from env
+        run: time bats test --print-output-on-failure --report-formatter junit --output test-results
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            test-results/**/*.xml
+
   alpine:
     runs-on: ubuntu-latest
     container: alpine:latest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * unbreak test suites with multiple files loading common constants (#904), introduced in v1.11.0
 * docker image won't crash if a file or directory named 'bats' exists (#920)
+* use $BATS_LIBDIR instead of hardcoded lib in 'bats-gather-tests' (#985)
 
 ### Changed
 

--- a/libexec/bats-core/bats-gather-tests
+++ b/libexec/bats-core/bats-gather-tests
@@ -5,9 +5,9 @@ args=("$@")
 filter_tags_list=()
 
 # shellcheck source=lib/bats-core/common.bash disable=SC2153 
-source "$BATS_ROOT/lib/bats-core/common.bash"
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/common.bash"
 # shellcheck source=lib/bats-core/preprocessing.bash
-source "$BATS_ROOT/lib/bats-core/preprocessing.bash"
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/preprocessing.bash"
 
 abort() {
   printf 'ERROR: '
@@ -52,7 +52,7 @@ done
 
 # shellcheck source=lib/bats-core/test_functions.bash disable=SC2153 
 # required to provide e.g. `load` for free code (some users rely on this)
-source "$BATS_ROOT/lib/bats-core/test_functions.bash"
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/test_functions.bash"
 # _bats_test_functions_setup will be called per file further down
 
 # override test_functions.bash's version to use it for test registration
@@ -253,7 +253,7 @@ else
 fi
 
 # shellcheck source=lib/bats-core/tracing.bash
-source "$BATS_ROOT/lib/bats-core/tracing.bash"
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/tracing.bash"
 
 BATS_OUT="$BATS_RUN_TMPDIR/gather-tests.out"
 touch "$BATS_OUT"


### PR DESCRIPTION
- [ I'm an idiot] I have reviewed the [Contributor Guidelines][contributor].
- [PR without testing...  PFFF... ] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
