### PR TITLE
fix: bats_test_function requires --tags to be sorted

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
   * fix retried tests being listed multiple times (#1150)
 * remove deprecated windows runner (#1119)
 * renamed `docker-compose.yml` to `compose.yaml` (#1128)
+* `bats_test_function`: don't require `--tags` to be sorted (#1158)
 
 ### Documentation
 

--- a/lib/bats-core/common.bash
+++ b/lib/bats-core/common.bash
@@ -104,6 +104,10 @@ bats_sort() { # <result-array-name> <values to sort...>
   local -r result_name=$1
   shift
 
+  if (($# == 1)) && [[ $1 == "" ]]; then
+    shift # remove leading "" to deal with bash 3 expanding "${empty_array[@]}" to one ""
+  fi
+
   if (($# == 0)); then
     eval "$result_name=()"
     return 0
@@ -116,11 +120,11 @@ bats_sort() { # <result-array-name> <values to sort...>
     shift
     for ((i = ${#sorted_array[@]}; i >= 0; --i)); do # loop over output array from end
       if (( i == 0 )) || [[ ${sorted_array[i - 1]} < $current_value ]]; then
-        # shift bigger elements one position to the end
+        # insert new element at (freed) desired location
         sorted_array[i]=$current_value
         break
       else
-        # insert new element at (freed) desired location
+        # shift bigger elements one position to the end
         sorted_array[i]=${sorted_array[i - 1]}
       fi
     done

--- a/lib/bats-core/test_functions.bash
+++ b/lib/bats-core/test_functions.bash
@@ -462,7 +462,7 @@ skip() {
 }
 
 bats_test_function() {
-  local tags=()
+  local tags=() current_tags=()
   while (( $# > 0 )); do
     case "$1" in
       --description)
@@ -472,7 +472,10 @@ bats_test_function() {
         shift 2
       ;;
       --tags)
-        IFS=',' read -ra tags <<<"$2"
+        if [[ "$2" != "" ]]; then # avoid unbound variable with set -u Bash 3
+          IFS=',' read -ra current_tags <<<"$2"
+          tags+=("${current_tags[@]}")
+        fi
         shift 2
       ;;
       --)
@@ -485,6 +488,11 @@ bats_test_function() {
       ;;
     esac
   done
+
+  if (( ${#tags[@]} > 1 )); then # avoid unbound variable with set -u Bash 3
+    bats_sort tags "${tags[@]}"
+  fi
+
   BATS_TEST_NAMES+=("$*")
   local quoted_parameters
   printf -v quoted_parameters " %q" "$@"

--- a/libexec/bats-core/bats-gather-tests
+++ b/libexec/bats-core/bats-gather-tests
@@ -57,7 +57,7 @@ source "$BATS_ROOT/$BATS_LIBDIR/bats-core/test_functions.bash"
 
 # override test_functions.bash's version to use it for test registration
 bats_test_function() {
-  local -a tags=()
+  local -a tags=() current_tags=()
   local description=
 
   while (( $# > 0 )); do
@@ -67,7 +67,10 @@ bats_test_function() {
         shift 2
       ;;
       --tags)
-        IFS=, read -ra tags <<<"$2" || true
+        if [[ "$2" != "" ]]; then # avoid unbound variable with set -u Bash 3
+          IFS=, read -ra current_tags <<<"$2" || true
+          tags+=("${current_tags[@]}")
+        fi
         shift 2
       ;;
       --)
@@ -80,6 +83,10 @@ bats_test_function() {
       ;;
     esac
   done
+
+  if (( ${#tags[@]} > 1 )); then # avoid unbound variable with set -u Bash 3
+    bats_sort tags "${tags[@]}"
+  fi
 
   line="$BATS_TEST_FILENAME"
   line+=$'\t'

--- a/libexec/bats-core/bats-preprocess
+++ b/libexec/bats-core/bats-preprocess
@@ -70,7 +70,6 @@ extract_tags() { # <tag_type/return_var> <tags-string>
 
 test_file="$1"
 test_tags=()
-# shellcheck disable=SC2034 # used in `bats_sort tags`/`extract_tags``
 file_tags=()
 line_number=0
 exit_code=0
@@ -93,15 +92,11 @@ IFS=,
         # avoid injecting non user code into tests
         lead=''
       fi
-      bats_append_arrays_as_args \
-        test_tags file_tags \
-        -- bats_sort tags
 
       # shellcheck disable=SC2154 # encoded_name is declare via bats_encode_test_name
-      printf 'bats_test_function --description %q  --tags "%s" -- %s;' "$name" "${tags[*]-}" "$encoded_name"
+      printf 'bats_test_function --description %q  --tags "%s" --tags "%s" -- %s;' "$name" "${test_tags[*]-}" "${file_tags[*]-}" "$encoded_name"
       printf '%s() { %s%s\n' "${encoded_name:?}" "$lead" "$body" || :
 
-      # shellcheck disable=SC2034 # used in `bats_sort tags`/`extract_tags`
       test_tags=() # reset test tags for next test
     else
       if [[ "$line" =~ $BATS_COMMENT_COMMAND_PATTERN ]]; then


### PR DESCRIPTION
- allow for multiple --tags
- simplify Bash 3 expansion handling