### PR TITLE
Revert "Removed duplicate `test` suite runs"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,16 +1,7 @@
 name: Tests
 
 # Controls when the action will run.
-on:
-  pull_request:
-    branches:
-      - main
-      - master
-  push:
-    branches:
-      - main
-      - master
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 permissions:
   contents: read


### PR DESCRIPTION
Reverts bats-core/bats-core#1172

It was reported that the test suite runs "duplicate" test runs. However, the configuration was intentional. https://github.com/bats-core/bats-core/pull/1172#issuecomment-3573593526

The pull_request event runs the suite against the PR's MERGE_HEAD. The push event runs against the PR's branch HEAD. These are not the same commits, and they don't include the same code. (The branch head will not include any code that has landed in main since the branch diverged, and the merge_head _does_.)

So first and foremost, having both runs sends a valuable signal when only one of the suites fails. If the suite fails only on push, then that means that `main` contains code that resolves the failure. Alternatively, if it fails only on pull_request, then that means that whatever causes the failure exists in within the code being merged from main (or the merge is bad for some other reason).

Beyond the fact that both events run against different source, there is value in the test suite being run more often. Test suites that have flaky tests can exhibit failures that seem random. Resolving these failures is difficult in repos that receive frequent activity, but is drastically more difficult when the "random" failure occurrence is infrequent (as is common in relatively low-activity OSS repos like bats). So having the suite run more frequently decreases the overall length of time that flaky tests can exist within the codebase. (As they would ideally be noticed and resolved sooner.)

Lastly, the change to push events failed to include tag push events. While this could have been addressed by explicitly include tags in the push-event trigger, this uncovers the more insidious problem with configuration: the more configuration that exists, the more likely for errors to creep in due to oversight.

Simplicity in configuration might not (on its own) be enough to keep the "duplicate" suites running. However, taken with all the other benefits outlined above, and the fact that the simple configuration also runs the suite on tags, it is surely an added benefit.