### PR TITLE
Fix setup_suite PATH changes breaking internals

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ### Fixed
 
+* resolve Bats internal tools independently of `PATH` mutations in `setup_suite` (#1209)
 * pretty formatter was not the default on interactive shells anymore (#1220)
 
 ### Documentation

--- a/lib/bats-core/common.bash
+++ b/lib/bats-core/common.bash
@@ -271,6 +271,18 @@ bats_format_file_line_reference_uri() {
   printf -v "$output" "file://%s:%d" "$filename" "$line"
 }
 
+bats_internal_path() { # <output-variable> <internal-command>
+  local output=$1 command=$2
+  printf -v "$output" '%s/%s' "${BATS_LIBEXEC?}" "$command"
+}
+
+bats_execute_internal() { # <internal-command> <args...>
+  local command=$1 path
+  shift
+  bats_internal_path path "$command"
+  "$path" "$@"
+}
+
 # execute command with backed up path
 # to prevent path mocks from interfering with our internals
 bats_execute() { # <command...>

--- a/lib/bats-core/preprocessing.bash
+++ b/lib/bats-core/preprocessing.bash
@@ -9,7 +9,7 @@ bats_export_preprocess_source_BATS_TEST_SOURCE() {
 bats_preprocess_source() { # index
   bats_export_preprocess_source_BATS_TEST_SOURCE
   # shellcheck disable=SC2153
-  CHECK_BATS_COMMENT_COMMANDS=1 "$BATS_ROOT/libexec/bats-core/bats-preprocess" "$BATS_TEST_FILENAME" >"$BATS_TEST_SOURCE"
+  CHECK_BATS_COMMENT_COMMANDS=1 bats_execute_internal bats-preprocess "$BATS_TEST_FILENAME" >"$BATS_TEST_SOURCE"
 }
 
 bats_evaluate_preprocessed_source() {

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -119,6 +119,9 @@ BATS_LIBEXEC="$(
   pwd
 )"
 export BATS_LIBEXEC
+# shellcheck source=lib/bats-core/common.bash
+source "$BATS_ROOT/$BATS_LIBDIR/bats-core/common.bash"
+
 export BATS_CWD="$PWD"
 export PATH="$BATS_LIBEXEC:$PATH"
 export BATS_ROOT_PID=$$
@@ -420,7 +423,14 @@ if [[ $formatter == /* ]]; then # absolute paths are direct references to format
   bats_check_formatter "$formatter"
   interpolated_formatter="$formatter"
 else
-  interpolated_formatter="bats-format-${formatter}"
+  case "$formatter" in
+  pretty | junit | tap | tap13 | cat)
+    bats_internal_path interpolated_formatter "bats-format-${formatter}"
+    ;;
+  *)
+    interpolated_formatter="bats-format-${formatter}"
+    ;;
+  esac
 fi
 
 if [[ "${#arguments[@]}" -eq 0 ]]; then
@@ -451,7 +461,7 @@ if [[ $report_formatter == /* ]]; then # absolute paths are direct references to
   bats_check_formatter "$report_formatter"
   interpolated_report_formatter="${report_formatter}"
 else
-  interpolated_report_formatter="bats-format-${report_formatter}"
+  bats_internal_path interpolated_report_formatter "bats-format-${report_formatter}"
 fi
 
 if [[ "${BATS_CODE_QUOTE_STYLE-BATS_CODE_QUOTE_STYLE_UNSET}" == BATS_CODE_QUOTE_STYLE_UNSET ]]; then
@@ -542,13 +552,15 @@ bats_tee() { # <output-file> <command...>
   return $status
 }
 
+bats_exec_suite=
+bats_internal_path bats_exec_suite bats-exec-suite
 if [[ -n "$report_formatter" ]]; then
-  exec bats-exec-suite "${flags[@]}" "${filenames[@]}" |
+  exec "$bats_exec_suite" "${flags[@]}" "${filenames[@]}" |
     bats_tee "${BATS_REPORT_OUTPUT_DIR}/${BATS_REPORT_FILENAME}" "$interpolated_report_formatter" "${report_formatter_flags[@]}" |
     bats_test_count_validator |
     "$interpolated_formatter" "${formatter_flags[@]}"
 else
-  exec bats-exec-suite "${flags[@]}" "${filenames[@]}" |
+  exec "$bats_exec_suite" "${flags[@]}" "${filenames[@]}" |
     bats_test_count_validator |
     "$interpolated_formatter" "${formatter_flags[@]}"
 fi

--- a/libexec/bats-core/bats-exec-file
+++ b/libexec/bats-core/bats-exec-file
@@ -233,7 +233,7 @@ bats_run_test_with_retries() { # <args>
   local status=0
   local should_try_again=1 try_number
   for ((try_number = 1; should_try_again; ++try_number)); do
-    if "$BATS_LIBEXEC/bats-exec-test" "$@" "$try_number"; then
+    if bats_execute_internal bats-exec-test "$@" "$try_number"; then
       should_try_again=0
     else
       status=$?

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -17,6 +17,11 @@ BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
 BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS=
 BATS_EMPTY_SUITE_STATUS=1
 
+if [[ -z ${BATS_LIBEXEC:-} ]]; then
+  BATS_LIBEXEC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  export BATS_LIBEXEC
+fi
+
 abort() {
   printf 'Error: %s\n' "$1" >&2
   exit 1
@@ -143,7 +148,7 @@ fi
 # create file even if no tests are found so the `read` below won't fail
 touch "$TESTS_LIST_FILE"
 
-gather_tests_output=$(TESTS_LIST_FILE="$TESTS_LIST_FILE" filter="$filter" nfilter="$nfilter" filter_status="$filter_status" bats-gather-tests "${gather_tests_flags[@]}" -- "$@")
+gather_tests_output=$(TESTS_LIST_FILE="$TESTS_LIST_FILE" filter="$filter" nfilter="$nfilter" filter_status="$filter_status" bats_execute_internal bats-gather-tests "${gather_tests_flags[@]}" -- "$@")
 test_count=$(grep -c ^ "$TESTS_LIST_FILE" || true) # don't fail here when there are no tests
 if [[ $gather_tests_output == focus_mode ]]; then
   focus_mode=1
@@ -313,6 +318,8 @@ fi
 
 if [[ "$num_jobs" -gt 1 ]] && [[ -z "$bats_no_parallelize_across_files" ]]; then
   parallel_flags=(--keep-order --jobs "$num_jobs")
+  bats_exec_file=
+  bats_internal_path bats_exec_file bats-exec-file
   if (( BATS_ABORT_ON_FAILURE )); then
     parallel_flags+=('--halt' 'now,fail=1')
   fi
@@ -320,7 +327,7 @@ if [[ "$num_jobs" -gt 1 ]] && [[ -z "$bats_no_parallelize_across_files" ]]; then
   # shellcheck disable=SC2086,SC2068
   # we need to handle the quoting of ${flags[@]} ourselves,
   # because parallel can only quote it as one
-  "${parallel_binary_name}" "${parallel_flags[@]}" -- "bats-exec-file" "$(printf "%q " "${flags[@]}")" "{#}" "{}" "$TESTS_LIST_FILE" <<< "$(printf "%s\n" "${BATS_UNIQUE_TEST_FILENAMES[@]}")" 2>&1 || bats_exec_suite_status=1
+  "${parallel_binary_name}" "${parallel_flags[@]}" -- "$(printf "%q" "$bats_exec_file")" "$(printf "%q " "${flags[@]}")" "{#}" "{}" "$TESTS_LIST_FILE" <<< "$(printf "%s\n" "${BATS_UNIQUE_TEST_FILENAMES[@]}")" 2>&1 || bats_exec_suite_status=1
 else
   file_index=0
   for filename in "${BATS_UNIQUE_TEST_FILENAMES[@]}"; do
@@ -329,7 +336,7 @@ else
       bats_exec_suite_status=130 # bash's code for SIGINT exits
       break
     fi
-    bats-exec-file "${flags[@]}" "$file_index" "$filename" "${TESTS_LIST_FILE}" || bats_exec_suite_status=1
+    bats_execute_internal bats-exec-file "${flags[@]}" "$file_index" "$filename" "${TESTS_LIST_FILE}" || bats_exec_suite_status=1
     if (( BATS_ABORT_ON_FAILURE && bats_exec_suite_status > 0 )); then
       break
     fi

--- a/test/common.bats
+++ b/test/common.bats
@@ -1,3 +1,20 @@
+@test "bats_execute_internal resolves tools independently of PATH" {
+  bats_require_minimum_version 1.5.0
+  local libexec="$BATS_TEST_TMPDIR/libexec with spaces"
+  local path_bin="$BATS_TEST_TMPDIR/path-bin"
+  mkdir -p "$libexec" "$path_bin"
+
+  # shellcheck disable=SC2016 # generated script variables expand when the fixture runs
+  printf '%s\n' '#!/bin/sh' 'printf "internal:%s\n" "$1"' >"$libexec/bats-fake"
+  # shellcheck disable=SC2016 # generated script variables expand when the fixture runs
+  printf '%s\n' '#!/bin/sh' 'printf "path:%s\n" "$1"' >"$path_bin/bats-fake"
+  chmod +x "$libexec/bats-fake" "$path_bin/bats-fake"
+
+  BATS_LIBEXEC="$libexec" PATH="$path_bin:/usr/bin:/bin" \
+    run -0 bats_execute_internal bats-fake "argument with spaces"
+  [ "$output" = "internal:argument with spaces" ]
+}
+
 @test bats_version_lt {
   bats_require_minimum_version 1.5.0
   run ! bats_version_lt 1.0.0 1.0

--- a/test/fixtures/suite_setup_teardown/path_mutation/setup_suite.bash
+++ b/test/fixtures/suite_setup_teardown/path_mutation/setup_suite.bash
@@ -1,0 +1,3 @@
+setup_suite() {
+  export PATH="${PATH_MUTATION_VALUE:-/usr/bin:/bin}"
+}

--- a/test/fixtures/suite_setup_teardown/path_mutation/test.bats
+++ b/test/fixtures/suite_setup_teardown/path_mutation/test.bats
@@ -1,0 +1,5 @@
+#!/usr/bin/env bats
+
+@test "passing" {
+  :
+}

--- a/test/formatter.bats
+++ b/test/formatter.bats
@@ -136,6 +136,19 @@ EOF
   [ "$output" = "Dummy Formatter!" ]
 }
 
+@test "BATS_FORMATTER finds custom formatters on PATH" {
+  bats_require_minimum_version 1.5.0
+  local formatter_dir="$BATS_TEST_TMPDIR/custom-formatters"
+  mkdir -p "$formatter_dir"
+  ln -s "$FIXTURE_ROOT/dummy-formatter" "$formatter_dir/bats-format-custom"
+
+  reentrant_run -0 -- env \
+    BATS_FORMATTER=custom \
+    PATH="$formatter_dir:$PATH" \
+    bats "$FIXTURE_ROOT/passing.bats"
+  [ "$output" = "Dummy Formatter!" ]
+}
+
 @test "specifying nonexistent external formatter is an error" {
   bats_require_minimum_version 1.5.0
   reentrant_run -1 bats "$FIXTURE_ROOT/passing.bats" --formatter "$FIXTURE_ROOT/non-existing-file"

--- a/test/suite_setup_teardown.bats
+++ b/test/suite_setup_teardown.bats
@@ -64,6 +64,50 @@ setup() {
   EXPECTED_VALUE=exported_var reentrant_run -0 bats "$FIXTURE_ROOT/exported_vars/"
 }
 
+@test "PATH mutations in setup_suite do not break Bats internals" {
+  reentrant_run -0 bats "$FIXTURE_ROOT/path_mutation/"
+  [ "${lines[0]}" = "1..1" ]
+  [ "${lines[1]}" = "ok 1 passing" ]
+  [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "parallel PATH mutations in setup_suite do not break Bats internals" {
+  local parallel_binary="${BATS_PARALLEL_BINARY_NAME:-parallel}"
+  local parallel_path
+  parallel_path="$(type -p "$parallel_binary")" || skip "--jobs requires $parallel_binary"
+
+  emulate_bats_env
+  local libexec_with_spaces="$BATS_TEST_TMPDIR/libexec with spaces"
+  mkdir -p "$libexec_with_spaces"
+  # Exercise GNU parallel command-template quoting for BATS_LIBEXEC paths with spaces.
+  for helper in "$BATS_ROOT"/libexec/bats-core/bats-*; do
+    ln -s "$helper" "$libexec_with_spaces/${helper##*/}"
+  done
+
+  local exec_file_marker="$BATS_TEST_TMPDIR/parallel-exec-file-ran"
+  export EXEC_FILE_MARKER="$exec_file_marker"
+  export REAL_EXEC_FILE="$BATS_ROOT/libexec/bats-core/bats-exec-file"
+  rm "$libexec_with_spaces/bats-exec-file"
+  # shellcheck disable=SC2016 # generated script variables expand when the wrapper runs
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "bats-exec-file\n" >>"$EXEC_FILE_MARKER"' \
+    'exec "$REAL_EXEC_FILE" "$@"' >"$libexec_with_spaces/bats-exec-file"
+  chmod +x "$libexec_with_spaces/bats-exec-file"
+
+  REENTRANT_RUN_PRESERVE+=(BATS_LIBEXEC)
+  BATS_LIBEXEC="$libexec_with_spaces" \
+    PATH_MUTATION_VALUE="$(dirname "$parallel_path"):/usr/bin:/bin" \
+    reentrant_run -0 bats-exec-suite -j 2 \
+      --setup-suite-file "$FIXTURE_ROOT/path_mutation/setup_suite.bash" \
+      "$FIXTURE_ROOT/path_mutation/test.bats"
+
+  [ "${lines[0]}" = "1..1" ]
+  [ "${lines[1]}" = "ok 1 passing" ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "$(wc -l <"$exec_file_marker")" -eq 1 ]
+}
+
 @test "syntax errors in setup_suite.bash are reported and lead to non zero exit code" {
   LANG=C reentrant_run ! bats --setup-suite-file "$FIXTURE_ROOT/syntax_error/setup_suite_no_shellcheck" "$FIXTURE_ROOT/syntax_error/"
   [[ "${lines[1]}" == "$FIXTURE_ROOT/syntax_error/setup_suite_no_shellcheck: line 2: syntax error: unexpected end of file"* ]]


### PR DESCRIPTION
## Summary

Fix `bats-exec-suite` so `setup_suite` can mutate `PATH` without breaking Bats' own internal helper lookup.

`setup_suite` runs in the suite process before `bats-exec-suite` invokes `bats-exec-file`. If `setup_suite` replaces `PATH`, for example by evaluating a tool-version manager environment, the unqualified internal command can disappear and the run fails before executing any tests.

## Maintainer-requested revision

This revision centralizes internal executable lookup through `bats_internal_path` and `bats_execute_internal`, based on `BATS_LIBEXEC` rather than `PATH`.

It routes the built-in formatter, suite, gather-tests, exec-file, exec-test, and preprocess paths through that boundary. Direct `bats-exec-suite` invocation derives `BATS_LIBEXEC` from its own location. GNU Parallel still receives a shell-quoted absolute `bats-exec-file` path, including when the libexec path contains spaces. Absolute external formatter paths keep their existing behavior.

## Reproducer

With Bats 1.13.0:

```bash
cat > setup_suite.bash <<'EOF'
setup_suite() {
  export PATH=/usr/bin:/bin
}
EOF

cat > sample.bats <<'EOF'
#!/usr/bin/env bats
@test "one" {
  [ 1 -eq 1 ]
}
EOF

bin/bats sample.bats
```

Before this change, that fails with:

```text
bats-exec-suite: line 323: bats-exec-file: command not found
# bats warning: Executed 0 instead of expected 1 tests
```

## Validation

- all 488 current test cases passed locally across bounded suite shards
- focused Bash 3.2 run passed 31/31, including serial and parallel `setup_suite` PATH mutation
- `./shellcheck.sh` passed with ShellCheck 0.11.0
- `git diff --check` passed
- upstream `Tests` run `30710912970` is waiting for maintainer approval (`action_required`)
