### PR TITLE
docs: Ensure reference to ABS renders as hyperlink

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * increase compatibility with Solaris (#1043)
 * fix `noclobber` breaking `bats-gather-tests` (#1042)
 
+### Documentation
+
+* Fix hyperlink to external Bash resource (#1033)
+
 ## [1.11.1] - 2024-11-29
 
 ### Added

--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -334,7 +334,7 @@ To allow to use `load` in conditions `bats_load_safe` has been added.
 loaded instead of exiting Bats.
 Aside from that `bats_load_safe` acts exactly like `load`.
 
-As pointed out by @iatrou in the [Advanced Bash Scripting Guide
+__Note:__ : As pointed out by @iatrou in the [Advanced Bash Scripting Guide
 (section 9.2)](https://www.tldp.org/LDP/abs/html/declareref.html),
 using the `declare` builtin restricts scope of a variable. Thus, since actual
 `source`-ing is performed in context of the `load` function, `declare`d symbols

--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -337,8 +337,9 @@ Aside from that `bats_load_safe` acts exactly like `load`.
 __Note:__ : As pointed out by @iatrou in the [Advanced Bash Scripting Guide
 (section 9.2)](https://www.tldp.org/LDP/abs/html/declareref.html),
 using the `declare` builtin restricts scope of a variable. Thus, since actual
-`source`-ing is performed in context of the `load` function, `declare`d symbols
-will _not_ be made available to callers of `load`.
+`source`-ing is performed in context of the `load` function, symbols
+defined using `declare` will _not_ be made available to callers of `load` (unless `declare -g`
+is used).
 
 ### `load` argument resolution
 

--- a/docs/source/writing-tests.md
+++ b/docs/source/writing-tests.md
@@ -334,7 +334,8 @@ To allow to use `load` in conditions `bats_load_safe` has been added.
 loaded instead of exiting Bats.
 Aside from that `bats_load_safe` acts exactly like `load`.
 
-As pointed out by @iatrou in https://www.tldp.org/LDP/abs/html/declareref.html,
+As pointed out by @iatrou in the [Advanced Bash Scripting Guide
+(section 9.2)](https://www.tldp.org/LDP/abs/html/declareref.html),
 using the `declare` builtin restricts scope of a variable. Thus, since actual
 `source`-ing is performed in context of the `load` function, `declare`d symbols
 will _not_ be made available to callers of `load`.


### PR DESCRIPTION
I learnt something today thanks to this reference, that is now rendered as a hyperlink (fixes #972)

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
