### PR TITLE
Add --errexit flag to enable errexit in run commands

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,9 +11,13 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+* `--errexit` flag to enable errexit (set -e) behavior for commands run in `run` (#1118)
+
 ### Fixed
 
-* junit formatter: 
+* junit formatter:
   * avoid interference between env and internals (#1175)
   * remove control characters (\x00-\x08\x0B\x0C\x0E-\x1F) (#1176)
   * don't report (skipped) last test as failed when `teardown_suite` generates FD3 output (#1181s)
@@ -29,7 +33,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ## [1.13.0] - 2025-11-07
 
-### Added 
+### Added
 
 * use the [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) parser directive to declare the Dockerfile syntax version (#1127)
 * Negative test filtering via `--negative-filter` - tests matching the filter are *excluded* (#1114)
@@ -37,7 +41,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ### Fixed
 
-* unset `output`, `stderr`, `lines`, `stderr_lines` at the start of `run` to avoid crosstalk 
+* unset `output`, `stderr`, `lines`, `stderr_lines` at the start of `run` to avoid crosstalk
   between successive invocations (#1105)
 * junit:
   * XML escape fully removes ANSI sequences, e.g. color codes, cursor movements (#1103)
@@ -56,7 +60,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ## [1.12.0] - 2025-05-18
 
-### Added 
+### Added
 
 * `bats::on_failure` hook that gets called when a test or `setup*` function fails (#1031)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
   * remove control characters (\x00-\x08\x0B\x0C\x0E-\x1F) (#1176)
   * don't report (skipped) last test as failed when `teardown_suite` generates FD3 output (#1181s)
 * fix failures with `--gather-test-outputs-in` when tests change directory (#1183)
+* `run` now honors `set -e` in your functions (#1118)
+  * **ATTENTION**: In previous versions this was suppressed unintentionally.
+    While it might constitute a breaking change for some, we decided the new behavior should be the default because it might uncover hidden errors.
+    If you need the old behavior, you can use this wrapper function `suppress_errexit() { "$@" || return $?; }` like `run suppress_errexit <your command...>`
 
 ### Changed
 

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -349,6 +349,8 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
   fi
 
   local pre_command=
+  # make sure tmpdir exists in case run() is called outside a @test
+  local tmpdir=${BATS_TEST_TMPDIR:-${BATS_FILE_TMPDIR:-${BATS_RUN_TMPDIR}}}
 
   case "$output_case" in
   merged) # redirects stderr into stdout and fills only $output/$lines
@@ -356,7 +358,7 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
     ;;
   separate) # splits stderr into own file and fills $stderr/$stderr_lines too
     local bats_run_separate_stderr_file
-    bats_run_separate_stderr_file="$(mktemp "${BATS_TEST_TMPDIR}/separate-stderr-XXXXXX")"
+    bats_run_separate_stderr_file="$(mktemp "${tmpdir}/separate-stderr-XXXXXX")"
     pre_command=bats_redirect_stderr_into_file
     ;;
   esac
@@ -372,7 +374,7 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
       # Use temp file to avoid ERR trap interference with errexit
       # Don't use mktemp because that doesn't work with `set -o noclobber`
       local status_file
-      status_file="${BATS_TEST_TMPDIR}/run_status.$(printf '%06d' $((RANDOM % 1000000)))"
+      status_file="${tmpdir}/run_status.$(printf '%06d' $((RANDOM % 1000000)))"
       output="$(
         ( set -eET; "$pre_command" "$@" )
         echo "$?" >"$status_file"
@@ -393,7 +395,7 @@ run() { # [!|-N] [--keep-empty-lines] [--separate-stderr] [--] <command to run..
     # shellcheck disable=SC2034
     if [[ -n "${BATS_RUN_ERREXIT:-}" ]]; then
       local status_file
-      status_file="${BATS_TEST_TMPDIR}/run_status.$(printf '%06d' $((RANDOM % 1000000)))"
+      status_file="${tmpdir}/run_status.$(printf '%06d' $((RANDOM % 1000000)))"
       output="$(
         ( set -eET; "$pre_command" "$@" )
         echo "$?" >"$status_file"

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -67,6 +67,7 @@ HELP_TEXT_HEADER
   -j, --jobs <jobs>         Number of parallel jobs (requires GNU parallel or shenwei356/rush)
   --parallel-binary-name    Name of parallel binary
   --no-tempdir-cleanup      Preserve test output temporary directory
+  --errexit                 Enable errexit (set -e) for commands run in `run`
   --no-parallelize-across-files
                             Serialize test file execution instead of running
                             them in parallel (requires --jobs >1)
@@ -255,6 +256,9 @@ while [[ "$#" -ne 0 ]]; do
   --no-tempdir-cleanup)
     BATS_TEMPDIR_CLEANUP=''
     ;;
+  --errexit)
+    BATS_RUN_ERREXIT=1
+    ;;
   --tempdir) # for internal test consumption only!
     BATS_RUN_TMPDIR="$2"
     shift
@@ -337,6 +341,7 @@ elif ! BATS_RUN_TMPDIR=$(mktemp -d "${BATS_TMPDIR}/bats-run-XXXXXX"); then
 fi
 
 export BATS_WARNING_FILE="${BATS_RUN_TMPDIR}/warnings.log"
+export BATS_RUN_ERREXIT=${BATS_RUN_ERREXIT:-}
 
 bats_exit_trap() {
   if [[ -s "$BATS_WARNING_FILE" ]]; then

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup() {
   load test_helper
   fixtures bats
@@ -1556,7 +1558,7 @@ END_OF_ERR_MSG
   [ "${lines[0]}" = 1..1 ]
   [ "${lines[1]}" = 'not ok 1 setup_file failed' ]
   [ "${lines[2]}" = "# (from function \`setup_file' in test file $RELATIVE_FIXTURE_ROOT/failure_callback_setup_file.bats, line 6)" ]
-  [ "${lines[3]}" = "#   \`false' failed" ] 
+  [ "${lines[3]}" = "#   \`false' failed" ]
   [ "${lines[4]}" = '# failure callback' ]
   [ ${#lines[@]} -eq 5 ]
 }
@@ -1644,8 +1646,33 @@ END_OF_ERR_MSG
 
   [ "${lines[0]}" = '1..5' ]
   [ "${lines[1]}" = 'not ok 1 failing' ] # the provoking test should always be printed!
-  
+
   # we should not reach the test that creates this file
   # shellcheck disable=SC2314
   ! cat "$MARKER_FILE"
+}
+
+@test "--errexit flag is accepted and sets BATS_RUN_ERREXIT" {
+  reentrant_run bats --tap --errexit "$FIXTURE_ROOT/errexit_env.bats"
+  [ "${lines[0]}" == "1..1" ]
+  [ "${lines[1]}" == "ok 1 check BATS_RUN_ERREXIT is set" ]
+  [ "${#lines[@]}" == 2 ]
+}
+
+@test "--errexit flag behavior differs from default run behavior" {
+  # Test without --errexit flag (default behavior)
+  reentrant_run bats --tap "$FIXTURE_ROOT/errexit_test.bats"
+  [ "${lines[0]}" == "1..2" ]
+  [ "${lines[1]}" == "ok 1 failing function without --errexit continues" ]
+  [ "${lines[2]}" == "ok 2 passing function works" ]
+  [ "${#lines[@]}" == 3 ]
+
+  # Test with --errexit flag - should fail the first test since it expects non-errexit behavior
+  reentrant_run ! bats --tap --errexit "$FIXTURE_ROOT/errexit_test.bats"
+  [ "${lines[0]}" == "1..2" ]
+  [[ "${lines[1]}" =~ "not ok 1 failing function without --errexit continues" ]]
+  [[ "${lines[2]}" =~ "in test file" ]]
+  [[ "${lines[3]}" =~ "Step 2: should not appear with errexit" ]]
+  [ "${lines[4]}" == "ok 2 passing function works" ]
+  [ "${#lines[@]}" == 5 ]
 }

--- a/test/fixtures/bats/errexit_env.bats
+++ b/test/fixtures/bats/errexit_env.bats
@@ -1,0 +1,3 @@
+@test "check BATS_RUN_ERREXIT is set" {
+  [ "${BATS_RUN_ERREXIT:-}" = "1" ]
+}

--- a/test/fixtures/bats/errexit_test.bats
+++ b/test/fixtures/bats/errexit_test.bats
@@ -1,0 +1,27 @@
+# Test function that fails fast with errexit
+failing_function() {
+  echo "Step 1"
+  false
+  echo "Step 2: should not appear with errexit"
+}
+
+# Test function that succeeds
+passing_function() {
+  echo "Step 1"
+  true
+  echo "Step 2: should always appear"
+}
+
+@test "failing function without --errexit continues" {
+  run failing_function
+  [[ "$output" =~ "Step 1" ]]
+  [[ "$output" =~ "Step 2: should not appear with errexit" ]]
+  [ "$status" -eq 0 ]
+}
+
+@test "passing function works" {
+  run passing_function
+  [[ "$output" =~ "Step 1" ]]
+  [[ "$output" =~ "Step 2: should always appear" ]]
+  [ "$status" -eq 0 ]
+}

--- a/test/fixtures/bats/errexit_test.bats
+++ b/test/fixtures/bats/errexit_test.bats
@@ -14,14 +14,14 @@ passing_function() {
 
 @test "failing function without --errexit continues" {
   run failing_function
-  [[ "$output" =~ "Step 1" ]]
-  [[ "$output" =~ "Step 2: should not appear with errexit" ]]
+  [[ "$output" =~ "Step 1" ]] || false
+  [[ "$output" =~ "Step 2: should not appear with errexit" ]] || false
   [ "$status" -eq 0 ]
 }
 
 @test "passing function works" {
   run passing_function
-  [[ "$output" =~ "Step 1" ]]
-  [[ "$output" =~ "Step 2: should always appear" ]]
+  [[ "$output" =~ "Step 1" ]] || false
+  [[ "$output" =~ "Step 2: should always appear" ]] || false
   [ "$status" -eq 0 ]
 }

--- a/test/run.bats
+++ b/test/run.bats
@@ -2,6 +2,10 @@ load test_helper
 fixtures run
 bats_require_minimum_version 1.5.0
 
+setup() {
+  emulate_bats_env
+}
+
 @test "run --keep-empty-lines preserves leading empty lines" {
   run --keep-empty-lines -- echo -n $'\na'
   printf "'%s'\n" "${lines[@]}"
@@ -85,7 +89,7 @@ print-stderr-stdout() {
 }
 
 @test "run exit code check output " {
-  reentrant_run ! bats --tap "${FIXTURE_ROOT}/failing.bats"
+  reentrant_run ! bats --no-tempdir-cleanup --tap "${FIXTURE_ROOT}/failing.bats"
   echo "$output"
   [ "${lines[0]}" == 1..5 ]
   [ "${lines[1]}" == "not ok 1 run -0 false" ]
@@ -172,4 +176,30 @@ failing_function() {
   [ "${lines[0]}" = "first line" ]
   [ "${lines[1]}" = "" ]
   [ "${lines[2]}" = "before failure" ]
+}
+
+function fail_with_set_e() {
+  set -e
+  echo before
+  false
+  echo after
+}
+
+suppress_errexit() { # <command with args...>
+  "$@" || return $?
+}
+
+@test "run allows for set -e in command" {
+  unset BATS_RUN_ERREXIT
+  run ! fail_with_set_e
+  [ "${lines[0]}" = before ]
+  [ "${#lines[@]}" -eq 1 ]
+}
+
+@test "recreate old run set -e behavior" {
+  unset BATS_RUN_ERREXIT
+  run -0 suppress_errexit fail_with_set_e
+  [ "${lines[0]}" = before ]
+  [ "${lines[1]}" = after ]
+  [ "${#lines[@]}" -eq 2 ]
 }


### PR DESCRIPTION
* Set BATS_RUN_ERREXIT environment variable when flag is provided.
* Write `$?` to a temp file when errexit is enabled.

I've tried for several hours, but have been unable to find a solution without using a temp file. I don't quite understand why, but I couldn't make it work.

Fixes #719
Fixes #748

---

- [X] I have reviewed the [Contributor Guidelines][contributor].
- [X] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
