### PR TITLE
test: eliminate SIGINT-after-run race

### DIFF
--- a/test/fixtures/bats/hang_after_run.bats
+++ b/test/fixtures/bats/hang_after_run.bats
@@ -3,7 +3,7 @@ setup() {
 }
 
 @test "test" {
-  single-use-latch::signal hang_after_run
   run true
+  single-use-latch::signal hang_after_run
   sleep 10
 }


### PR DESCRIPTION
## Summary

Fix an intermittent Windows failure in `CTRL-C aborts and fails after run`.

The fixture signalled readiness before `run true` completed. The parent could
therefore send SIGINT before the intended post-`run` phase, resulting in a
different TAP result. Signal readiness after `run true` so the interrupt always
targets the following sleep.

## Validation

- `bin/bats --filter 'CTRL-C aborts and fails after run' test/bats.bats`

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
