### PR TITLE
fix(bats-preprocess): make test-name encoding locale-independent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 ### Fixed
 
 * pretty formatter was not the default on interactive shells anymore (#1220)
+* `bats_encode_test_name()` used the locale-dependent `[[:alnum:]]` character class, causing test names with non-ASCII characters to be silently skipped under some locales (#1236)
 
 ### Documentation
 

--- a/libexec/bats-core/bats-preprocess
+++ b/libexec/bats-core/bats-preprocess
@@ -6,7 +6,7 @@ bats_encode_test_name() {
   local result='test_'
   local hex_code
 
-  if [[ ! "$name" =~ [^[:alnum:]\ _-] ]]; then
+  if [[ ! "$name" =~ [^a-zA-Z0-9\ _-] ]]; then
     name="${name//_/-5f}"
     name="${name//-/-2d}"
     name="${name// /_}"
@@ -19,7 +19,7 @@ bats_encode_test_name() {
       char="${name:$i:1}"
       if [[ "$char" == ' ' ]]; then
         result+='_'
-      elif [[ "$char" =~ [[:alnum:]] ]]; then
+      elif [[ "$char" =~ [a-zA-Z0-9] ]]; then
         result+="$char"
       else
         printf -v 'hex_code' -- '-%02x' \'"$char"

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -529,6 +529,24 @@ END_OF_ERR_MSG
   [[ "${lines[3]}" == "ok 3 test 3" ]]
 }
 
+@test "test names with non-ASCII characters run under a UTF-8 locale (see #1233)" {
+  if ! locale -a 2>/dev/null | grep -qi '^en_US\.utf-\?8$'; then
+    skip "en_US.UTF-8 locale is not available on this system"
+  fi
+
+  # shellcheck disable=SC2030,SC2031
+  REENTRANT_RUN_PRESERVE+=(LC_ALL)
+  LC_ALL=en_US.UTF-8 reentrant_run --separate-stderr bats "$FIXTURE_ROOT/non_ascii_test_names.bats"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "1..6" ]
+  # all 6 tests must actually run (none may be silently skipped/"ghosted"
+  # due to locale-dependent [[:alnum:]] matching in bats_encode_test_name)
+  local ok_count
+  ok_count="$(grep -c '^ok ' <<<"$output")"
+  [ "$ok_count" -eq 6 ]
+  [ -z "$stderr" ]
+}
+
 @test "report correct line on unset variables" {
   LANG=C reentrant_run bats "$FIXTURE_ROOT/unbound_variable.bats"
   [ "$status" -eq 1 ]

--- a/test/fixtures/bats/non_ascii_test_names.bats
+++ b/test/fixtures/bats/non_ascii_test_names.bats
@@ -1,0 +1,23 @@
+@test "pure ascii" {
+  true
+}
+
+@test "あ" {
+  true
+}
+
+@test "中" {
+  true
+}
+
+@test "Кириллица" {
+  true
+}
+
+@test "한국어" {
+  true
+}
+
+@test "café" {
+  true
+}


### PR DESCRIPTION
## Bug

`bats_encode_test_name()` in `libexec/bats-core/bats-preprocess` picks between two
encoding strategies for a test name using a **locale-dependent** regex:

```sh
if [[ ! "$name" =~ [^[:alnum:]\ _-] ]]; then
```

Under `LC_ALL=C` this is false for any non-ASCII name, so the safe hex-encoding
branch runs and the generated shell function name stays pure ASCII.

Under a UTF-8 locale, `[[:alnum:]]` matches CJK, Cyrillic, Hangul, fullwidth and
other multibyte "letters", so the condition flips to true, the "fast" branch runs
instead, and the raw multibyte bytes get embedded directly into the generated
function name. For a subset of codepoints this causes `declare -F` (in
`bats_perform_test`, `libexec/bats-core/bats-exec-test`) to fail to find the
generated function, so the test **silently never runs** — while the `1..N` TAP
plan line still counts it as declared. This is a false-green failure mode: bats
does print `# bats warning: Executed N instead of expected M tests` to stderr,
but that's easy to miss in a CI log that only surfaces the last lines or the exit
code of a formatter/pipeline.

This is #1233, which already narrows the root cause to this exact line with a
detailed repro (`889 declared / 804 executed` on a real suite) and proposes
this exact fix. No PR had been opened for it, so I opened this one.

## Fix

Use an explicit ASCII character class (`a-zA-Z0-9`) instead of the
locale-dependent POSIX `[[:alnum:]]` class, both in the branch-selection regex
and in the per-character check inside the hex-encoding loop, so any non-ASCII
name always takes the safe hex-encoding path regardless of the caller's locale.

## Testing

- Verified the branch-selection bug directly: running
  `libexec/bats-core/bats-preprocess` on a fixture with CJK/Cyrillic/Hangul test
  names under `LC_ALL=C` vs `LC_ALL=en_US.UTF-8` produces different generated
  function names before the fix (safe hex-encoded under `C`, raw multibyte
  under UTF-8), and identical (always hex-encoded) after the fix.
- I could not reproduce the downstream `declare -F` failure itself in my dev
  environment (bash 5.2 on MSYS/Windows) — #1233 reports the exact
  ghosting boundary as codepoint- and bash-build-dependent, reproduced on two
  separate macOS/bash-3.2 machines. The fix removes the locale-dependent branch
  selection that #1233 identifies as the root cause regardless of which
  specific codepoints ghost on a given platform.
- Added `test/fixtures/bats/non_ascii_test_names.bats` and a regression test in
  `test/bats.bats` ("test names with non-ASCII characters run under a UTF-8
  locale") that runs this fixture under `LC_ALL=en_US.UTF-8` and asserts all 6
  tests execute (`1..6` and 6 `ok` lines). It's skipped if `en_US.UTF-8` isn't
  installed on the runner, following the existing skip pattern used for the
  unicode `BATS_CODE_QUOTE_STYLE` test.
- Ran the full `test/bats.bats` suite (127 tests) before and after the change;
  all pass, no regressions.

Closes #1233.