### PR TITLE
ci: cancel superseded workflow runs with concurrency groups

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,12 @@ on:
       - master
   workflow_dispatch:
 
+# Group runs by workflow and PR/ref; release-triggered runs use a separate
+# `-release` suffix. Cancel an older run when a new one uses the same group.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ github.event_name == 'release' && '-release' || '' }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Use concurrency groups based on the workflow and PR number or Git ref. Cancel an in-progress run when a newer run uses the same group, freeing CI capacity from outdated runs.

Release events use a separate suffix to keep them distinct where applicable.

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
