### PR TITLE
feat: add BATS_ALLOW_EMPTY_SUITE environment variable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog][kac] and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+* `$BATS_ALLOW_EMPTY_SUITE` environment variable as an alternative to `--allow-empty-suite`, which keeps test setups compatible with Bats versions before 1.14 that don't know the flag (#1240)
+
 ### Fixed
 
 * pretty formatter was not the default on interactive shells anymore (#1220)

--- a/libexec/bats-core/bats
+++ b/libexec/bats-core/bats
@@ -36,6 +36,7 @@ HELP_TEXT_HEADER
 
   --abort                   Stop execution of suite on first failed test
   --allow-empty-suite       Exit with code 0 (instead of the default code 1) when no tests are found.
+                            Can also be set via $BATS_ALLOW_EMPTY_SUITE
   -c, --count               Count test cases without running any tests
   --code-quote-style <style>
                             A two character string of code quote delimiters

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -197,7 +197,7 @@ printf '1..%d\n' "${test_count}"
 if [[ "${test_count}" == 0 ]]; then
   bats_exec_suite_status=$BATS_EMPTY_SUITE_STATUS
   if (( bats_exec_suite_status != 0)); then
-    printf "ERROR: Found no tests. (Try \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\`?)" >&2
+    printf "ERROR: Found no tests. Use \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\` to suppress this error." >&2
   fi
   bats_exit_suite
 fi

--- a/libexec/bats-core/bats-exec-suite
+++ b/libexec/bats-core/bats-exec-suite
@@ -15,7 +15,11 @@ flags=('--dummy-flag') # add a dummy flag to prevent unset variable errors on em
 setup_suite_file=''
 BATS_TRACE_LEVEL="${BATS_TRACE_LEVEL:-0}"
 BATS_SHOW_OUTPUT_OF_SUCCEEDING_TESTS=
-BATS_EMPTY_SUITE_STATUS=1
+if [[ -n "${BATS_ALLOW_EMPTY_SUITE:-}" ]]; then
+  BATS_EMPTY_SUITE_STATUS=0
+else
+  BATS_EMPTY_SUITE_STATUS=1
+fi
 
 abort() {
   printf 'Error: %s\n' "$1" >&2
@@ -193,7 +197,7 @@ printf '1..%d\n' "${test_count}"
 if [[ "${test_count}" == 0 ]]; then
   bats_exec_suite_status=$BATS_EMPTY_SUITE_STATUS
   if (( bats_exec_suite_status != 0)); then
-    printf "ERROR: Found no tests. (Try \`--allow-empty-suite\`?)" >&2
+    printf "ERROR: Found no tests. (Try \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\`?)" >&2
   fi
   bats_exit_suite
 fi

--- a/man/bats.1
+++ b/man/bats.1
@@ -42,7 +42,7 @@ An empty tag list matches tests without tags\.
 .IP "\(bu" 4
 \fB\-\-abort\fR: Stop execution of suite on first failed test
 .IP "\(bu" 4
-\fB\-\-allow\-empty\-suite\fR: Exit with code 0 (instead of the default code 1) when no tests are found\.
+\fB\-\-allow\-empty\-suite\fR: Exit with code 0 (instead of the default code 1) when no tests are found\. Can also be set via \fB$BATS_ALLOW_EMPTY_SUITE\fR (to any non\-empty value), which keeps compatibility with Bats versions that don't know this flag\.
 .IP "\(bu" 4
 \fB\-c\fR, \fB\-\-count\fR: Count the number of test cases without running any tests
 .IP "\(bu" 4

--- a/man/bats.1.ronn
+++ b/man/bats.1.ronn
@@ -80,6 +80,8 @@ OPTIONS
     Stop execution of suite on first failed test
   * `--allow-empty-suite`:
     Exit with code 0 (instead of the default code 1) when no tests are found.
+    Can also be set via `$BATS_ALLOW_EMPTY_SUITE` (to any non-empty value),
+    which keeps compatibility with Bats versions that don't know this flag.
   * `-c`, `--count`:
     Count the number of test cases without running any tests
   * `--code-quote-style <style>`:

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -47,7 +47,7 @@ setup() {
   [ "${lines[0]}" = "1..0" ]
   [ "${#lines[@]}" -eq 1 ]
 
-  [ "${stderr_lines[0]}" = "ERROR: Found no tests. (Try \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\`?)" ]
+  [ "${stderr_lines[0]}" = "ERROR: Found no tests. Use \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\` to suppress this error." ]
   [ "${#stderr_lines[@]}" -eq 1 ]
 }
 
@@ -1719,7 +1719,7 @@ END_OF_ERR_MSG
   reentrant_run --separate-stderr -1 env BATS_ALLOW_EMPTY_SUITE= bats "$FIXTURE_ROOT/empty.bats"
 
   [ "${lines[0]}" = "1..0" ]
-  [ "${stderr_lines[0]}" = "ERROR: Found no tests. (Try \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\`?)" ]
+  [ "${stderr_lines[0]}" = "ERROR: Found no tests. Use \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\` to suppress this error." ]
 }
 
 @test "BATS_ALLOW_EMPTY_SUITE does not fail when there are tests" {

--- a/test/bats.bats
+++ b/test/bats.bats
@@ -47,7 +47,7 @@ setup() {
   [ "${lines[0]}" = "1..0" ]
   [ "${#lines[@]}" -eq 1 ]
 
-  [ "${stderr_lines[0]}" = "ERROR: Found no tests. (Try \`--allow-empty-suite\`?)" ]
+  [ "${stderr_lines[0]}" = "ERROR: Found no tests. (Try \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\`?)" ]
   [ "${#stderr_lines[@]}" -eq 1 ]
 }
 
@@ -1694,6 +1694,37 @@ END_OF_ERR_MSG
 @test "--allow-empty-suite fails when there are tests" {
   bats_require_minimum_version 1.5.0
   reentrant_run -0 bats --allow-empty-suite "$FIXTURE_ROOT/passing.bats"
+}
+
+@test "--allow-empty-suite exits successfully on empty suite" {
+  bats_require_minimum_version 1.5.0
+  reentrant_run --separate-stderr -0 bats --allow-empty-suite "$FIXTURE_ROOT/empty.bats"
+
+  [ "${lines[0]}" = "1..0" ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${#stderr_lines[@]}" -eq 0 ]
+}
+
+@test "BATS_ALLOW_EMPTY_SUITE exits successfully on empty suite" {
+  bats_require_minimum_version 1.5.0
+  reentrant_run --separate-stderr -0 env BATS_ALLOW_EMPTY_SUITE=1 bats "$FIXTURE_ROOT/empty.bats"
+
+  [ "${lines[0]}" = "1..0" ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${#stderr_lines[@]}" -eq 0 ]
+}
+
+@test "empty BATS_ALLOW_EMPTY_SUITE does not allow an empty suite" {
+  bats_require_minimum_version 1.5.0
+  reentrant_run --separate-stderr -1 env BATS_ALLOW_EMPTY_SUITE= bats "$FIXTURE_ROOT/empty.bats"
+
+  [ "${lines[0]}" = "1..0" ]
+  [ "${stderr_lines[0]}" = "ERROR: Found no tests. (Try \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\`?)" ]
+}
+
+@test "BATS_ALLOW_EMPTY_SUITE does not fail when there are tests" {
+  bats_require_minimum_version 1.5.0
+  reentrant_run -0 env BATS_ALLOW_EMPTY_SUITE=1 bats "$FIXTURE_ROOT/passing.bats"
 }
 
 @test "empty testfile path is an error" {

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -9,7 +9,7 @@ setup() {
   reentrant_run --separate-stderr -1 bats "$FIXTURE_ROOT/empty"
   [ "$output" = "1..0" ]
   # shellcheck disable=SC2154
-  [ "$stderr" = "ERROR: Found no tests. (Try \`--allow-empty-suite\`?)" ]
+  [ "$stderr" = "ERROR: Found no tests. (Try \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\`?)" ]
 }
 
 @test "running a suite with one test file" {

--- a/test/suite.bats
+++ b/test/suite.bats
@@ -9,7 +9,7 @@ setup() {
   reentrant_run --separate-stderr -1 bats "$FIXTURE_ROOT/empty"
   [ "$output" = "1..0" ]
   # shellcheck disable=SC2154
-  [ "$stderr" = "ERROR: Found no tests. (Try \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\`?)" ]
+  [ "$stderr" = "ERROR: Found no tests. Use \`--allow-empty-suite\` or \`BATS_ALLOW_EMPTY_SUITE=1\` to suppress this error." ]
 }
 
 @test "running a suite with one test file" {


### PR DESCRIPTION
Fixes #1239.

`--allow-empty-suite` (added in v1.14.0) can only be used by projects that no longer need to run with bats < 1.14, since older versions abort on the unknown flag. This adds `BATS_ALLOW_EMPTY_SUITE`: set it to any non-empty value and an empty suite exits 0, just like the flag. Older bats versions ignore the variable and already exit 0 on an empty suite, so the same setting works across versions — which is what motivated this, see https://github.com/containers/conmon/pull/672 where pinning bats to v1.13.0 was the only option.

The second commit (feel free to drop if you don't like it) rewords the error message to say what to do instead of asking a question, and mentions the variable next to the flag:

```
ERROR: Found no tests. Use `--allow-empty-suite` or `BATS_ALLOW_EMPTY_SUITE=1` to suppress this error.
```

Tests cover the variable enabling an empty suite, an empty value not enabling it, and no effect when tests exist; the flag's own positive case was missing and is added too. Docs (`--help`, man page, CHANGELOG) updated.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md