### PR TITLE
docs(gotchas): add entry for declare scoping in load-ed helpers (#973)

### DIFF
--- a/docs/source/gotchas.rst
+++ b/docs/source/gotchas.rst
@@ -64,6 +64,24 @@ If you want to fail the test, you should explicitly check `$status` or omit `run
 `load` is intended as an internal helper function that always loads `.bash` files (by appending this suffix).
 If you want to load an `.sh` file, you can simple `source` it.
 
+Variables I `declare` in a `load`\ -ed file are not visible in my tests.
+------------------------------------------------------------------------
+
+`load` sources the helper file from inside the `load` shell function. Bash's
+`declare` builtin creates function-local variables by default, so any
+variable set with a bare `declare` in the loaded file goes out of scope as
+soon as `load` returns and is not visible to your tests.
+
+Use `declare -g` in the helper file to make the variable global:
+
+.. code-block:: bash
+
+    # in helpers.bash, loaded via `load 'helpers'`
+    declare -g MY_VAR="some value"
+
+See the note under `load: Share common code <writing-tests.html#load-share-common-code>`_
+in the writing-tests guide for the underlying Bash behaviour.
+
 I can't lint/shell-format my bats tests.
 ----------------------------------------
 


### PR DESCRIPTION
## Summary

Resolves #973.

The `writing-tests.md` doc already explains that Bash's `declare` creates function-local variables and that `load`-ed helpers need `declare -g` to expose variables to the test. The Gotchas page had no entry for this, so users hitting the symptom ('I set the variable in my loaded helper and it's undefined in my test') had no path from symptom to explanation without reading the full writing-tests guide.

This PR adds a Gotchas entry following the page's symptom-first convention, modelled on the adjacent ``load`` won't load my `.sh` files.`` entry, and links back to the writing-tests section for readers who want the deeper Bash background.

## Changes

- `docs/source/gotchas.rst`: new `Variables I \`declare\` in a \`load\`-ed file are not visible in my tests.` section with a minimal `declare -g` example and a cross-reference to `writing-tests.html#load-share-common-code`.

## Test plan

- `sphinx-build -b html docs/source /tmp/bats-docs-out` — builds cleanly with no new warnings (the two pre-existing `BW01` and `pre` lexer warnings are unrelated).
- Verified the new section renders as a proper `<h2>` with a headerlink and appears in the Gotchas TOC at the expected position (between the `.sh` files entry and the lint/shell-format entry).

Fixes #973