### PR TITLE
junit: XML escape fully removes ANSI sequences

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * unset `output`, `stderr`, `lines`, `stderr_lines` at the start of `run` to avoid crosstalk 
   between successive invocations (#1105)
+* junit: XML escape fully removes ANSI sequences, e.g. color codes, cursor movements (#1103)
 
 ### Documentation
 

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -348,8 +348,6 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
     bats_warn_minimum_guaranteed_version "Using flags on \`run\`" 1.5.0
   fi
 
-  unset output stderr lines stderr_lines
-
   local pre_command=
 
   case "$output_case" in
@@ -388,6 +386,8 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
     # shellcheck disable=SC2034
     read -d '' -r stderr <"$bats_run_separate_stderr_file" || true
     bats_separate_lines stderr_lines stderr
+  else
+    unset stderr stderr_lines
   fi
 
   # shellcheck disable=SC2034

--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -103,9 +103,9 @@ xml_escape() {
   output=${output//>/\&gt;}
   output=${output//'"'/\&quot;}
   output=${output//\'/\&#39;}
-  # remove ANSI Color codes
+  # remove ANSI escape sequences (e.g. color codes, cursor movements)
   local CONTROL_CHAR=$'\033'
-  local REGEX="$CONTROL_CHAR\[[0-9;]+m"
+  local REGEX="$CONTROL_CHAR\[[0-9;]*[a-zA-Z]"
   while [[ "$output" =~ $REGEX ]]; do
       output=${output//${BASH_REMATCH[0]}/}
   done

--- a/report.log
+++ b/report.log
@@ -1,0 +1,6 @@
+[31;1m[1G ✗ setup_suite[K
+[0m[31;22m   (from function `setup_suite' in test file test2/setup_suite.bash, line 2)
+[0m[31;22m     `false' failed
+[0m[31;1m
+1 test, 1 failure
+[0m

--- a/report.xml
+++ b/report.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites time="0">
+</testsuites>

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1560,6 +1560,8 @@ END_OF_ERR_MSG
     echo stderr >&2
   }
 
+  local stderr stderr_lines # shut up shellcheck
+
   run --separate-stderr echo_stdout_stderr
 
   [ "$output" == "stdout" ]
@@ -1573,6 +1575,6 @@ END_OF_ERR_MSG
   [ "$output" == "" ]
   [ "${lines[*]}" == "" ]
 
-  [ "$stderr" == "" ]
-  [ "${stderr_lines[*]}" == "" ]
+  [ "${stderr-UNSET}" == "UNSET" ]
+  [ "${stderr_lines[*]-UNSET}" == "UNSET" ]
 }

--- a/test/fixtures/junit-formatter/xml-escape.bats
+++ b/test/fixtures/junit-formatter/xml-escape.bats
@@ -1,11 +1,11 @@
-@test "Successful test with escape characters: \"'<>&[0m (0x1b)" {
+@test "Successful test with escape characters: \"'<>&[0m[K (0x1b)" {
   true
 }
 
-@test "Failed test with escape characters: \"'<>&[0m (0x1b)" {
-  echo "<>'&[0m" && false
+@test "Failed test with escape characters: \"'<>&[0m[K (0x1b)" {
+  echo "<>'&[0m[K" && false
 }
 
-@test "Skipped test with escape characters: \"'<>&[0m (0x1b)" {
-  skip "\"'<>&[0m"
+@test "Skipped test with escape characters: \"'<>&[0m[K (0x1b)" {
+  skip "\"'<>&[0m[K"
 }

--- a/test2/setup_suite.bash
+++ b/test2/setup_suite.bash
@@ -1,0 +1,3 @@
+setup_suite() {
+	false
+}

--- a/test2/test.bats
+++ b/test2/test.bats
@@ -1,0 +1,3 @@
+@test "fail" {
+	echo success!
+}


### PR DESCRIPTION
Previously, ANSI sequences like '\033[H\033[J' (e.g. clearing terminal) broke XML output and tests.

Added removal of full ANSI escape codes to fix this issue.

fixes #896

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
