### PR TITLE
test: allow parallel suite startup on loaded macOS runners

### DIFF
--- a/test/parallel.bats
+++ b/test/parallel.bats
@@ -70,6 +70,9 @@ check_parallel_tests() { # <expected maximum parallelity>
 @test "parallel suite execution with --jobs" {
   # shellcheck disable=SC2034
   BATS_TEST_RETRIES=2 # be more robust against flaky MacOS runners
+  # Starting 12 Bash processes can take longer than a minute on loaded macOS runners.
+  # shellcheck disable=SC2034
+  BATS_TEST_TIMEOUT=120
   # shellcheck disable=SC2031,SC2030
   export FILE_MARKER
   # shellcheck disable=SC2030


### PR DESCRIPTION
## Summary

Fix an intermittent macOS timeout in `parallel suite execution with --jobs`.

The test requires 12 Bash workers to reach a barrier but inherited the
10-second watchdog. On loaded runners, process startup can exceed that limit
and exhaust the retries. Give this test a local 120-second timeout; its TAP,
ordering, and concurrency assertions remain unchanged.

## Validation

- `bin/bats --filter 'parallel suite execution with --jobs' test/parallel.bats`

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
