### PR TITLE
fix: negate the whole GNU parallel availability check

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 ### Fixed
 
 * pretty formatter was not the default on interactive shells anymore (#1220)
+* `--jobs` now aborts when GNU parallel is unavailable instead of failing later (#1237, #1238)
 
 ### Documentation
 

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -111,7 +111,7 @@ while [[ "$#" -ne 0 ]]; do
 done
 
 if [[ "$num_jobs" != 1 ]]; then
-  if ! type -p "${parallel_binary_name}" >/dev/null && "${parallel_binary_name}" --version &>/dev/null && [[ -z "$bats_no_parallelize_across_files" ]]; then
+  if ! (type -p "${parallel_binary_name}" >/dev/null && "${parallel_binary_name}" --version &>/dev/null) && [[ -z "$bats_no_parallelize_across_files" ]]; then
     abort "Cannot execute \"${num_jobs}\" jobs without GNU parallel"
   fi
   # shellcheck source=lib/bats-core/semaphore.bash


### PR DESCRIPTION
Fixes #1237.

## What's broken

The guard that refuses `--jobs` without GNU parallel can never fire. `!` binds only to the first command of an `&&` chain, so when parallel is absent, `! type -p parallel` is true but the next clause runs the missing binary and fails, and the chain is false. When parallel is present the first clause is false and the chain short-circuits. Both directions skip the abort.

## Repro

```
$ if ! type -p nonexistent_xyz >/dev/null && "nonexistent_xyz" --version &>/dev/null && [[ -z "$x" ]]; then echo FIRED; else echo "DID NOT FIRE"; fi
DID NOT FIRE
```

End to end on a machine without GNU parallel, `bats --jobs 2 test/` runs zero tests and dies on `parallel: command not found` instead of printing the guard's message.

## The fix

Group the availability check and negate it as a whole, the same shape `test/parallel.bats` already uses:

```
(type -p parallel &>/dev/null && parallel --version &>/dev/null) || skip ...
```

The `bats_no_parallelize_across_files` clause stays outside the group, so its behaviour is unchanged.

## Verification

Truth table over all four combinations of binary present/absent and the flag set/empty: the new condition fires in exactly one case, parallel absent with the flag empty, and the old one fires in none. `bin/bats test/bats.bats` passes 126/126.

One thing I could not verify: GNU parallel is not installed on this machine, so all 18 tests in `test/parallel.bats` skip here, before and after. That suite gives no direct coverage of this change and it is worth one run on a box that has parallel.
