### PR TITLE
chore(docker): add `syntax` parser directive to Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG bashver=latest
 
 FROM bash:${bashver}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG bashver=latest
 
 FROM bash:${bashver}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ## [Unreleased]
 
+### Added 
+
+* use the [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) parser directive to declare the Dockerfile syntax version (#1127)
+
 ### Fixed
 
 * unset `output`, `stderr`, `lines`, `stderr_lines` at the start of `run` to avoid crosstalk 


### PR DESCRIPTION
## Summary

Add the Dockerfile [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) parser directive to project Dockerfiles and update the changelog accordingly

Documentation:
- Include the new syntax parser directive under Unreleased in [CHANGELOG.md](https://github.com/bats-core/bats-core/blob/master/docs/CHANGELOG.md)

Chores:
- Add `# syntax=docker/dockerfile:1` directive to the top of [Dockerfile](https://github.com/bats-core/bats-core/blob/master/Dockerfile) and [.devcontainer/Dockerfile](https://github.com/bats-core/bats-core/blob/master/.devcontainer/Dockerfile)

---

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
