### PR TITLE
Remove mentions to find_library_load_path in docstrings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 ### Documentation
 
 * Fix hyperlink to external Bash resource (#1033)
+* Remove mentions to no longer existing `find_library_load_path` in
+  `lib/bats-core` docstrings (#1032)
 
 ## [1.11.1] - 2024-11-29
 

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -17,8 +17,6 @@ source "$BATS_ROOT/$BATS_LIBDIR/bats-core/warnings.bash"
 # Libraries relative to BATS_TEST_DIRNAME take precedence over
 # BATS_LIB_PATH.
 #
-# Library load paths are recognized using find_library_load_path.
-#
 # If no library is found find_in_bats_lib_path returns 1.
 find_in_bats_lib_path() { # <return-var> <library-name>
   local return_var="${1:?}"
@@ -80,18 +78,12 @@ bats_internal_load() {
 # bats_load_safe accepts an argument called 'slug' and attempts to find and
 # source a library based on the slug.
 #
-# A slug can be an absolute path, a library name or a relative path.
+# A slug can be an absolute path or a relative path.
 #
-# If the slug is an absolute path bats_load_safe attempts to find the library
-# load path using find_library_load_path.
-# What is considered a library load path is documented in the
-# documentation for find_library_load_path.
+# If the slug is not an absolute path it is resolved relative to
+# BATS_TEST_DIRNAME
 #
-# If the slug is not an absolute path it is considered a library name or
-# relative path. bats_load_safe attempts to find the library load path using
-# find_in_bats_lib_path.
-#
-# If bats_load_safe can find a library load path it is passed to bats_internal_load.
+# The resolved slug is passed to bats_internal_load.
 # If bats_internal_load fails bats_load_safe returns 1.
 #
 # If no library load path can be found bats_load_safe prints an error message

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -68,9 +68,9 @@ setup() {
     [ "${#lines[@]}" -eq 6 ]
   else
     [ "${lines[2]}" = "# (in file $RELATIVE_FIXTURE_ROOT/errors_in_multiple_load/test_helper.bash, line 1," ]
-    [ "${lines[3]}" = "#  from function \`bats_internal_load' in file ${RELATIVE_BATS_ROOT}lib/bats-core/test_functions.bash, line 69," ]
-    [ "${lines[4]}" = "#  from function \`bats_load_safe' in file ${RELATIVE_BATS_ROOT}lib/bats-core/test_functions.bash, line 106," ]
-    [ "${lines[5]}" = "#  from function \`load' in file ${RELATIVE_BATS_ROOT}lib/bats-core/test_functions.bash, line 156," ]
+    [ "${lines[3]}" = "#  from function \`bats_internal_load' in file ${RELATIVE_BATS_ROOT}lib/bats-core/test_functions.bash, line 67," ]
+    [ "${lines[4]}" = "#  from function \`bats_load_safe' in file ${RELATIVE_BATS_ROOT}lib/bats-core/test_functions.bash, line 98," ]
+    [ "${lines[5]}" = "#  from function \`load' in file ${RELATIVE_BATS_ROOT}lib/bats-core/test_functions.bash, line 148," ]
     [ "${lines[6]}" = "#  in test file $RELATIVE_FIXTURE_ROOT/errors_in_multiple_load/a.bats, line 1)" ]
     if (( BASH_VERSINFO[0] == 4)); then
       [ "${lines[7]}" = "#   \`load test_helper' failed" ]


### PR DESCRIPTION
Hi. Thanks for great software and documentation.

Perusing library code I found some docstring mentions to no-longer-existing function `find_library_load_path` (removed in 4977720) This is a proposal to edit them away.

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
