### PR TITLE
feat: exit 1 on empty suite

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = .git,*.pdf,*.svg
+skip = .git,*.pdf,*.svg,./man/bats.1,./man/bats.7
 ignore-words-list = dne

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * junit formatter:
   * avoid interference between env and internals (#1175)
   * remove control characters (\x00-\x08\x0B\x0C\x0E-\x1F) (#1176)
-  * don't report (skipped) last test as failed when `teardown_suite` generates FD3 output (#1181s)
+  * don't report (skipped) last test as failed when `teardown_suite` generates FD3 output (#1181)
   * fix(junit-formatter): skipped tests outputs reported as <system-err> (#1177)
 * fix failures with `--gather-test-outputs-in` when tests change directory (#1183)
 * `run` now honors `set -e` in your functions (#1118)
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 ### Changed
 
 * update the default version of the `bash` Docker image to 5.3 in `devcontainer` (#1184)
+* exit with error when no tests are found. Use `--allow-empty-suite` to revert to old behavior. (#1211)
 
 ### Documentation
 
@@ -58,7 +59,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 * renamed `docker-compose.yml` to `compose.yaml` (#1128)
 * `bats_test_function`: don't require `--tags` to be sorted (#1158)
 * fix `BATS_TEST_TIMEOUT` (#1160)
-  * not stopping processes under `run` 
+  * not stopping processes under `run`
   * prolonging skipped tests
 
 ### Documentation
@@ -671,4 +672,3 @@ Changes:
 [0.3.0]: https://github.com/bats-core/bats-core/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/bats-core/bats-core/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/bats-core/bats-core/commits/v0.1.0
-

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -23,7 +23,6 @@ abort() {
 
 usage() {
   local cmd="${0##*/}"
-  local line
 
   cat <<HELP_TEXT_HEADER
 Usage: ${cmd} [OPTIONS] <tests>
@@ -36,6 +35,7 @@ HELP_TEXT_HEADER
   containing Bats test files (ending with ".bats")
 
   --abort                   Stop execution of suite on first failed test
+  --allow-empty-suite       Exit with code 0 (instead of the default code 1) when no tests are found.
   -c, --count               Count test cases without running any tests
   --code-quote-style <style>
                             A two character string of code quote delimiters
@@ -185,6 +185,9 @@ while [[ "$#" -ne 0 ]]; do
     ;;
   -c | --count)
     flags+=('-c')
+    ;;
+  --allow-empty-suite)
+    flags+=(--allow-empty-suite)
     ;;
   -f | --filter)
     shift

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -15,6 +15,7 @@ flags=('--dummy-flag') # add a dummy flag to prevent unset variable errors on em
 setup_suite_file=''
 BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
 BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS=
+BATS_EMPTY_SUITE_STATUS=1
 
 abort() {
   printf 'Error: %s\n' "$1" >&2
@@ -94,6 +95,9 @@ while [[ "$#" -ne 0 ]]; do
   --setup-suite-file)
     shift
     setup_suite_file="$1"
+    ;;
+  --allow-empty-suite)
+    BATS_EMPTY_SUITE_STATUS=0
     ;;
   *)
     break
@@ -186,7 +190,10 @@ printf '1..%d\n' "${test_count}"
 
 # No point on continuing if there's no tests.
 if [[ "${test_count}" == 0 ]]; then
-  bats_exec_suite_status=0
+  bats_exec_suite_status=$BATS_EMPTY_SUITE_STATUS
+  if (( bats_exec_suite_status != 0)); then
+    printf "ERROR: Found no tests. (Try \`--allow-empty-suite\`?)" >&2
+  fi
   bats_exit_suite
 fi
 
@@ -247,7 +254,7 @@ bats_run_teardown_suite() {
   # avoid being called twice, in case this is not called through bats_teardown_suite_trap
   # but from the end of file
   trap bats_suite_exit_trap EXIT
-  
+
   bats_set_stacktrace_limit
 
   BATS_TEARDOWN_SUITE_COMPLETED=
@@ -255,6 +262,7 @@ bats_run_teardown_suite() {
   if ((bats_teardown_suite_status == 0)); then
     BATS_TEARDOWN_SUITE_COMPLETED=1
   elif [[ -n "${BATS_SETUP_SUITE_COMPLETED:-}" ]]; then
+    # shellcheck disable=SC2034
     BATS_DEBUG_LAST_STACK_TRACE_IS_VALID=1
     BATS_ERROR_STATUS=$bats_teardown_suite_status
     return $BATS_ERROR_STATUS

--- a/man/bats.1
+++ b/man/bats.1
@@ -1,6 +1,6 @@
-.\" generated with Ronn-NG/v0.9.1
-.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "BATS" "1" "November 2022" "bats-core" "Bash Automated Testing System"
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "BATS" "1" "July 2026" "bats-core" "Bash Automated Testing System"
 .SH "NAME"
 \fBbats\fR \- Bash Automated Testing System
 .SH "SYNOPSIS"
@@ -12,26 +12,26 @@ Bats is a TAP\-compliant testing framework for Bash\. It provides a simple way t
 .P
 A Bats test file is a Bash script with special syntax for defining test cases\. Under the hood, each test case is just a function with a description\.
 .P
-Test cases consist of standard shell commands\. Bats makes use of Bash\'s \fBerrexit\fR (\fBset \-e\fR) option when running test cases\. If every command in the test case exits with a \fB0\fR status code (success), the test passes\. In this way, each line is an assertion of truth\.
+Test cases consist of standard shell commands\. Bats makes use of Bash's \fBerrexit\fR (\fBset \-e\fR) option when running test cases\. If every command in the test case exits with a \fB0\fR status code (success), the test passes\. In this way, each line is an assertion of truth\.
 .P
 See \fBbats\fR(7) for more information on writing Bats tests\.
 .SH "RUNNING TESTS"
-To run your tests, invoke the \fBbats\fR interpreter with a path to a test file\. The file\'s test cases are run sequentially and in isolation\. If all the test cases pass, \fBbats\fR exits with a \fB0\fR status code\. If there are any failures, \fBbats\fR exits with a \fB1\fR status code\.
+To run your tests, invoke the \fBbats\fR interpreter with a path to a test file\. The file's test cases are run sequentially and in isolation\. If all the test cases pass, \fBbats\fR exits with a \fB0\fR status code\. If there are any failures, \fBbats\fR exits with a \fB1\fR status code\.
 .P
 You can invoke the \fBbats\fR interpreter with multiple test file arguments, or with a path to a directory containing multiple \fB\.bats\fR files\. Bats will run each test file individually and aggregate the results\. If any test case fails, \fBbats\fR exits with a \fB1\fR status code\.
 .SH "FILTERING TESTS"
 There are multiple mechanisms to filter which tests to execute:
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB\-\-filter <regex>\fR to filter by test name
-.IP "\[ci]" 4
-\fB\-\-filter\-status <status>\fR to filter by the test\'s status in the last run
-.IP "\[ci]" 4
+.IP "\(bu" 4
+\fB\-\-filter\-status <status>\fR to filter by the test's status in the last run
+.IP "\(bu" 4
 \fB\-\-filter\-tags <tag\-list>\fR to filter by the tags of a test
 .IP "" 0
 .SH "\-\-FILTER\-TAGS <var>TAG\-LIST</var>"
 Tags can be used for finegrained filtering of which tests to run via \fB\-\-filter\-tags\fR\. This accepts a comma separated list of tags\. Only tests that match all of these tags will be executed\. For example, \fBbats \-\-filter\-tags a,b,c\fR will pick up tests with tags \fBa,b,c\fR, but not tests that miss one or more of those tags\.
 .P
-Additionally, you can specify negative tags via \fBbats \-\-filter\-tags a,!b,c\fR, which now won\'t match tests with tags \fBa,b,c\fR, due to the \fBb\fR, but will select \fBa,c\fR\. To put it more formally, \fB\-\-filter\-tags\fR is a boolean conjunction\.
+Additionally, you can specify negative tags via \fBbats \-\-filter\-tags a,!b,c\fR, which now won't match tests with tags \fBa,b,c\fR, due to the \fBb\fR, but will select \fBa,c\fR\. To put it more formally, \fB\-\-filter\-tags\fR is a boolean conjunction\.
 .P
 To allow for more complex queries, you can specify multiple \fB\-\-filter\-tags\fR\. A test will be executed, if it matches at least one of them\. This means multiple \fB\-\-filter\-tags\fR form a boolean disjunction\.
 .P
@@ -39,77 +39,77 @@ A query of \fB\-\-filter\-tags a,!b \-\-filter\-tags b,c\fR can be translated to
 .P
 An empty tag list matches tests without tags\.
 .SH "OPTIONS"
-.TP
-\fB\-c\fR, \fB\-\-count\fR
-Count the number of test cases without running any tests
-.TP
-\fB\-\-code\-quote\-style <style>\fR
-A two character string of code quote delimiters or \fBcustom\fR which requires setting \fB$BATS_BEGIN_CODE_QUOTE\fR and \fB$BATS_END_CODE_QUOTE\fR\. Can also be set via \fB$BATS_CODE_QUOTE_STYLE\fR\.
-.TP
-\fB\-f\fR, \fB\-\-filter <regex>\fR
-Filter test cases by names matching the regular expression
-.TP
-\fB\-F\fR, \fB\-\-formatter <type>\fR
-Switch between formatters: pretty (default), tap (default w/o term), tap13, junit, \fB/<absolute path to formatter>\fR
-.TP
-\fB\-\-filter\-status <status>\fR
-Only run tests with the given status in the last completed (no CTRL+C/SIGINT) run\. Valid \fIstatus\fR values are: failed \- runs tests that failed or were not present in the last run missed \- runs tests that were not present in the last run
-.TP
-\fB\-\-filter\-tags <comma\-separated\-tag\-list>\fR
-Only run tests that match all the tags in the list (\fB&&\fR)\. You can negate a tag via prepending \fB!\fR\. Specifying this flag multiple times allows for logical or (\fB||\fR): \fB\-\-filter\-tags A,B \-\-filter\-tags A,!C\fR matches tags \fB(A && B) || (A && !C)\fR
-.TP
-\fB\-\-gather\-test\-outputs\-in <directory>\fR
-Gather the output of failing \fIand\fR passing tests as files in directory
-.TP
-\fB\-h\fR, \fB\-\-help\fR
-Display this help message
-.TP
-\fB\-j\fR, \fB\-\-jobs <jobs>\fR
-Number of parallel jobs (requires GNU parallel)
-.TP
-\fB\-\-no\-tempdir\-cleanup\fR
-Preserve test output temporary directory
-.TP
-\fB\-\-no\-parallelize\-across\-files\fR
-Serialize test file execution instead of running them in parallel (requires \-\-jobs >1)
-.TP
-\fB\-\-no\-parallelize\-within\-files\fR
-Serialize test execution within files instead of running them in parallel (requires \-\-jobs >1)
-.TP
-\fB\-\-report\-formatter <type>\fR
-Switch between reporters (same options as \-\-formatter)
-.TP
-\fB\-o\fR, \fB\-\-output <dir>\fR
-Directory to write report files
-.TP
-\fB\-p\fR, \fB\-\-pretty\fR
-Shorthand for "\-\-formatter pretty"
-.TP
-\fB\-\-print\-output\-on\-failure\fR
-Automatically print the value of \fB$output\fR on failed tests
-.TP
-\fB\-r\fR, \fB\-\-recursive\fR
-Include tests in subdirectories
-.TP
-\fB\-\-show\-output\-of\-passing\-tests\fR
-Print output of passing tests
-.TP
-\fB\-t\fR, \fB\-\-tap\fR
-Shorthand for "\-\-formatter tap"
-.TP
-\fB\-T\fR, \fB\-\-timing\fR
-Add timing information to tests
-.TP
-\fB\-x\fR, \fB\-\-trace\fR
-Print test commands as they are executed (like \fBset \-x\fR)
-.TP
-\fB\-\-verbose\-run\fR
-Make \fBrun\fR print \fB$output\fR by default
-.TP
-\fB\-v\fR, \fB\-\-version\fR
-Display the version number
+.IP "\(bu" 4
+\fB\-\-abort\fR: Stop execution of suite on first failed test
+.IP "\(bu" 4
+\fB\-\-allow\-empty\-suite\fR: Exit with code 0 (instead of the default code 1) when no tests are found\.
+.IP "\(bu" 4
+\fB\-c\fR, \fB\-\-count\fR: Count the number of test cases without running any tests
+.IP "\(bu" 4
+\fB\-\-code\-quote\-style <style>\fR: A two character string of code quote delimiters or \fBcustom\fR which requires setting \fB$BATS_BEGIN_CODE_QUOTE\fR and \fB$BATS_END_CODE_QUOTE\fR\. Can also be set via \fB$BATS_CODE_QUOTE_STYLE\fR\.
+.IP "\(bu" 4
+\fB\-\-line\-reference\-format\fR Controls how file/line references e\.g\. in stack traces are printed:
+.IP "\(bu" 4
+comma_line (default): a\.bats, line 1
+.IP "\(bu" 4
+colon: a\.bats:1
+.IP "\(bu" 4
+uri: file:///tests/a\.bats:1
+.IP "\(bu" 4
+custom: provide your own via defining bats_format_file_line_reference_custom with parameters \fIfilename\fR \fIline\fR, store via \fBprintf \-v "$output"\fR
+.IP "" 0
+
+.IP "\(bu" 4
+\fB\-\-errexit\fR: Enable errexit (\fBset \-e\fR) for commands run in \fBrun\fR
+.IP "\(bu" 4
+\fB\-f\fR, \fB\-\-filter <regex>\fR: Filter test cases by names matching the regular expression
+.IP "\(bu" 4
+\fB\-F\fR, \fB\-\-formatter <type>\fR: Switch between formatters: pretty (default), tap (default w/o term), tap13, junit, \fB/<absolute path to formatter>\fR
+.IP "\(bu" 4
+\fB\-\-filter\-status <status>\fR: Only run tests with the given status in the last completed (no CTRL+C/SIGINT) run\. Valid \fIstatus\fR values are: failed \- runs tests that failed or were not present in the last run missed \- runs tests that were not present in the last run
+.IP "\(bu" 4
+\fB\-\-filter\-tags <comma\-separated\-tag\-list>\fR: Only run tests that match all the tags in the list (\fB&&\fR)\. You can negate a tag via prepending \fB!\fR\. Specifying this flag multiple times allows for logical or (\fB||\fR): \fB\-\-filter\-tags A,B \-\-filter\-tags A,!C\fR matches tags \fB(A && B) || (A && !C)\fR
+.IP "\(bu" 4
+\fB\-\-gather\-test\-outputs\-in <directory>\fR: Gather the output of failing \fIand\fR passing tests as files in directory
+.IP "\(bu" 4
+\fB\-h\fR, \fB\-\-help\fR: Display this help message
+.IP "\(bu" 4
+\fB\-j\fR, \fB\-\-jobs <jobs>\fR: Number of parallel jobs (requires GNU parallel)
+.IP "\(bu" 4
+\fB\-\-negative\-filter <regex>\fR: Only run tests that do not match the regular expression
+.IP "\(bu" 4
+\fB\-\-no\-tempdir\-cleanup\fR: Preserve test output temporary directory
+.IP "\(bu" 4
+\fB\-\-no\-parallelize\-across\-files\fR: Serialize test file execution instead of running them in parallel (requires \-\-jobs >1)
+.IP "\(bu" 4
+\fB\-\-no\-parallelize\-within\-files\fR: Serialize test execution within files instead of running them in parallel (requires \-\-jobs >1)
+.IP "\(bu" 4
+\fB\-\-parallel\-binary\-name <name>\fR: Name of parallel binary
+.IP "\(bu" 4
+\fB\-\-report\-formatter <type>\fR: Switch between reporters (same options as \-\-formatter)
+.IP "\(bu" 4
+\fB\-o\fR, \fB\-\-output <dir>\fR: Directory to write report files
+.IP "\(bu" 4
+\fB\-p\fR, \fB\-\-pretty\fR: Shorthand for "\-\-formatter pretty"
+.IP "\(bu" 4
+\fB\-\-print\-output\-on\-failure\fR: Automatically print the value of \fB$output\fR on failed tests
+.IP "\(bu" 4
+\fB\-r\fR, \fB\-\-recursive\fR: Include tests in subdirectories
+.IP "\(bu" 4
+\fB\-\-show\-output\-of\-passing\-tests\fR: Print output of passing tests
+.IP "\(bu" 4
+\fB\-t\fR, \fB\-\-tap\fR: Shorthand for "\-\-formatter tap"
+.IP "\(bu" 4
+\fB\-T\fR, \fB\-\-timing\fR: Add timing information to tests
+.IP "\(bu" 4
+\fB\-x\fR, \fB\-\-trace\fR: Print test commands as they are executed (like \fBset \-x\fR)
+.IP "\(bu" 4
+\fB\-\-verbose\-run\fR: Make \fBrun\fR print \fB$output\fR by default
+.IP "\(bu" 4
+\fB\-v\fR, \fB\-\-version\fR: Display the version number
+.IP "" 0
 .SH "OUTPUT"
-When you run Bats from a terminal, you\'ll see output as each test is performed, with a check\-mark next to the test\'s name if it passes or an "X" if it fails\.
+When you run Bats from a terminal, you'll see output as each test is performed, with a check\-mark next to the test's name if it passes or an "X" if it fails\.
 .IP "" 4
 .nf
 $ bats addition\.bats

--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -78,12 +78,14 @@ OPTIONS
 
   * `--abort`:
     Stop execution of suite on first failed test
+  * `--allow-empty-suite`:
+    Exit with code 0 (instead of the default code 1) when no tests are found.
   * `-c`, `--count`:
     Count the number of test cases without running any tests
   * `--code-quote-style <style>`:
     A two character string of code quote delimiters or `custom`
-    which requires setting `$BATS_BEGIN_CODE_QUOTE` and 
-    `$BATS_END_CODE_QUOTE`. 
+    which requires setting `$BATS_BEGIN_CODE_QUOTE` and
+    `$BATS_END_CODE_QUOTE`.
     Can also be set via `$BATS_CODE_QUOTE_STYLE`.
   * `--line-reference-format`
     Controls how file/line references e.g. in stack traces are printed:
@@ -105,7 +107,7 @@ OPTIONS
       failed - runs tests that failed or were not present in the last run
       missed - runs tests that were not present in the last run
   * `--filter-tags <comma-separated-tag-list>`:
-    Only run tests that match all the tags in the list (`&&`). You can negate a 
+    Only run tests that match all the tags in the list (`&&`). You can negate a
     tag via prepending `!`.
     Specifying this flag multiple times allows for logical or (`||`):
     `--filter-tags A,B --filter-tags A,!C` matches tags `(A && B) || (A && !C)`
@@ -195,6 +197,3 @@ COPYRIGHT
 (c) 2011-2016 Sam Stephenson
 
 Bats is released under the terms of an MIT-style license.
-
-
-

--- a/man/bats.7
+++ b/man/bats.7
@@ -1,6 +1,6 @@
-.\" generated with Ronn-NG/v0.9.1
-.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "BATS" "7" "November 2022" "bats-core" "Bash Automated Testing System"
+.\" generated with Ronn-NG/v0.10.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.10.1
+.TH "BATS" "7" "July 2026" "bats-core" "Bash Automated Testing System"
 .SH "NAME"
 \fBbats\fR \- Bats test file format
 .SH "DESCRIPTION"
@@ -57,23 +57,25 @@ Tags are case sensitive and must only consist of alphanumeric characters and \fB
 .P
 Tag lists must be separated by commas and are allowed to contain whitespace\. They must not contain empty tags like \fBtest_tags=,b\fR (first tag is empty), \fBtest_tags=a,,c\fR, \fBtest_tags=a, ,c\fR (second tag is only whitespace/empty), \fBtest_tags=a,b,\fR (third tag is empty)\.
 .P
-Every tag starting with \fBbats:\fR (case insensitive!) is reserved for Bats\' internal use:
+Every tag starting with \fBbats:\fR (case insensitive!) is reserved for Bats' internal use:
 .TP
 \fBbats:focus\fR
-If any test with the tag \fBbats:focus\fR is encountered in a test suite, only those tagged with this tag will be executed\. To prevent the CI from silently running on a subset of tests due to an accidentally committed \fBbats:focus\fR tag, the exit code of successful runs will be overridden to 1\.
+If any test with the tag \fBbats:focus\fR is encountered in a test suite, only those tagged with this tag will be executed\.
 .IP
-Should you require the true exit code, e\.g\. for a \fBgit bisect\fR operation, you can disable this behavior by setting \fBBATS_NO_FAIL_FOCUS_RUN=1\fR when running \fBbats\fR, but make sure to not commit this to CI!
+In focus mode, the exit code of successful runs will be overridden to 1 to prevent CI from silently running on a subset of tests due to an accidentally committed \fBbats:focus\fR tag\.
+.br
+Should you require the true exit code, e\.g\. for a \fBgit bisect\fR operation, you can disable this behavior by setting \fBBATS_NO_FAIL_FOCUS_RUN=1\fR when running \fBbats\fR, but make sure not to commit this to CI!
 .SH "THE RUN HELPER"
 Usage: run [OPTIONS] [\-\-]
 .P
 Many Bats tests need to run a command and then make assertions about its exit status and output\. Bats includes a \fBrun\fR helper that invokes its arguments as a command, saves the exit status and output into special global variables, and (optionally) checks exit status against a given expected value\. If successful, \fBrun\fR returns with a \fB0\fR status code so you can continue to make assertions in your test case\.
 .P
-For example, let\'s say you\'re testing that the \fBfoo\fR command, when passed a nonexistent filename, exits with a \fB1\fR status code and prints an error message\.
+For example, let's say you're testing that the \fBfoo\fR command, when passed a nonexistent filename, exits with a \fB1\fR status code and prints an error message\.
 .IP "" 4
 .nf
 @test "invoking foo with a nonexistent file prints an error" {
   run \-1 foo nonexistent_filename
-  [ "$output" = "foo: no such file \'nonexistent_filename\'" ]
+  [ "$output" = "foo: no such file 'nonexistent_filename'" ]
 }
 .fi
 .IP "" 0
@@ -82,13 +84,13 @@ The \fB\-1\fR as first argument tells \fBrun\fR to expect 1 as an exit status, a
 .IP "" 4
 .nf
 (in test file test\.bats, line 2)
- `run \-1 foo nonexistent_filename\' failed, expected exit code 1, got 127
+ `run \-1 foo nonexistent_filename' failed, expected exit code 1, got 127
 .fi
 .IP "" 0
 .P
 This error indicates a possible problem with the installation or configuration of \fBfoo\fR; note that a simple \fB[ $status != 0 ]\fR test would not have caught this kind of failure\.
 .P
-The \fB$status\fR variable contains the status code of the command, and the \fB$output\fR variable contains the combined contents of the command\'s standard output and standard error streams\.
+The \fB$status\fR variable contains the status code of the command, and the \fB$output\fR variable contains the combined contents of the command's standard output and standard error streams\.
 .P
 A third special variable, the \fB$lines\fR array, is available for easily accessing individual lines of output\. For example, if you want to test that invoking \fBfoo\fR without any arguments prints usage information on the first line:
 .IP "" 4
@@ -105,6 +107,63 @@ By default \fBrun\fR leaves out empty lines in \fB${lines[@]}\fR\. Use \fBrun \-
 Additionally, you can use \fB\-\-separate\-stderr\fR to split stdout and stderr into \fB$output\fR/\fB$stderr\fR and \fB${lines[@]}\fR/\fB${stderr_lines[@]}\fR\.
 .P
 All additional parameters to run should come before the command\. If you want to run a command that starts with \fB\-\fR, prefix it with \fB\-\-\fR to prevent \fBrun\fR from parsing it as an option\.
+.SH "THE BATS_PIPE HELPER"
+Usage: bats_pipe [OPTIONS] [\-\-]
+.P
+The bats_pipe helper command is meant to handle piping between commands\. Its main purpose is to aide the \fBrun\fR helper command (which cannot handle pipes, due to bash parsing priority)\. \fBrun command0 | command1\fR will parse \fB|\fR before \fBrun\fR, which is commonly not intended by test authors\.
+.P
+Running \fBrun bats_pipe command0 \e| command1\fR will have the piped commands run within the context of the \fBrun\fR command, and thus have the output and status variables properly contained within the normal \fBoutput\fR and \fBstatus\fR variables\.
+.P
+Note that this requires the usage of \fB\e|\fR, not \fB|\fR\. This is to avoid bash parsing out \fB|\fR first, instead sending \fB\e|\fR to the bats_pipe command for it to parse and set up intended piping\. Running bats_pipe with no instances of \fB\e|\fR will always fail; this is intended to catch typos (accidentally using \fB|\fR) by the test author\.
+.P
+The bats_pipe command will also properly propagate exit status from the piped commands\. The default behavior mimics \fBset \-o pipefail\fR, returning the status of the last (rightmost) command that exits with a non\-zero status\. This ensures that usage of pipes do not mask the exit statuses of earlier commands\.
+.IP "" 4
+.nf
+@test "invoking foo piped to bar" {
+  run bats_pipe foo \e| bar
+  # asserting foo or bar would return 17 (from foo if bar returns 0)\.
+  [ "$status" \-eq 17 ]
+  [ "$output" = "bar output\." ]
+}
+.fi
+.IP "" 0
+.P
+Alternatively, if the test always cares about the status of a specific command, the \-\fIN\fR option can be given (e\.g\. \-0) to always return the status of the command of interest\.
+.IP "" 4
+.nf
+@test "invoking foo piped to bar always return foo status" {
+  run bats_pipe \-0 foo \e| bar
+  # status of bar is ignored, status is always from foo\.
+  [ "$status" \-eq 2 ]
+  [ "$output" = "bar output\." ]
+}
+.fi
+.IP "" 0
+.P
+Similarly, \-\-returned\-status N (or \-\-returned\-status=N) can be used for similar functionality\. This option supports negative values, which always return the status of the command starting from the end and in reverse order\.
+.IP "" 4
+.nf
+@test "invoking foo piped to bar always return foo status" {
+  run bats_pipe \-\-returned\-status \-2 foo \e| bar
+  # status of bar is ignored, status is always from foo\.
+  [ "$status" \-eq 2 ]
+  [ "$output" = "bar output\." ]
+}
+.fi
+.IP "" 0
+.P
+Piping of command output is especially helpful when the output needs to be modified in some way (e\.g\. the command outputs binary data into stdout, which cannot be stored as\-is in an environment variable)\.
+.IP "" 4
+.nf
+@test "invoking foo that returns binary data" {
+  run bats_pipe foo \e| hexdump \-v \-e "1/1 \e"0x%02X \e""
+  [ "$status" \-eq 17 ]
+  [[ "$output" =~ 0xDE\e 0xAD ]]
+}
+.fi
+.IP "" 0
+.P
+Any number of pipes can be used in conjunction to chain output between some set of running commands\.
 .SH "THE LOAD COMMAND"
 You may want to share common code across multiple test files\. Bats includes a convenient \fBload\fR command for sourcing a Bash source file relative to the location of the current test file\. For example, if you have a Bats test in \fBtest/foo\.bats\fR, the command
 .IP "" 4
@@ -125,26 +184,26 @@ by library name, expecting libraries to have a \fBload\.bash\fR entrypoint
 .IP "" 0
 .P
 For example if your \fBBATS_LIB_PATH\fR is set to \fB~/\.bats/libs:/usr/lib/bats\fR, then \fBbats_load_library test_helper\fR would look for existing files with the following paths:
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB~/\.bats/libs/test_helper\fR
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB~/\.bats/libs/test_helper/load\.bash\fR
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB/usr/lib/bats/test_helper\fR
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB/usr/lib/bats/test_helper/load\.bash\fR
 .IP "" 0
 .P
 The first existing file in this list will be sourced\.
 .P
 If you want to load only part of a library or the entry point is not named \fBload\.bash\fR, you have to include it in the argument: \fBbats_load_library library_name/file_to_load\fR will try
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB~/\.bats/libs/library_name/file_to_load\fR
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB~/\.bats/libs/library_name/file_to_load/load\.bash\fR
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB/usr/lib/bats/library_name/file_to_load\fR
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB/usr/lib/bats/library_name/file_to_load/load\.bash\fR
 .IP "" 0
 .P
@@ -157,7 +216,7 @@ Apart from the changed lookup rules, \fBbats_load_library\fR behaves like \fBloa
 Tests can be skipped by using the \fBskip\fR command at the point in a test you wish to skip\.
 .IP "" 4
 .nf
-@test "A test I don\'t want to execute for now" {
+@test "A test I don't want to execute for now" {
   skip
   run \-0 foo
 }
@@ -167,7 +226,7 @@ Tests can be skipped by using the \fBskip\fR command at the point in a test you 
 Optionally, you may include a reason for skipping:
 .IP "" 4
 .nf
-@test "A test I don\'t want to execute for now" {
+@test "A test I don't want to execute for now" {
   skip "This command will return zero soon, but not now"
   run \-0 foo
 }
@@ -179,7 +238,7 @@ Or you can skip conditionally:
 .nf
 @test "A test which should run" {
   if [ foo != bar ]; then
-    skip "foo isn\'t bar"
+    skip "foo isn't bar"
   fi
 
   run \-0 foo
@@ -191,48 +250,50 @@ Code for newer versions of Bats can be incompatible with older versions\. In the
 .P
 Use \fBbats_require_minimum_version <Bats version number>\fR to avoid this\. It communicates in a concise manner, that you intend the following code to be run under the given Bats version or higher\.
 .P
-Additionally, this function will communicate the current Bats version floor to subsequent code, allowing e\.g\. Bats\' internal warning to give more informed warnings\.
+Additionally, this function will communicate the current Bats version floor to subsequent code, allowing e\.g\. Bats' internal warning to give more informed warnings\.
 .P
 \fBNote\fR: By default, calling \fBbats_require_minimum_version\fR with versions before Bats 1\.7\.0 will fail regardless of the required version as the function is not available\. However, you can use the bats\-backports plugin (https://github\.com/bats\-core/bats\-backports) to make your code usable with older versions, e\.g\. during migration while your CI system is not yet upgraded\.
 .SH "SETUP AND TEARDOWN FUNCTIONS"
-You can define special \fBsetup\fR and \fBteardown\fR functions which run before and after each test case, respectively\. Use these to load fixtures, set up your environment, and clean up when you\'re done\.
+You can define special \fBsetup\fR and \fBteardown\fR functions which run before and after each test case, respectively\. Use these to load fixtures, set up your environment, and clean up when you're done\.
 .SH "CODE OUTSIDE OF TEST CASES"
-You can include code in your test file outside of \fB@test\fR functions\. For example, this may be useful if you want to check for dependencies and fail immediately if they\'re not present\. However, any output that you print in code outside of \fB@test\fR, \fBsetup\fR or \fBteardown\fR functions must be redirected to \fBstderr\fR (\fB>&2\fR)\. Otherwise, the output may cause Bats to fail by polluting the TAP stream on \fBstdout\fR\.
+You can include code in your test file outside of \fB@test\fR functions\. For example, this may be useful if you want to check for dependencies and fail immediately if they're not present\. However, any output that you print in code outside of \fB@test\fR, \fBsetup\fR or \fBteardown\fR functions must be redirected to \fBstderr\fR (\fB>&2\fR)\. Otherwise, the output may cause Bats to fail by polluting the TAP stream on \fBstdout\fR\.
 .SH "SPECIAL VARIABLES"
 There are several global variables you can use to introspect on Bats tests:
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_TEST_FILENAME\fR is the fully expanded path to the Bats test file\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_TEST_DIRNAME\fR is the directory in which the Bats test file is located\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_TEST_NAMES\fR is an array of function names for each test case\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_TEST_NAME\fR is the name of the function containing the current test case\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fBBATS_TEST_NAME_PREFIX\fR will be prepended to the description of each test on stdout and in reports\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_TEST_DESCRIPTION\fR is the description of the current test case\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fBBATS_TEST_RETRIES\fR is the maximum number of additional attempts that will be made on a failed test before it is finally considered failed\. The default of 0 means the test must pass on the first attempt\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fBBATS_TEST_TIMEOUT\fR is the number of seconds after which a test (including setup) will be aborted and marked as failed\. Updates to this value in \fBsetup()\fR or \fB@test\fR cannot change the running timeout countdown, so the latest useful update location is \fBsetup_file()\fR\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_TEST_NUMBER\fR is the (1\-based) index of the current test case in the test file\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_SUITE_TEST_NUMBER\fR is the (1\-based) index of the current test case in the test suite (over all files)\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_TMPDIR\fR is the base temporary directory used by bats to create its temporary files / directories\. (default: \fB$TMPDIR\fR\. If \fB$TMPDIR\fR is not set, \fB/tmp\fR is used\.)
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_RUN_TMPDIR\fR is the location to the temporary directory used by bats to store all its internal temporary files during the tests\. (default: \fB$BATS_TMPDIR/bats\-run\-$BATS_ROOT_PID\-XXXXXX\fR)
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_FILE_EXTENSION\fR (default: \fBbats\fR) specifies the extension of test files that should be found when running a suite (via \fBbats [\-r] suite_folder/\fR)
-.IP "\[ci]" 4
+.IP "\(bu" 4
+\fB$BATS_TEST_TAGS\fR the tags of the current test\.
+.IP "\(bu" 4
 \fB$BATS_SUITE_TMPDIR\fR is a temporary directory common to all tests of a suite\. Could be used to create files required by multiple tests\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_FILE_TMPDIR\fR is a temporary directory common to all tests of a test file\. Could be used to create files required by multiple tests in the same test file\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_TEST_TMPDIR\fR is a temporary directory unique for each test\. Could be used to create files required only for specific tests\.
-.IP "\[ci]" 4
+.IP "\(bu" 4
 \fB$BATS_VERSION\fR is the version of Bats running the test\.
 .IP "" 0
 .SH "SEE ALSO"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -40,10 +40,15 @@ setup() {
   [ "$(expr "$output" : ".*does not exist")" -ne 0 ]
 }
 
-@test "empty test file runs zero tests" {
-  reentrant_run bats "$FIXTURE_ROOT/empty.bats"
-  [ $status -eq 0 ]
-  [ "$output" = "1..0" ]
+@test "empty test file runs zero tests but returns non-zero exit code" {
+  bats_require_minimum_version 1.5.0
+  reentrant_run --separate-stderr -1 bats "$FIXTURE_ROOT/empty.bats"
+
+  [ "${lines[0]}" = "1..0" ]
+  [ "${#lines[@]}" -eq 1 ]
+
+  [ "${stderr_lines[0]}" = "ERROR: Found no tests. (Try \`--allow-empty-suite\`?)" ]
+  [ "${#stderr_lines[@]}" -eq 1 ]
 }
 
 @test "one passing test" {
@@ -1681,7 +1686,12 @@ END_OF_ERR_MSG
 @test "Bats's DEBUG trap should not overwrite \$_ (#1208)" {
   # set $_
   : '<lastarg#1208>'
-  
+
   # shellcheck disable=SC2031 # see https://github.com/koalaman/shellcheck/issues/3478
   [ "$_" == '<lastarg#1208>' ] # check that $_ is preserved
+}
+
+@test "--allow-empty-suite fails when there are tests" {
+  bats_require_minimum_version 1.5.0
+  reentrant_run -0 bats --allow-empty-suite "$FIXTURE_ROOT/passing.bats"
 }

--- a/test/filter.bats
+++ b/test/filter.bats
@@ -94,7 +94,7 @@ setup() {
   # have no failing tests
   reentrant_run -0 bats --filter-status failed "passing.bats"
   # try to run the empty list of failing tests
-  reentrant_run -0 bats --filter-status failed "passing.bats"
+  reentrant_run -0 bats --filter-status failed --allow-empty-suite "passing.bats"
   [ "${lines[0]}" == "There were no tests of status 'failed' in the last recorded run." ]
   [ "${lines[1]}" == "1..0" ]
   [ "${#lines[@]}" -eq 2 ]

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -4,10 +4,12 @@ setup() {
   REENTRANT_RUN_PRESERVE+=(BATS_LIBEXEC)
 }
 
-@test "running a suite with no test files" {
-  reentrant_run bats "$FIXTURE_ROOT/empty"
-  [ $status -eq 0 ]
+@test "Empty suite is an error" {
+  bats_require_minimum_version 1.5.0
+  reentrant_run --separate-stderr -1 bats "$FIXTURE_ROOT/empty"
   [ "$output" = "1..0" ]
+  # shellcheck disable=SC2154
+  [ "$stderr" = "ERROR: Found no tests. (Try \`--allow-empty-suite\`?)" ]
 }
 
 @test "running a suite with one test file" {


### PR DESCRIPTION
so far, an empty suite returned exit code 0. This is problematic as accidentally filtering away all tests can miss "wanted" failures. Therefore, the new default is to fail on an empty suite unless explicitly turned on via --allow-empty-suite.
fixes #1199 
