### PR TITLE
fix missing linebreaks on bootstrap errors for BATS_TMPDIR

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
   * **ATTENTION**: In previous versions this was suppressed unintentionally.
     While it might constitute a breaking change for some, we decided the new behavior should be the default because it might uncover hidden errors.
     If you need the old behavior, you can use this wrapper function `suppress_errexit() { "$@" || return $?; }` like `run suppress_errexit <your command...>`
+* fix missing newlines in `$BATS_TMPDIR`-error handling checks at startup
 
 ### Changed
 

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -127,10 +127,10 @@ BATS_REPORT_OUTPUT_DIR=${BATS_REPORT_OUTPUT_DIR-.}
 export BATS_LINE_REFERENCE_FORMAT=${BATS_LINE_REFERENCE_FORMAT-comma_line}
 
 if [[ ! -d "${BATS_TMPDIR}" ]]; then
-  printf "Error: BATS_TMPDIR (%s) does not exist or is not a directory" "${BATS_TMPDIR}" >&2
+  printf "Error: BATS_TMPDIR (%s) does not exist or is not a directory\n" "${BATS_TMPDIR}" >&2
   exit 1
 elif [[ ! -w "${BATS_TMPDIR}" ]]; then
-  printf "Error: BATS_TMPDIR (%s) is not writable" "${BATS_TMPDIR}" >&2
+  printf "Error: BATS_TMPDIR (%s) is not writable\n" "${BATS_TMPDIR}" >&2
   exit 1
 fi
 


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
