### PR TITLE
docs(man): add four flags missing from bats(1) OPTIONS

### DIFF
--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -76,6 +76,8 @@ An empty tag list matches tests without tags.
 OPTIONS
 -------
 
+  * `--abort`:
+    Stop execution of suite on first failed test
   * `-c`, `--count`:
     Count the number of test cases without running any tests
   * `--code-quote-style <style>`:
@@ -90,6 +92,8 @@ OPTIONS
       - uri: file:///tests/a.bats:1
       - custom: provide your own via defining bats_format_file_line_reference_custom
                 with parameters <filename> <line>, store via `printf -v "$output"`
+  * `--errexit`:
+    Enable errexit (`set -e`) for commands run in `run`
   * `-f`, `--filter <regex>`:
     Filter test cases by names matching the regular expression
   * `-F`, `--formatter <type>`:
@@ -111,12 +115,16 @@ OPTIONS
     Display this help message
   * `-j`, `--jobs <jobs>`:
     Number of parallel jobs (requires GNU parallel)
+  * `--negative-filter <regex>`:
+    Only run tests that do not match the regular expression
   * `--no-tempdir-cleanup`:
     Preserve test output temporary directory
   * `--no-parallelize-across-files`:
     Serialize test file execution instead of running them in parallel (requires --jobs >1)
   * `--no-parallelize-within-files`:
     Serialize test execution within files instead of running them in parallel (requires --jobs >1)
+  * `--parallel-binary-name <name>`:
+    Name of parallel binary
   * `--report-formatter <type>`:
     Switch between reporters (same options as --formatter)
   * `-o`, `--output <dir>`:


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines](https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md).
- [x] I have reviewed the [Code of Conduct](https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md) and agree to abide by it

---

The bats(1) man page is missing OPTIONS entries for four flags that exist in `bats --help` and have working implementations in `libexec/bats-core/bats`:

| flag | added in |
| --- | --- |
| `--abort` | 2025-10-12 (commit 2153e6a) |
| `--errexit` | 2025-07-26 (commit 185f268) |
| `--negative-filter` | 2025-07-16 (commit 9e6627e, #1114) |
| `--parallel-binary-name` | 2023-05-28 (commit 2c31eb3) |

`bats.1.ronn` was last touched in November 2022, before any of these landed, so the gap accumulated quietly.

The descriptions added here mirror the wording of `bats --help` so the two stay in sync. To verify the gap is closed:

```sh
diff <(bin/bats --help | grep -oE '(^|[^-])--?[a-z][a-z-]*' | tr -d ' ' | sort -u) \
     <(grep -oE '`--[a-z-]+`' man/bats.1.ronn | tr -d '`' | sort -u)
```

Only `bats.1.ronn` is touched in this PR. `bats.1` was not regenerated because the Ronn-NG version available locally would have introduced unrelated header noise. Happy to regen with whichever toolchain version a maintainer prefers.
