### PR TITLE
Removed duplicate `test` suite runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,16 @@
 name: Tests
 
 # Controls when the action will run.
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently every pull request runs an identical test suite _twice_. Once for the `pull_request` event and once for the `push` event. This change reduces it only one once for PRs that will be merged into the default branch. And the `push` runs are limited to the default branch as well. 

> [!NOTE]
> 
> I saw some repositories in this org are named with the new default branch name (`main`) and this one is still using the legacy name (`master`) so I added both so it would continue to work if this default branch were renamed.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
