### PR TITLE
Fix #1199: error when first argument is empty string

### DIFF
--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -471,6 +471,11 @@ fi
 
 filenames=()
 for filename in "${arguments[@]}"; do
+  
+  if [[ -z "$filename" ]]; then
+    printf "Error: filename argument cannot be empty\n" >&2
+    exit 1
+  fi
   expand_path "$filename" 'filename'
 
   if [[ -z "$setup_suite_file" ]]; then

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -22,6 +22,12 @@ setup() {
   [ "${lines[1]%% *}" == 'Usage:' ]
 }
 
+@test "empty filename prints an error" {
+  reentrant_run bats ""
+  [ $status -eq 1 ]
+  [ "${lines[0]}" == "Error: filename argument cannot be empty" ]
+}
+
 @test "-v and --version print version number" {
   reentrant_run bats -v
   [ $status -eq 0 ]


### PR DESCRIPTION
When invoked with bats "" (empty string as the first argument), bats previously silently collected 0 tests and exited 0, hiding the missing input from CI scripts. This is particularly dangerous in shell pipelines where bats "$var" expands to bats "" when $var is empty, leading to passing CI with no tests actually running.

This change adds an explicit empty-string check in the argument-processing loop, producing a clear error and exit code 1.

Fixes #1199

- [ ] I have reviewed the [Contributor Guidelines][contributor].
- [ ] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
