### PR TITLE
doc: add missing "status" word in `--returned-status` documentation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * Fix hyperlink to external Bash resource (#1033)
 * Remove mentions to no longer existing `find_library_load_path` in
   `lib/bats-core` docstrings (#1032)
+* Add missing "status" word in `--returned-status` documentation (#1077)
 
 ## [1.11.1] - 2024-11-29
 

--- a/man/bats.7.ronn
+++ b/man/bats.7.ronn
@@ -203,7 +203,7 @@ command of interest.
 
 Similarly, --returned-status N (or --returned-status=N) can be used for similar
 functionality. This option supports negative values, which always return the
-of the command starting from the end and in reverse order.
+status of the command starting from the end and in reverse order.
 
     @test "invoking foo piped to bar always return foo status" {
       run bats_pipe --returned-status -2 foo \| bar


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
