### PR TITLE
Avoid overwriting $_ by the DEBUG and ERR traps set by Bats

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
   * **ATTENTION**: In previous versions this was suppressed unintentionally.
     While it might constitute a breaking change for some, we decided the new behavior should be the default because it might uncover hidden errors.
     If you need the old behavior, you can use this wrapper function `suppress_errexit() { "$@" || return $?; }` like `run suppress_errexit <your command...>`
+* avoid overwriting `$_` by the DEBUG and ERR traps set by Bats (#1208)
 
 ### Changed
 

--- a/lib/bats-core/tracing.bash
+++ b/lib/bats-core/tracing.bash
@@ -382,8 +382,8 @@ bats_setup_tracing() {
   done
 
   # turn on traps after setting excludes to avoid tracing the exclude setup
-  trap 'bats_debug_trap "$BASH_SOURCE"' DEBUG
-  trap 'bats_error_trap' ERR
+  trap 'bats_debug_trap "$BASH_SOURCE" "$_"' DEBUG
+  trap 'bats_error_trap "$_"' ERR
 }
 
 # predefine to avoid problems when the user does not declare one

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -1280,6 +1280,7 @@ END_OF_ERR_MSG
   else
     normalize_variable_list() {
       # `declare -p`: declare -X VAR_NAME="VALUE"
+      # shellcheck disable=SC2030 # false positive `$_` (see https://github.com/koalaman/shellcheck/issues/3478)
       while IFS=' =' read -r _declare _ variable _; do
         if [[ "$_declare" == declare ]]; then # skip multiline variables' values
           printf "%s\n" "$variable"
@@ -1675,4 +1676,12 @@ END_OF_ERR_MSG
   [[ "${lines[3]}" =~ "Step 2: should not appear with errexit" ]]
   [ "${lines[4]}" == "ok 2 passing function works" ]
   [ "${#lines[@]}" == 5 ]
+}
+
+@test "Bats's DEBUG trap should not overwrite \$_ (#1208)" {
+  # set $_
+  : '<lastarg#1208>'
+  
+  # shellcheck disable=SC2031 # see https://github.com/koalaman/shellcheck/issues/3478
+  [ "$_" == '<lastarg#1208>' ] # check that $_ is preserved
 }


### PR DESCRIPTION
- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md

**Summary**

In short, the current DEBUG trap set by Bats breaks the value of `$_`, which becomes an issue in testing a shell function that uses the value of `$_`. The DEBUG and ERR traps should preserve the value of `$_`.

**Details**

I want to test a function that uses `$_` in https://github.com/rcaloras/bash-preexec/pull/187. However, the `DEBUG` trap set by Bats seems to overwrite `$_` with a string like `/tmp/bats-run-lfvLSG/bats.201138.src` between the execution of the line to set `$_` and the line to use the value of `$_`. There doesn't seem to be a way to test this function (except for unsetting the trap, though I'm not sure what would be a side effect of removing the hooks installed by Bats in the middle of the test).

For example, see the test case included in this PR. This test case doesn't pass with the `master` branch because the DEBUG trap string `bats_debug_trap "$BASH_SOURCE"` set by Bats will overwrite `$_` to be `"$BASH_SOURCE"`. To reproduce the value of `$_` at the end of the evaluation of the function `bats_debug_trap`, the function in the DEBUG trap should receive an extra dummy argument `"$_"` as in the suggested change. With this change, the test case passes.
