### PR TITLE
ci: use available locale in FreeBSD tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -259,6 +259,7 @@ jobs:
         with:
           run-in-vm: |
             pkg install -y bash parallel ${{ matrix.packages }}
+            export LC_ALL=C
             time ./bin/bats --print-output-on-failure test/
 
   find_broken_symlinks:


### PR DESCRIPTION
The Firecracker FreeBSD guest inherits LANG=C.UTF-8 from the Linux runner, but that locale is not installed in the guest. GNU parallel's Perl processes then print locale warnings to stdout, interleaving with TAP output and causing parallel-test assertions to fail.

Set LC_ALL=C before running the suite. The C locale is always available on FreeBSD, preventing the warnings and preserving the expected TAP output.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
