### PR TITLE
fix(timeout): close inherited FDs in watchdog subshell (fixes #1206)

### DIFF
--- a/libexec/bats-core/bats-exec-test
+++ b/libexec/bats-core/bats-exec-test
@@ -278,9 +278,15 @@ bats_start_timeout_countdown() { # <timeout>
   fi
   # Start another process to kill the children of this process
   (
+    # Close inherited FDs so this watchdog cannot block the parent
+    # on pipe EOF when a test exits before the timeout fires — the
+    # watchdog otherwise keeps the parent's pipes open until its
+    # sleep completes. Mirrors the close-fds pattern in the inner
+    # subshell below. Fixes #1206.
+    eval exec {0..255}">&-"
     # with sleep in foreground this shell wouldn't receive signals,
     # so we use wait below and kill sleep explicitly when signalled to do so
-    # On Windows the TERM signal does not seem to shut down sleep -> 
+    # On Windows the TERM signal does not seem to shut down sleep ->
     # close all fds to avoid blocking IO when sleep does not turn off
     (eval exec {0..255}">&-"; sleep "$timeout") &
     # shellcheck disable=SC2064

--- a/test/fixtures/timeout/issue1206.bats
+++ b/test/fixtures/timeout/issue1206.bats
@@ -1,0 +1,3 @@
+@test fail_fast {
+	false
+}

--- a/test/timeout.bats
+++ b/test/timeout.bats
@@ -42,3 +42,11 @@ bats_require_minimum_version 1.5.0
   echo Took $SECONDS seconds
   (( SECONDS < DURATION ))
 }
+
+@test "timeout should not hold up faster (failing) tests (#1206)" {
+  SECONDS=0
+  DURATION=10
+  reentrant_run ! env BATS_TEST_TIMEOUT=$DURATION bats -T "$FIXTURE_ROOT/issue1206.bats"
+  echo Took $SECONDS seconds
+  (( SECONDS < DURATION ))
+}


### PR DESCRIPTION
Closes #1206.

## Problem

`BATS_TEST_TIMEOUT` extends the wall-clock runtime of fast-failing
tests to the full timeout duration, instead of letting the test fail
in <1s. Reproduces on 1.13.0:

| Scenario                          | `BATS_TEST_TIMEOUT` | Wall clock | Status |
|-----------------------------------|---------------------|------------|--------|
| Single passing test               | 10s                 | 0.07s      | OK     |
| Slow passing, timeout fires       | 2s                  | 2.12s      | OK     |
| Single skipped test (#1067 fix)   | 10s                 | 0.07s      | OK     |
| Single failing (`false`)          | 8s                  | 8.14s      | BUG    |
| Multiple failing tests            | 8s                  | 8.14s      | BUG    |
| `exit 1`                          | 8s                  | ~8s        | BUG    |

Smoking gun on stderr: `bats-exec-test: line 263: kill: (PID) - No such process`
firing after the full timeout, indicating the watchdog's TERM trap
path wasn't taken and the watchdog ran through to
`bats_kill_processes_of` after its full sleep.

## Root cause

`bats_start_timeout_countdown` forks an outer subshell that inherits
all FDs from `bats-exec-test`, including pipes connecting it to its
parent. On a fast-failing test, `bats-exec-test`'s EXIT trap calls
`bats_abort_timeout_countdown`, which sends SIGTERM to the watchdog —
but in practice the watchdog runs for the full sleep duration. While
it's alive, it holds the parent's pipe write-ends open, so the
parent blocks on pipe EOF for the full `BATS_TEST_TIMEOUT` duration.

## Fix

Close inherited FDs in the outer watchdog subshell before spawning
the inner sleep, mirroring the existing `eval exec {0..255}">&-"`
pattern in the inner subshell (added in the #1067 series for the
Windows-SIGTERM-doesn't-kill-sleep case). The watchdog can no longer
hold the parent's pipes open regardless of whether the TERM trap
reaches it.

After fix:

| Scenario              | `BATS_TEST_TIMEOUT` | Wall clock | Status |
|-----------------------|---------------------|------------|--------|
| Single failing        | 8s                  | 0.064s     | OK     |
| Multiple failing      | 8s                  | 0.082s     | OK     |
| `exit 1`              | 8s                  | 0.065s     | OK     |

Stress-tested 20× at `BATS_TEST_TIMEOUT=2`: max wall-clock 0.069s,
zero hangs. The full `bin/bats test/` suite stays green (480/480).

## Considered alternatives

- Process-group `kill -KILL -<pgid>` of the watchdog — higher risk of
  regressing #1020 (run-children-leak) by killing unrelated siblings;
  needs `set -m`/process-group plumbing that's awkward in bash 3.2.
- Replace forked subshell with `coproc` or `read -t` — requires bash
  4+; bats supports 3.2+.

## Scope decision: open to maintainer steering

This patch closes FDs 0-255 in the outer subshell, exactly mirroring
the inner subshell's pattern. Tighter alternative if preferred:
`exec 0<&- 1>&-` (close only stdin/stdout, preserve stderr for
diagnostic output from `bats_kill_processes_of`). Happy to iterate.

## Tests

- New fixture: `test/fixtures/timeout/issue1206.bats` — single
  failing test.
- New assertion in `test/timeout.bats` mirroring the existing #1067
  test: asserts wall-clock `< DURATION` for a fast-failing test under
  `BATS_TEST_TIMEOUT=10`.
- `bin/bats test/` stays 100% green (480 tests).

## Related observation (out of scope, possible follow-up)

`libexec/bats-core/bats-exec-test:357-361` redirects stdout, stderr,
and FD 4 for the test body (`} >>"$BATS_OUT" 2>&1 4>&1`) but doesn't
touch stdin. Tests inherit the bats invocation's FD 0. A downstream
consumer running bats inside a tool harness saw a hang from a
blocking socket inherited as FD 0 through 8 process layers,
reaching a fixture mock that called `query="$(cat)"` even on a
side-effect-only `--refresh` invocation. Same FD-handling class as
this PR — could be a follow-up to tighten test-body stdin discipline,
but a different code path and a different test surface. Happy to
file as a separate issue if there's interest; not bundled here.
