### PR TITLE
docs: remove outdated claim that suite-wide setup does not exist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 * pretty formatter was not the default on interactive shells anymore (#1220)
 
+### Documentation
+
+* removed the FAQ's outdated claim that suite-wide setup functionality does not exist; it now points to `setup_suite` (#1213)
+
 ## [1.14.0] - 2026-07-21
 
 ### Added

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -102,8 +102,11 @@ Is there a mechanism to add file/test specific functionality to a common setup f
 ----------------------------------------------------------------------------------------
 
 Often the setup consists of parts that are common between different files of a test suite and parts that are specific to each file.
-There is no suite wide setup functionality yet, so you should extract these common setup steps into their own file (e.g. `common-test-setup.sh`) and function (e.g. `commonSetup() {}`),
-which can be `source`d or `load`ed and call it in `setup_file` or `setup`.
+To share the common parts, you should extract these common setup steps into their own file (e.g. `common-test-setup.sh`) and function (e.g. `commonSetup() {}`),
+which can be loaded via `source` or `load` and called in `setup_file` or `setup`.
+
+Note that this is about setup that runs again for each file or test.
+If you instead need setup that runs only once for the entire suite, use `setup_suite` (see `How can I setup/cleanup before/after all tests?`_).
 
 How can I use helper libraries like bats-assert?
 ------------------------------------------------


### PR DESCRIPTION
Addresses the FAQ part of #715.

The answer under *"Is there a mechanism to add file/test specific functionality to a common setup function?"* still said:

> There is no suite wide setup functionality yet

That contradicts the later FAQ entry *"How can I setup/cleanup before/after all tests?"* in the same file, as well as the setup and teardown docs, both of which document `setup_suite`.

The rest of that answer is still correct, though — `setup_suite` runs once for the whole suite, so it doesn't replace the "extract common steps into a loadable helper" advice for setup that has to run again per file or per test. So rather than rewriting the answer, this drops the stale clause and adds a short note pointing at `setup_suite` for the suite-wide case.

### Also included

One wording change in the same sentence: `` `source`d or `load`ed `` → "loaded via `source` or `load`".

This is a rendering fix, not just style. reStructuredText requires an inline-markup end-string to be followed by whitespace or punctuation, so the trailing `d` prevented the markup from closing, and the whole span from `source` through `setup_file` rendered as one mangled reference. Happy to split this into its own PR if you'd prefer to keep the diff to the stale claim alone.

### Scope question

#715 also notes that the tutorial's *"Avoiding costly repeated setups"* and *"Setting up a multifile test suite"* sections don't mention `setup_suite`. I left those alone since the `common-setup` pattern they teach is still valid for per-file setup, and changing them is a judgement call about the tutorial's flow rather than a factual correction. Glad to extend this PR to cover them if you want that.

The second stale spot the issue mentions (*"Currently, this is not supported. Please contribute your usecase to issue #39"*) has already been fixed on master.

### Verification

Built the docs locally with Sphinx: the new cross-reference resolves to an internal anchor, and the reworded sentence now renders as separate references instead of one run-together span. No new build warnings — the two that remain are pre-existing and in `warnings/index.rst` and `writing-tests.md`.

---

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
