### PR TITLE
chore(devcontainer): update default bash version to 5.3

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
     "name": "Bats core development environment",
     "dockerFile": "Dockerfile",
-    "build": {"args": {"bashver": "4.3"}}
+    "build": {"args": {"bashver": "5.3"}}
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
   * avoid interference between env and internals (#1175)
   * remove control characters (\x00-\x08\x0B\x0C\x0E-\x1F) (#1176)
 
+### Changed
+
+* update the default version of the `bash` Docker image to 5.3 in `devcontainer` (#1184)
+
 ## [1.13.0] - 2025-11-07
 
 ### Added 


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

## Summary

Build:
- Adjust devcontainer configuration to set the default Bash version to 5.3 for local development.

## Why?

[The Dockerfile](https://github.com/bats-core/bats-core/blob/master/Dockerfile) uses the latest version.

https://github.com/bats-core/bats-core/blob/33ae8862cd058e004f9f04e1f9ad6197763a1cb2/Dockerfile#L2-L4

This PR sync it.